### PR TITLE
fix(web): reduce web gateway scope request

### DIFF
--- a/apps/web/lib/agent-runner.test.ts
+++ b/apps/web/lib/agent-runner.test.ts
@@ -212,6 +212,14 @@ describe("agent-runner", () => {
 			expect(params.client.mode).toBe("backend");
 		});
 
+		it("requests operator.admin only so agent startup works with admin-scoped gateway auth", async () => {
+			const { buildConnectParams } = await import("./agent-runner.js");
+			const params = buildConnectParams({ url: "ws://127.0.0.1:19001" }) as {
+				scopes?: string[];
+			};
+			expect(params.scopes).toEqual(["operator.admin"]);
+		});
+
 		it("advertises tool-events capability for tool stream parity", async () => {
 			const { buildConnectParams } = await import("./agent-runner.js");
 			const params = buildConnectParams({ url: "ws://127.0.0.1:19001" }) as {

--- a/apps/web/lib/agent-runner.ts
+++ b/apps/web/lib/agent-runner.ts
@@ -156,6 +156,9 @@ const DEFAULT_GATEWAY_PORT = 18_789;
 const OPEN_TIMEOUT_MS = 8_000;
 const REQUEST_TIMEOUT_MS = 12_000;
 const DEFAULT_GATEWAY_CLIENT_CAPS = ["tool-events"];
+// operator.admin already covers the operator RPCs this web path uses, and
+// keeping the requested scope set minimal avoids write-scope mismatches.
+const DEFAULT_GATEWAY_OPERATOR_SCOPES = ["operator.admin"];
 const SESSIONS_PATCH_RETRY_DELAY_MS = 150;
 const SESSIONS_PATCH_MAX_ATTEMPTS = 2;
 
@@ -323,7 +326,7 @@ export function buildConnectParams(
 		locale: "en-US",
 		userAgent: "denchclaw-web",
 		role: "operator",
-		scopes: ["operator.read", "operator.write", "operator.admin"],
+		scopes: DEFAULT_GATEWAY_OPERATOR_SCOPES,
 		caps,
 		...(auth ? { auth } : {}),
 	};


### PR DESCRIPTION
## Summary
- request only `operator.admin` from the web chat gateway client instead of asking for redundant read/write/admin scopes
- avoid `missing scope: operator.write` failures on admin-scoped gateway auth while preserving the operator RPC access this path needs
- add a regression test that locks the web runner to the admin-only scope contract

## Test plan
- [ ] `pnpm --dir apps/web test -- lib/agent-runner.test.ts`
- [ ] `pnpm lint` (currently fails due unrelated existing `curly` / `no-unused-vars` violations in files outside this change, including `apps/web/lib/terminal-server.ts`, `src/cli/web-runtime-command.ts`, `src/cli/web-runtime-launchd.ts`, `src/cli/web-runtime.ts`, `apps/web/lib/active-runs.test.ts`, and `apps/web/app/components/cron/cron-dashboard.tsx`)