### PR TITLE
fix: proxy local file paths in webchat markdown images

### DIFF
--- a/apps/web/app/components/chat-message.tsx
+++ b/apps/web/app/components/chat-message.tsx
@@ -556,12 +556,16 @@ const mdComponents: Components = {
 			</a>
 		);
 	},
-	// Render images with loading=lazy
-	img: ({ src, alt, ...props }) => (
-		// eslint-disable-next-line @next/next/no-img-element
-		<img src={src} alt={alt ?? ""} loading="lazy" {...props} />
-	),
-	// Syntax-highlighted fenced code blocks
+	// Render images — route local file paths through raw-file API
+	img: ({ src, alt, ...props }) => {
+		const resolvedSrc = typeof src === "string" && !src.startsWith("http://") && !src.startsWith("https://") && !src.startsWith("data:")
+			? `/api/workspace/raw-file?path=${encodeURIComponent(src)}`
+			: src;
+		return (
+			// eslint-disable-next-line @next/next/no-img-element
+			<img src={resolvedSrc} alt={alt ?? ""} loading="lazy" {...props} />
+		);
+	},
 	pre: ({ children, ...props }) => {
 		// react-markdown wraps code blocks in <pre><code>...
 		// Extract the code element to get lang + content


### PR DESCRIPTION
## Summary
- Webchat markdown images with local file paths (e.g. agent screenshots) fail to load — browser gets 404 because `<img src="/tmp/screenshot.png">` isn't a valid URL
- The `chain-of-thought.tsx` component already handles this correctly via `resolveMediaUrl()`, routing paths through `/api/workspace/raw-file?path=...`
- Updated the ReactMarkdown `img` override in `chat-message.tsx` to apply the same proxying for non-HTTP/data `src` values

## Test plan
- [ ] Open the webchat workspace
- [ ] Trigger the agent to produce a markdown image (e.g. screenshot via browser tool)
- [ ] Verify the image renders correctly in the chat instead of showing a broken icon
- [ ] Verify HTTP/HTTPS and data: URL images still render normally