### PR TITLE
fix(workspace): parse YAML list syntax in parseSimpleYaml

### DIFF
--- a/apps/web/lib/workspace.ts
+++ b/apps/web/lib/workspace.ts
@@ -1067,16 +1067,23 @@ export function parseSimpleYaml(
 ): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   const lines = content.split("\n");
+  let currentListKey: string | null = null;
 
   for (const line of lines) {
-    // Skip comments and empty lines
     if (line.trim().startsWith("#") || !line.trim()) {continue;}
 
-    // Match top-level key: value
-    const match = line.match(/^(\w[\w_-]*)\s*:\s*(.+)/);
+    // Match top-level key: value (value may be empty for list parents)
+    const match = line.match(/^(\w[\w_-]*)\s*:\s*(.*)/);
     if (match) {
+      currentListKey = null;
       const key = match[1];
       let value: unknown = match[2].trim();
+
+      if (value === "") {
+        currentListKey = key;
+        result[key] = [];
+        continue;
+      }
 
       // Strip quotes
       if (
@@ -1099,6 +1106,25 @@ export function parseSimpleYaml(
       }
 
       result[key] = value;
+      continue;
+    }
+
+    // Collect indented list items ("  - value") under the current list key
+    if (currentListKey) {
+      const listMatch = line.match(/^\s+-\s+(.*)/);
+      if (listMatch) {
+        let item: unknown = listMatch[1].trim();
+        if (
+          typeof item === "string" &&
+          ((item.startsWith('"') && item.endsWith('"')) ||
+            (item.startsWith("'") && item.endsWith("'")))
+        ) {
+          item = (item).slice(1, -1);
+        }
+        (result[currentListKey] as unknown[]).push(item);
+      } else {
+        currentListKey = null;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- `parseSimpleYaml` could not parse YAML list syntax (`- item` lines under a key with no inline value), so `permissions` from `.dench.yaml` was always `undefined`
- This caused all permission-gated app bridge methods (`db.query`, `db.execute`, `files.read`, `files.list`) to fail with "Unknown method or insufficient permissions"
- Fixed the regex from `.+` to `.*` and added collection of indented `- item` lines into arrays

Closes #87

## Test plan

- [ ] Create a `.dench.app` with `permissions:\n  - database` in its `.dench.yaml`
- [ ] Verify `window.dench.db.query("SELECT 1")` succeeds instead of returning the "Unknown method or insufficient permissions" error
- [ ] Verify `window.dench.app.getManifest()` still works (no regression on flat key: value parsing)
- [ ] Verify a manifest with `permissions:\n  - database\n  - files` returns both permissions as an array