### PR TITLE
dx: improve .env.example token placeholder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,9 @@
 # Gateway auth + paths
 # -----------------------------------------------------------------------------
 # Recommended if the gateway binds beyond loopback.
-OPENCLAW_GATEWAY_TOKEN=change-me-to-a-long-random-token
-# Example generator: openssl rand -hex 32
+# Generate a secure random token:  openssl rand -hex 32
+# Docker/Podman setup scripts auto-generate this if left empty.
+OPENCLAW_GATEWAY_TOKEN=
 
 # Optional alternative auth mode (use token OR password).
 # OPENCLAW_GATEWAY_PASSWORD=change-me-to-a-strong-password


### PR DESCRIPTION
Fixes #37

Removes the hardcoded `change-me` placeholder, leaves token empty so users must explicitly set it, and adds a comment with `openssl rand -hex 32` generation instruction.