### PR TITLE
feat(chat): multi-session chat tabs with stop controls UI

### DIFF
--- a/apps/web/app/components/chat-message.tsx
+++ b/apps/web/app/components/chat-message.tsx
@@ -10,6 +10,7 @@ import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { ChainOfThought, type ChainPart } from "./chain-of-thought";
+import { isStatusReasoningText } from "./chat-stream-status";
 import { splitReportBlocks, hasReportBlocks } from "@/lib/report-blocks";
 import { splitDiffBlocks, hasDiffBlocks } from "@/lib/diff-blocks";
 import type { ReportConfig } from "./charts/types";
@@ -55,12 +56,15 @@ type MessageSegment =
 	| { type: "subagent-card"; task: string; label?: string; sessionKey?: string; status: "running" | "done" | "error" };
 
 /** Map AI SDK tool state string to a simplified status */
-function toolStatus(state: string): "running" | "done" | "error" {
-	if (state === "output-available") {
-		return "done";
-	}
-	if (state === "error") {
+function toolStatus(
+	state: string,
+	preliminary = false,
+): "running" | "done" | "error" {
+	if (state === "output-error" || state === "error") {
 		return "error";
+	}
+	if (state === "output-available" && !preliminary) {
+		return "done";
 	}
 	return "running";
 }
@@ -115,18 +119,10 @@ function groupParts(parts: UIMessage["parts"]): MessageSegment[] {
 				text: string;
 				state?: string;
 			};
-			// Skip lifecycle/compaction status labels — they add noise
-			// (e.g. "Preparing response...", "Optimizing session context...")
-			const statusLabels = [
-				"Preparing response...",
-				"Optimizing session context...",
-				"Waiting for subagent results...",
-				"Waiting for subagents...",
-			];
-			const isStatus = statusLabels.some((l) =>
-				rp.text.startsWith(l),
-			);
-			if (!isStatus) {
+			// Skip lifecycle/compaction status labels in the thought body.
+			// The active stream row renders them separately so they stay visible
+			// without cluttering the permanent transcript.
+			if (!isStatusReasoningText(rp.text)) {
 				chain.push({
 					kind: "reasoning",
 					text: rp.text,
@@ -141,6 +137,7 @@ function groupParts(parts: UIMessage["parts"]): MessageSegment[] {
 			state: string;
 			input?: unknown;
 			output?: unknown;
+			preliminary?: boolean;
 		};
 		if (tp.toolName === "sessions_spawn") {
 			flush(true);
@@ -149,13 +146,19 @@ function groupParts(parts: UIMessage["parts"]): MessageSegment[] {
 			const task = typeof args?.task === "string" ? args.task : "Subagent task";
 			const label = typeof args?.label === "string" ? args.label : undefined;
 			const sessionKey = typeof out?.sessionKey === "string" ? out.sessionKey : undefined;
-			segments.push({ type: "subagent-card", task, label, sessionKey, status: toolStatus(tp.state) });
+			segments.push({
+				type: "subagent-card",
+				task,
+				label,
+				sessionKey,
+				status: toolStatus(tp.state, tp.preliminary === true),
+			});
 		} else {
 			chain.push({
 				kind: "tool",
 				toolName: tp.toolName,
 				toolCallId: tp.toolCallId,
-				status: toolStatus(tp.state),
+				status: toolStatus(tp.state, tp.preliminary === true),
 				args: asRecord(tp.input),
 				output: asRecord(tp.output),
 			});
@@ -175,6 +178,7 @@ function groupParts(parts: UIMessage["parts"]): MessageSegment[] {
 			args?: unknown;
 			result?: unknown;
 			errorText?: string;
+			preliminary?: boolean;
 		};
 		const resolvedToolName = tp.title ?? tp.toolName ?? part.type.replace("tool-", "");
 		if (resolvedToolName === "sessions_spawn") {
@@ -186,19 +190,25 @@ function groupParts(parts: UIMessage["parts"]): MessageSegment[] {
 			const sessionKey = typeof out?.sessionKey === "string" ? out.sessionKey : undefined;
 			const resolvedState =
 				tp.state ??
-				(tp.errorText ? "error" : ("result" in tp || "output" in tp) ? "output-available" : "input-available");
-			segments.push({ type: "subagent-card", task, label, sessionKey, status: toolStatus(resolvedState) });
+				(tp.errorText ? "output-error" : ("result" in tp || "output" in tp) ? "output-available" : "input-available");
+			segments.push({
+				type: "subagent-card",
+				task,
+				label,
+				sessionKey,
+				status: toolStatus(resolvedState, tp.preliminary === true),
+			});
 		} else {
 			// Persisted tool-invocation parts have no state field but
 			// include result/output/errorText to indicate completion.
 			const resolvedState =
 				tp.state ??
-				(tp.errorText ? "error" : ("result" in tp || "output" in tp) ? "output-available" : "input-available");
+				(tp.errorText ? "output-error" : ("result" in tp || "output" in tp) ? "output-available" : "input-available");
 			chain.push({
 				kind: "tool",
 				toolName: resolvedToolName,
 				toolCallId: tp.toolCallId,
-				status: toolStatus(resolvedState),
+				status: toolStatus(resolvedState, tp.preliminary === true),
 				args: asRecord(tp.input) ?? asRecord(tp.args),
 				output: asRecord(tp.output) ?? asRecord(tp.result),
 			});
@@ -784,7 +794,7 @@ export const ChatMessage = memo(function ChatMessage({ message, isStreaming, onS
 		if (attachmentInfo) {
 			return (
 				<div className="flex flex-col items-end gap-1.5 py-2">
-					{!richHtml && <AttachedFilesCard paths={attachmentInfo.paths} />}
+					<AttachedFilesCard paths={attachmentInfo.paths} />
 					{(attachmentInfo.message || richHtml) && (
 						<div
 							className="max-w-[80%] w-fit rounded-2xl rounded-br-sm px-3 py-2 text-sm leading-6 break-words chat-message-font"

--- a/apps/web/app/components/chat-panel.tsx
+++ b/apps/web/app/components/chat-panel.tsx
@@ -29,6 +29,11 @@ import {
 	DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
 import { UnicodeSpinner } from "./unicode-spinner";
+import type { ChatPanelRuntimeState } from "@/lib/chat-session-registry";
+import {
+	getStreamActivityLabel,
+	hasAssistantText,
+} from "./chat-stream-status";
 
 // ── Prompt suggestions for new chat hero ──
 
@@ -590,6 +595,7 @@ type ParsedPart =
 			state: string;
 			input?: Record<string, unknown>;
 			output?: Record<string, unknown>;
+			preliminary?: boolean;
 		};
 
 export function createStreamParser() {
@@ -685,6 +691,7 @@ export function createStreamParser() {
 						p.type === "dynamic-tool" &&
 						p.toolCallId === event.toolCallId
 					) {
+						p.preliminary = true;
 						p.output =
 							(event.output as Record<
 								string,
@@ -701,7 +708,13 @@ export function createStreamParser() {
 						p.type === "dynamic-tool" &&
 						p.toolCallId === event.toolCallId
 					) {
-						p.state = "output-available";
+						if (event.preliminary === true) {
+							p.preliminary = true;
+							p.state = "input-available";
+						} else {
+							delete p.preliminary;
+							p.state = "output-available";
+						}
 						p.output =
 							(event.output as Record<
 								string,
@@ -814,6 +827,8 @@ type ChatPanelProps = {
 	onBack?: () => void;
 	/** Hide the header action buttons (when they're rendered elsewhere, e.g. tab bar). */
 	hideHeaderActions?: boolean;
+	/** Called whenever the panel's runtime state changes. */
+	onRuntimeStateChange?: (state: ChatPanelRuntimeState) => void;
 };
 
 export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
@@ -836,6 +851,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 			subagentLabel,
 			onBack,
 			hideHeaderActions,
+			onRuntimeStateChange,
 		},
 		ref,
 	) {
@@ -961,6 +977,25 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 			status === "streaming" ||
 			status === "submitted" ||
 			isReconnecting;
+
+		useEffect(() => {
+			onRuntimeStateChange?.({
+				sessionId: currentSessionId,
+				sessionKey: subagentSessionKey ?? null,
+				isStreaming,
+				status,
+				isReconnecting,
+				loadingSession,
+			});
+		}, [
+			currentSessionId,
+			subagentSessionKey,
+			isStreaming,
+			status,
+			isReconnecting,
+			loadingSession,
+			onRuntimeStateChange,
+		]);
 
 		// Stream stall detection: if we stay in "submitted" (no first
 		// token received) for too long, surface an error and reset.
@@ -1955,29 +1990,18 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 			[],
 		);
 
-		// ── Status label ──
+		// ── Active stream status row ──
 
-		const _statusLabel = loadingSession
-			? "Loading session..."
-			: isReconnecting
-					? "Resuming stream..."
-					: status === "ready"
-						? "Ready"
-						: status === "submitted"
-							? "Thinking..."
-							: status === "streaming"
-								? (hasRunningSubagents ? "Waiting for subagents..." : "Streaming...")
-								: status === "error"
-									? "Error"
-									: status;
-
-		// Show an inline Unicode spinner in the message flow when the AI
-		// is thinking/streaming but hasn't produced visible text yet.
 		const lastMsg = messages.length > 0 ? messages[messages.length - 1] : null;
-		const lastAssistantHasText =
-			lastMsg?.role === "assistant" &&
-			lastMsg.parts.some((p) => p.type === "text" && (p as { text: string }).text.length > 0);
-		const showInlineSpinner = isStreaming && !lastAssistantHasText;
+		const lastAssistantHasText = hasAssistantText(lastMsg);
+		const streamActivityLabel = getStreamActivityLabel({
+			loadingSession,
+			isReconnecting,
+			status,
+			hasRunningSubagents,
+			lastMessage: lastMsg,
+		});
+		const showStreamActivity = isStreaming && !!streamActivityLabel;
 
 		const showHeroState = messages.length === 0 && !compact && !isSubagentMode && !loadingSession;
 
@@ -2159,12 +2183,12 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 
 		return (
 			<div
-				className="h-full flex flex-col"
+				className="h-full min-h-0 flex flex-col overflow-hidden"
 				style={{ background: "var(--color-main-bg)" }}
 			>
 				{/* Header — sticky glass bar */}
 				<header
-					className={`${compact ? "px-3 py-2" : "px-3 py-2 md:px-6 md:py-3"} flex items-center ${isSubagentMode ? "gap-3" : "justify-between"} z-20`}
+					className={`${compact ? "px-3 py-2" : "px-3 py-2 md:px-6 md:py-3"} flex shrink-0 items-center ${isSubagentMode ? "gap-3" : "justify-between"} z-20`}
 				>
 				{isSubagentMode ? (
 					<>
@@ -2280,7 +2304,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 				{/* File-scoped session tabs (compact mode, not in subagent mode) */}
 				{!isSubagentMode && compact && fileContext && fileSessions.length > 0 && (
 					<div
-						className="px-2 py-1.5 border-b flex gap-1 overflow-x-auto z-20"
+						className="px-2 py-1.5 border-b flex shrink-0 gap-1 overflow-x-auto z-20"
 						style={{
 							borderColor: "var(--color-border)",
 							background: "var(--color-bg-glass)",
@@ -2319,7 +2343,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 
 				<div
 					ref={scrollContainerRef}
-					className="flex-1 overflow-y-auto min-h-0"
+					className="min-h-0 min-w-0 flex-1 overflow-y-auto"
 					style={{ scrollbarGutter: "stable" }}
 				>
 				{/* Messages */}
@@ -2444,13 +2468,25 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 								userHtmlMap={userHtmlMapRef.current}
 							/>
 						))}
-						{showInlineSpinner && (
+						{showStreamActivity && (
 							<div className="py-3 min-w-0">
-								<UnicodeSpinner
-									name="pulse"
-									className="text-base"
-									style={{ color: "var(--color-text-muted)" }}
-								/>
+								<div
+									className="inline-flex max-w-full items-center gap-2 rounded-full px-3 py-1.5"
+									style={{
+										background: "var(--color-surface-hover)",
+										border: "1px solid var(--color-border)",
+										color: "var(--color-text-muted)",
+									}}
+								>
+									<UnicodeSpinner
+										name="braille"
+										className={`text-sm ${lastAssistantHasText ? "" : "opacity-90"}`}
+										style={{ color: "inherit" }}
+									/>
+									<span className="text-xs truncate">
+										{streamActivityLabel}
+									</span>
+								</div>
 							</div>
 						)}
 							<div ref={messagesEndRef} />
@@ -2501,7 +2537,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 				{/* Input bar at bottom (hidden when hero state is active) */}
 				{!showHeroState && (
 					<div
-						className={`${compact ? "px-3 py-2" : "px-3 pb-3 pt-0 md:px-6 md:pb-5"} z-20`}
+						className={`${compact ? "px-3 py-2" : "px-3 pb-3 pt-0 md:px-6 md:pb-5"} shrink-0 z-20`}
 						style={{ background: "var(--color-bg-glass)" }}
 					>
 						<div className={compact ? "" : "max-w-[720px] mx-auto"}>

--- a/apps/web/app/components/workspace/chat-sessions-sidebar.tsx
+++ b/apps/web/app/components/workspace/chat-sessions-sidebar.tsx
@@ -51,6 +51,10 @@ type ChatSessionsSidebarProps = {
 	onDeleteSession?: (sessionId: string) => void;
 	/** Called when the user renames a session from the sidebar menu. */
 	onRenameSession?: (sessionId: string, newTitle: string) => void;
+	/** Called when the user stops an actively running parent session. */
+	onStopSession?: (sessionId: string) => void;
+	/** Called when the user stops an actively running subagent session. */
+	onStopSubagent?: (sessionKey: string) => void;
 	/** Called when the user clicks the collapse/hide sidebar button. */
 	onCollapse?: () => void;
 	/** When true, show a loader instead of empty state (e.g. initial sessions fetch). */
@@ -149,6 +153,20 @@ function MoreHorizontalIcon() {
 	);
 }
 
+function StopIcon() {
+	return (
+		<svg
+			width="12"
+			height="12"
+			viewBox="0 0 24 24"
+			fill="currentColor"
+			aria-hidden="true"
+		>
+			<rect x="6" y="6" width="12" height="12" rx="2" />
+		</svg>
+	);
+}
+
 export function ChatSessionsSidebar({
 	sessions,
 	activeSessionId,
@@ -161,6 +179,8 @@ export function ChatSessionsSidebar({
 	onSelectSubagent,
 	onDeleteSession,
 	onRenameSession,
+	onStopSession,
+	onStopSubagent,
 	onCollapse,
 	mobile,
 	onClose,
@@ -286,8 +306,8 @@ export function ChatSessionsSidebar({
 							{group.sessions.map((session) => {
 								const isActive = session.id === activeSessionId && !activeSubagentKey;
 								const isHovered = session.id === hoveredId;
-								const showMore = isHovered;
 								const isStreamingSession = streamingSessionIds?.has(session.id) ?? false;
+								const showMore = isHovered || isStreamingSession;
 								const sessionSubagents = subagentsByParent.get(session.id);
 								return (
 									<div
@@ -366,8 +386,23 @@ export function ChatSessionsSidebar({
 											</div>
 										</button>
 										)}
-										{onDeleteSession && (
-											<div className={`shrink-0 flex items-center pr-1 transition-opacity ${showMore ? "opacity-100" : "opacity-0"}`}>
+										<div className={`shrink-0 flex items-center pr-1 gap-0.5 transition-opacity ${showMore ? "opacity-100" : "opacity-0"}`}>
+											{isStreamingSession && onStopSession && (
+												<button
+													type="button"
+													onClick={(e) => {
+														e.stopPropagation();
+														onStopSession(session.id);
+													}}
+													className="flex items-center justify-center w-6 h-6 rounded-md transition-colors hover:bg-black/5"
+													style={{ color: "var(--color-text-muted)" }}
+													title="Stop chat"
+													aria-label="Stop chat"
+												>
+													<StopIcon />
+												</button>
+											)}
+											{onDeleteSession && (
 												<DropdownMenu>
 													<DropdownMenuTrigger
 														onClick={(e) => e.stopPropagation()}
@@ -394,8 +429,8 @@ export function ChatSessionsSidebar({
 														</DropdownMenuItem>
 													</DropdownMenuContent>
 												</DropdownMenu>
-											</div>
-										)}
+											)}
+										</div>
 									</div>
 									{/* Subagent sub-items */}
 									{sessionSubagents && sessionSubagents.length > 0 && (
@@ -406,38 +441,57 @@ export function ChatSessionsSidebar({
 												const subLabel = sa.label || sa.task;
 												const truncated = subLabel.length > 40 ? subLabel.slice(0, 40) + "..." : subLabel;
 												return (
-													<button
+													<div
 														key={sa.childSessionKey}
-														type="button"
-														onClick={() => handleSelectSubagentItem(sa.childSessionKey)}
-														className="w-full text-left pl-3 pr-2 py-1.5 rounded-r-lg transition-colors cursor-pointer"
-														style={{
-															background: isSubActive
-																? "var(--color-chat-sidebar-active-bg)"
-																: "transparent",
-														}}
+														className="flex items-center"
 													>
-														<div className="flex items-center gap-1.5">
-															{isSubRunning && (
-																<UnicodeSpinner
-																	name="braille"
-																	className="text-[9px] flex-shrink-0"
-																	style={{ color: "var(--color-chat-sidebar-muted)" }}
-																/>
-															)}
-															<SubagentIcon />
-															<span
-																className="text-[11px] truncate"
-																style={{
-																	color: isSubActive
-																		? "var(--color-chat-sidebar-active-text)"
-																		: "var(--color-text-muted)",
+														<button
+															type="button"
+															onClick={() => handleSelectSubagentItem(sa.childSessionKey)}
+															className="flex-1 text-left pl-3 pr-2 py-1.5 rounded-r-lg transition-colors cursor-pointer"
+															style={{
+																background: isSubActive
+																	? "var(--color-chat-sidebar-active-bg)"
+																	: "transparent",
+															}}
+														>
+															<div className="flex items-center gap-1.5">
+																{isSubRunning && (
+																	<UnicodeSpinner
+																		name="braille"
+																		className="text-[9px] flex-shrink-0"
+																		style={{ color: "var(--color-chat-sidebar-muted)" }}
+																	/>
+																)}
+																<SubagentIcon />
+																<span
+																	className="text-[11px] truncate"
+																	style={{
+																		color: isSubActive
+																			? "var(--color-chat-sidebar-active-text)"
+																			: "var(--color-text-muted)",
+																	}}
+																>
+																	{truncated}
+																</span>
+															</div>
+														</button>
+														{isSubRunning && onStopSubagent && (
+															<button
+																type="button"
+																onClick={(e) => {
+																	e.stopPropagation();
+																	onStopSubagent(sa.childSessionKey);
 																}}
+																className="shrink-0 flex items-center justify-center w-6 h-6 rounded-md mr-1 transition-colors hover:bg-black/5"
+																style={{ color: "var(--color-text-muted)" }}
+																title="Stop subagent"
+																aria-label="Stop subagent"
 															>
-																{truncated}
-															</span>
-														</div>
-													</button>
+																<StopIcon />
+															</button>
+														)}
+													</div>
 												);
 											})}
 										</div>

--- a/apps/web/app/components/workspace/tab-bar.tsx
+++ b/apps/web/app/components/workspace/tab-bar.tsx
@@ -21,6 +21,8 @@ type TabBarProps = {
   onCloseAll: () => void;
   onReorder: (fromIndex: number, toIndex: number) => void;
   onTogglePin: (tabId: string) => void;
+  liveChatTabIds?: Set<string>;
+  onStopTab?: (tabId: string) => void;
   onNewTab?: () => void;
   leftContent?: React.ReactNode;
   rightContent?: React.ReactNode;
@@ -32,10 +34,10 @@ type ContextMenuState = {
   y: number;
 } | null;
 
-function tabToFaviconClass(tab: Tab): string | undefined {
+function tabToFaviconClass(tab: Tab, isLive: boolean): string | undefined {
   switch (tab.type) {
     case "home": return "dench-favicon-home";
-    case "chat": return "dench-favicon-chat";
+    case "chat": return isLive ? "dench-favicon-chat-live" : "dench-favicon-chat";
     case "app": return "dench-favicon-app";
     case "cron": return "dench-favicon-cron";
     case "object": return "dench-favicon-object";
@@ -60,6 +62,8 @@ export function TabBar({
   onCloseAll,
   onReorder,
   onTogglePin,
+  liveChatTabIds,
+  onStopTab,
   onNewTab,
   leftContent,
   rightContent,
@@ -104,10 +108,10 @@ export function TabBar({
       title: tab.title,
       active: tab.id === activeTabId,
       favicon: tabToFavicon(tab),
-      faviconClass: tabToFaviconClass(tab),
+      faviconClass: tabToFaviconClass(tab, liveChatTabIds?.has(tab.id) ?? false),
       isCloseIconVisible: !tab.pinned,
     }));
-  }, [nonHomeTabs, activeTabId]);
+  }, [nonHomeTabs, activeTabId, liveChatTabIds]);
 
   const handleActive = useCallback((id: string) => onActivate(id), [onActivate]);
   const handleClose = useCallback((id: string) => onClose(id), [onClose]);
@@ -177,6 +181,15 @@ export function TabBar({
             label={contextTab.pinned ? "Unpin Tab" : "Pin Tab"}
             onClick={() => { onTogglePin(contextMenu.tabId); setContextMenu(null); }}
           />
+          {contextTab.type === "chat" && liveChatTabIds?.has(contextMenu.tabId) && onStopTab && (
+            <>
+              <div className="h-px my-0.5 mx-1 bg-neutral-400/15" />
+              <ContextMenuItem
+                label="Stop Session"
+                onClick={() => { onStopTab(contextMenu.tabId); setContextMenu(null); }}
+              />
+            </>
+          )}
           <div className="h-px my-0.5 mx-1 bg-neutral-400/15" />
           <ContextMenuItem
             label="Close"

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1974,6 +1974,7 @@ body {
 /* Favicon icon classes (SVG data-uri with currentColor replaced by hex) */
 .dench-favicon-home,
 .dench-favicon-chat,
+.dench-favicon-chat-live,
 .dench-favicon-file,
 .dench-favicon-app,
 .dench-favicon-cron,
@@ -1988,6 +1989,10 @@ body {
 }
 .dench-favicon-chat {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' stroke='%23666' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z'/%3E%3C/svg%3E") !important;
+}
+.dench-favicon-chat-live {
+  opacity: 0.9;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' stroke='%23666' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z'/%3E%3Ccircle cx='18' cy='18' r='3' fill='%2310b981' stroke='none'/%3E%3C/svg%3E") !important;
 }
 .dench-favicon-file {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' stroke='%23666' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z'/%3E%3Cpath d='M14 2v4a2 2 0 0 0 2 2h4'/%3E%3C/svg%3E") !important;

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -59,8 +59,28 @@ import {
   generateTabId, loadTabs, saveTabs, openTab, closeTab,
   closeOtherTabs, closeTabsToRight, closeAllTabs,
   activateTab, reorderTabs, togglePinTab,
-  inferTabType, inferTabTitle, updateTabTitle,
+  inferTabType, inferTabTitle,
 } from "@/lib/tab-state";
+import {
+  bindParentSessionToChatTab,
+  closeChatTabsForSession,
+  createBlankChatTab,
+  isChatTab,
+  openOrFocusParentChatTab,
+  openOrFocusSubagentChatTab,
+  resolveChatIdentityForTab,
+  syncParentChatTabTitles,
+  syncSubagentChatTabTitles,
+  updateChatTabTitle,
+} from "@/lib/chat-tabs";
+import {
+  createChatRunsSnapshot,
+  mergeChatRuntimeSnapshot,
+  removeChatRuntimeSnapshot,
+  type ChatTabRuntimeSnapshot,
+  type ChatRunsSnapshot,
+  type ChatPanelRuntimeState,
+} from "@/lib/chat-session-registry";
 import dynamic from "next/dynamic";
 
 const TerminalDrawer = dynamic(
@@ -409,8 +429,10 @@ function WorkspacePageInner() {
   const rendersSinceHydration = useRef(-1);
   const lastPushedQs = useRef<string | null>(null);
 
-  // Chat panel ref for session management
+  // Visible main chat panel ref for session management
   const chatRef = useRef<ChatPanelHandle>(null);
+  // Mounted main chat panels keyed by tab id so inactive tabs can keep streaming.
+  const chatPanelRefs = useRef<Record<string, ChatPanelHandle | null>>({});
   // Compact (file-scoped) chat panel ref for sidebar drag-and-drop
   const compactChatRef = useRef<ChatPanelHandle>(null);
   // Root layout ref for resize handle position (handle follows cursor)
@@ -442,52 +464,14 @@ function WorkspacePageInner() {
   const [sessionsLoading, setSessionsLoading] = useState(true);
   const [sidebarRefreshKey, setSidebarRefreshKey] = useState(0);
   const [streamingSessionIds, setStreamingSessionIds] = useState<Set<string>>(new Set());
+  const [chatRuntimeSnapshots, setChatRuntimeSnapshots] = useState<Record<string, ChatTabRuntimeSnapshot>>({});
+  const [chatRunsSnapshot, setChatRunsSnapshot] = useState<ChatRunsSnapshot>(() =>
+    createChatRunsSnapshot({ parentRuns: [], subagents: [] }),
+  );
 
   // Subagent tracking
   const [subagents, setSubagents] = useState<SubagentSpawnInfo[]>([]);
   const [activeSubagentKey, setActiveSubagentKey] = useState<string | null>(null);
-
-  const handleSubagentSpawned = useCallback((info: SubagentSpawnInfo) => {
-    setSubagents((prev) => {
-      const idx = prev.findIndex((sa) => sa.childSessionKey === info.childSessionKey);
-      if (idx >= 0) {
-        // Update status if changed
-        if (prev[idx].status === info.status) {return prev;}
-        const updated = [...prev];
-        updated[idx] = { ...prev[idx], ...info };
-        return updated;
-      }
-      return [...prev, info];
-    });
-  }, []);
-
-  const handleSelectSubagent = useCallback((sessionKey: string) => {
-    setActiveSubagentKey(sessionKey);
-  }, []);
-
-  const handleBackFromSubagent = useCallback(() => {
-    setActiveSubagentKey(null);
-  }, []);
-
-  // Navigate to a subagent panel when its card is clicked in the chat.
-  // The identifier may be a childSessionKey (preferred) or a task label (legacy fallback).
-  const handleSubagentClickFromChat = useCallback((identifier: string) => {
-    const byKey = subagents.find((sa) => sa.childSessionKey === identifier);
-    if (byKey) {
-      setActiveSubagentKey(byKey.childSessionKey);
-      return;
-    }
-    const byTask = subagents.find((sa) => sa.task === identifier);
-    if (byTask) {
-      setActiveSubagentKey(byTask.childSessionKey);
-    }
-  }, [subagents]);
-
-  // Find the active subagent's info for the panel
-  const activeSubagent = useMemo(() => {
-    if (!activeSubagentKey) {return null;}
-    return subagents.find((sa) => sa.childSessionKey === activeSubagentKey) ?? null;
-  }, [activeSubagentKey, subagents]);
 
   // Cron jobs state
   const [cronJobs, setCronJobs] = useState<CronJob[]>([]);
@@ -531,15 +515,11 @@ function WorkspacePageInner() {
     const loaded = loadTabs(key);
     const hasNonHomeTabs = loaded.tabs.some((t) => t.id !== HOME_TAB_ID);
     if (!hasNonHomeTabs) {
-      const newTab: Tab = {
-        id: generateTabId(),
-        type: "chat",
-        title: "New Chat",
-      };
-      setTabState(openTab(loaded, newTab));
+      setTabState(openTab(loaded, createBlankChatTab()));
     } else {
       setTabState(loaded);
     }
+    setChatRuntimeSnapshots({});
   }, [workspaceName]);
 
   // Persist tabs to localStorage on change (only after initial load for this workspace)
@@ -549,8 +529,171 @@ function WorkspacePageInner() {
     saveTabs(tabState, key);
   }, [tabState, workspaceName]);
 
+  useEffect(() => {
+    const validTabIds = new Set(tabState.tabs.map((tab) => tab.id));
+    setChatRuntimeSnapshots((prev) => {
+      let next = prev;
+      for (const tabId of Object.keys(prev)) {
+        if (!validTabIds.has(tabId)) {
+          next = removeChatRuntimeSnapshot(next, tabId);
+        }
+      }
+      return next;
+    });
+    for (const tabId of Object.keys(chatPanelRefs.current)) {
+      if (!validTabIds.has(tabId)) {
+        delete chatPanelRefs.current[tabId];
+      }
+    }
+  }, [tabState.tabs]);
+
   // Ref for the keyboard shortcut to close the active tab (avoids stale closure over loadContent)
   const tabCloseActiveRef = useRef<(() => void) | null>(null);
+  const activeTab = useMemo(
+    () => tabState.tabs.find((tab) => tab.id === tabState.activeTabId) ?? HOME_TAB,
+    [tabState],
+  );
+  const mainChatTabs = useMemo(
+    () => tabState.tabs.filter((tab) => tab.id !== HOME_TAB_ID && isChatTab(tab)),
+    [tabState.tabs],
+  );
+
+  const openBlankChatTab = useCallback(() => {
+    const tab = createBlankChatTab();
+    setActivePath(null);
+    setContent({ kind: "none" });
+    setActiveSessionId(null);
+    setActiveSubagentKey(null);
+    setTabState((prev) => openTab(prev, tab));
+    return tab;
+  }, []);
+
+  const openSessionChatTab = useCallback((sessionId: string, title?: string) => {
+    setActivePath(null);
+    setContent({ kind: "none" });
+    setActiveSessionId(sessionId);
+    setActiveSubagentKey(null);
+    setTabState((prev) => openOrFocusParentChatTab(prev, { sessionId, title }));
+  }, []);
+
+  const openSubagentChatTab = useCallback((params: {
+    sessionKey: string;
+    parentSessionId: string;
+    title?: string;
+  }) => {
+    setActivePath(null);
+    setContent({ kind: "none" });
+    setActiveSessionId(params.parentSessionId);
+    setActiveSubagentKey(params.sessionKey);
+    setTabState((prev) => openOrFocusSubagentChatTab(prev, params));
+  }, []);
+
+  const visibleMainChatTabId = useMemo(() => {
+    if (isChatTab(activeTab)) {
+      return activeTab.id;
+    }
+    if (activeSubagentKey) {
+      const matchingSubagentTab = mainChatTabs.find((tab) => tab.sessionKey === activeSubagentKey);
+      if (matchingSubagentTab) {
+        return matchingSubagentTab.id;
+      }
+    }
+    if (activeSessionId) {
+      const matchingParentTab = mainChatTabs.find((tab) => tab.sessionId === activeSessionId);
+      if (matchingParentTab) {
+        return matchingParentTab.id;
+      }
+    }
+    return mainChatTabs[0]?.id ?? null;
+  }, [activeTab, activeSessionId, activeSubagentKey, mainChatTabs]);
+
+  useEffect(() => {
+    if (!isChatTab(activeTab)) {
+      return;
+    }
+    const identity = resolveChatIdentityForTab(activeTab);
+    setActiveSessionId((prev) => prev === identity.sessionId ? prev : identity.sessionId);
+    setActiveSubagentKey((prev) => prev === identity.subagentKey ? prev : identity.subagentKey);
+  }, [activeTab]);
+
+  const setMainChatPanelRef = useCallback((tabId: string, handle: ChatPanelHandle | null) => {
+    chatPanelRefs.current[tabId] = handle;
+  }, []);
+
+  useEffect(() => {
+    chatRef.current = visibleMainChatTabId ? chatPanelRefs.current[visibleMainChatTabId] ?? null : null;
+  }, [visibleMainChatTabId]);
+
+  const handleChatRuntimeStateChange = useCallback((tabId: string, runtime: ChatPanelRuntimeState) => {
+    setChatRuntimeSnapshots((prev) =>
+      mergeChatRuntimeSnapshot(prev, {
+        tabId,
+        ...runtime,
+      }),
+    );
+  }, []);
+
+  const handleChatTabSessionChange = useCallback((tabId: string, sessionId: string | null) => {
+    setTabState((prev) => bindParentSessionToChatTab(prev, tabId, sessionId));
+    if (tabState.activeTabId === tabId || visibleMainChatTabId === tabId) {
+      setActiveSessionId(sessionId);
+      setActiveSubagentKey(null);
+    }
+  }, [tabState.activeTabId, visibleMainChatTabId]);
+
+  const sendMessageInChatTab = useCallback((tabId: string, message: string) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        void chatPanelRefs.current[tabId]?.sendNewMessage(message);
+      });
+    });
+  }, []);
+
+  // Navigate to a subagent panel when its card is clicked in the chat.
+  // The identifier may be a childSessionKey (preferred) or a task label (legacy fallback).
+  const handleSubagentClickFromChat = useCallback((identifier: string) => {
+    const byKey = subagents.find((sa) => sa.childSessionKey === identifier);
+    if (byKey) {
+      openSubagentChatTab({
+        sessionKey: byKey.childSessionKey,
+        parentSessionId: byKey.parentSessionId,
+        title: byKey.label || byKey.task,
+      });
+      return;
+    }
+    const byTask = subagents.find((sa) => sa.task === identifier);
+    if (byTask) {
+      openSubagentChatTab({
+        sessionKey: byTask.childSessionKey,
+        parentSessionId: byTask.parentSessionId,
+        title: byTask.label || byTask.task,
+      });
+    }
+  }, [openSubagentChatTab, subagents]);
+
+  const handleSelectSubagent = useCallback((sessionKey: string) => {
+    const subagent = subagents.find((entry) => entry.childSessionKey === sessionKey);
+    if (!subagent) {
+      return;
+    }
+    openSubagentChatTab({
+      sessionKey,
+      parentSessionId: subagent.parentSessionId,
+      title: subagent.label || subagent.task,
+    });
+  }, [openSubagentChatTab, subagents]);
+
+  const handleBackFromSubagent = useCallback(() => {
+    if (!activeSubagentKey) {
+      return;
+    }
+    const activeChild = subagents.find((entry) => entry.childSessionKey === activeSubagentKey);
+    if (activeChild) {
+      openSessionChatTab(activeChild.parentSessionId);
+      return;
+    }
+    setActiveSubagentKey(null);
+  }, [activeSubagentKey, openSessionChatTab, subagents]);
 
   const openTabForNode = useCallback((node: { path: string; name: string; type: string }) => {
     const tab: Tab = {
@@ -700,7 +843,12 @@ function WorkspacePageInner() {
       setActiveSessionId,
       setActiveSubagentKey,
       resetMainChat: () => {
-        void chatRef.current?.newSession();
+        chatPanelRefs.current = {};
+        setChatRuntimeSnapshots({});
+        setChatRunsSnapshot(createChatRunsSnapshot({ parentRuns: [], subagents: [] }));
+        setStreamingSessionIds(new Set());
+        setSubagents([]);
+        setTabState({ tabs: [HOME_TAB], activeTabId: HOME_TAB_ID });
       },
       replaceUrlToRoot: () => {
         // URL sync effect will write the correct URL after state is cleared
@@ -717,21 +865,37 @@ function WorkspacePageInner() {
     async (sessionId: string) => {
       const res = await fetch(`/api/web-sessions/${sessionId}`, { method: "DELETE" });
       if (!res.ok) {return;}
+      const closedTabIds = new Set(
+        tabState.tabs
+          .filter((tab) => tab.type === "chat" && (tab.sessionId === sessionId || tab.parentSessionId === sessionId))
+          .map((tab) => tab.id),
+      );
+      setTabState((prev) => {
+        let next = closeChatTabsForSession(prev, sessionId);
+        const hasNonHomeTabs = next.tabs.some((tab) => tab.id !== HOME_TAB_ID);
+        if (!hasNonHomeTabs) {
+          next = openTab(next, createBlankChatTab());
+        }
+        return next;
+      });
+      setChatRuntimeSnapshots((prev) => {
+        let next = prev;
+        for (const tabId of closedTabIds) {
+          next = removeChatRuntimeSnapshot(next, tabId);
+        }
+        return next;
+      });
       if (activeSessionId === sessionId) {
-        setActiveSessionId(null);
-        setActiveSubagentKey(null);
         const remaining = sessions.filter((s) => s.id !== sessionId);
         if (remaining.length > 0) {
-          const next = remaining[0];
-          setActiveSessionId(next.id);
-          void chatRef.current?.loadSession(next.id);
+          openSessionChatTab(remaining[0].id, remaining[0].title);
         } else {
-          void chatRef.current?.newSession();
+          openBlankChatTab();
         }
       }
       void fetchSessions();
     },
-    [activeSessionId, sessions, fetchSessions],
+    [activeSessionId, sessions, fetchSessions, openBlankChatTab, openSessionChatTab, tabState.tabs],
   );
 
   const handleRenameSession = useCallback(
@@ -746,15 +910,28 @@ function WorkspacePageInner() {
     [fetchSessions],
   );
 
-  // Poll for active (streaming) agent runs so the sidebar can show indicators.
+  // Poll for parent/subagent run state so tabs and sidebars can reflect
+  // background activity across all open chats.
   useEffect(() => {
     let cancelled = false;
     const poll = async () => {
       try {
-        const res = await fetch("/api/chat/active");
+        const res = await fetch("/api/chat/runs");
         if (cancelled) {return;}
         const data = await res.json();
-        const ids: string[] = data.sessionIds ?? [];
+        const parentRuns: Array<{ sessionId: string; status: "running" | "waiting-for-subagents" | "completed" | "error" }> = data.parentRuns ?? [];
+        const nextSubagents: SubagentSpawnInfo[] = data.subagents ?? [];
+        const ids = parentRuns
+          .filter((run) => run.status === "running" || run.status === "waiting-for-subagents")
+          .map((run) => run.sessionId);
+        setChatRunsSnapshot(createChatRunsSnapshot({
+          parentRuns,
+          subagents: nextSubagents.map((subagent) => ({
+            childSessionKey: subagent.childSessionKey,
+            status: subagent.status ?? "completed",
+          })),
+        }));
+        setSubagents(nextSubagents);
         setStreamingSessionIds((prev) => {
           // Only update state if the set actually changed (avoid re-renders).
           if (prev.size === ids.length && ids.every((id) => prev.has(id))) {return prev;}
@@ -924,7 +1101,7 @@ function WorkspacePageInner() {
             setBrowseDir(null);
             setActivePath(null);
             setContent({ kind: "none" });
-            void chatRef.current?.newSession();
+            openBlankChatTab();
             return;
           }
         }
@@ -944,18 +1121,12 @@ function WorkspacePageInner() {
       // Intercept chat folder item clicks
       if (node.path.startsWith("~chats/")) {
         const sessionId = node.path.slice("~chats/".length);
-        setActivePath(null);
-        setContent({ kind: "none" });
-        setActiveSessionId(sessionId);
-        void chatRef.current?.loadSession(sessionId);
-        // URL is synced by the activeSessionId effect
+        openSessionChatTab(sessionId);
         return;
       }
       // Clicking the Chats folder itself opens a new chat
       if (node.path === "~chats") {
-        setActivePath(null);
-        setContent({ kind: "none" });
-        void chatRef.current?.newSession();
+        openBlankChatTab();
         return;
       }
       // Intercept cron job item clicks
@@ -977,15 +1148,44 @@ function WorkspacePageInner() {
       openTabForNode(node);
       void loadContent(node);
     },
-    [loadContent, openTabForNode, cronJobs, browseDir, workspaceRoot, openclawDir, setBrowseDir],
+    [loadContent, openBlankChatTab, openSessionChatTab, openTabForNode, cronJobs, browseDir, workspaceRoot, openclawDir, setBrowseDir],
   );
+
+  const applyActivatedTab = useCallback((tab: Tab | undefined) => {
+    if (!tab || tab.id === HOME_TAB_ID) {
+      setActivePath(null);
+      setContent({ kind: "none" });
+      return;
+    }
+    if (tab.type === "chat") {
+      setActivePath(null);
+      setContent({ kind: "none" });
+      const identity = resolveChatIdentityForTab(tab);
+      setActiveSessionId(identity.sessionId);
+      setActiveSubagentKey(identity.subagentKey);
+      return;
+    }
+    if (tab.path) {
+      const node = resolveNode(tree, tab.path);
+      if (node) {
+        void loadContent(node);
+      } else if (tab.path === "~cron") {
+        setActivePath("~cron");
+        setContent({ kind: "cron-dashboard" });
+      } else if (tab.path.startsWith("~cron/")) {
+        setActivePath(tab.path);
+        const jobId = tab.path.slice("~cron/".length);
+        const job = cronJobs.find((j) => j.id === jobId);
+        if (job) setContent({ kind: "cron-job", jobId, job });
+      }
+    }
+  }, [tree, loadContent, cronJobs]);
 
   // Tab handler callbacks (defined after loadContent is available)
   const handleTabActivate = useCallback((tabId: string) => {
     if (tabId === HOME_TAB_ID) {
-      setActivePath(null);
-      setContent({ kind: "none" });
       setTabState((prev) => activateTab(prev, tabId));
+      applyActivatedTab(undefined);
       return;
     }
     let tab: Tab | undefined;
@@ -995,81 +1195,36 @@ function WorkspacePageInner() {
       return next;
     });
     requestAnimationFrame(() => {
-      if (!tab) return;
-      if (tab.type === "chat") {
-        setActivePath(null);
-        setContent({ kind: "none" });
-        if (tab.sessionId) {
-          setActiveSessionId(tab.sessionId);
-          setActiveSubagentKey(null);
-          void chatRef.current?.loadSession(tab.sessionId);
-        } else {
-          setActiveSessionId(null);
-          setActiveSubagentKey(null);
-          void chatRef.current?.newSession();
-        }
-      } else if (tab.path) {
-        const node = resolveNode(tree, tab.path);
-        if (node) {
-          void loadContent(node);
-        } else if (tab.path === "~cron") {
-          setActivePath("~cron");
-          setContent({ kind: "cron-dashboard" });
-        } else if (tab.path.startsWith("~cron/")) {
-          setActivePath(tab.path);
-          const jobId = tab.path.slice("~cron/".length);
-          const job = cronJobs.find((j) => j.id === jobId);
-          if (job) setContent({ kind: "cron-job", jobId, job });
-        }
-      }
+      applyActivatedTab(tab);
     });
-  }, [tree, loadContent, cronJobs]);
+  }, [applyActivatedTab]);
 
   const handleTabClose = useCallback((tabId: string) => {
     const prev = tabState;
     let next = closeTab(prev, tabId);
     const hasNonHomeTabs = next.tabs.some((t) => t.id !== HOME_TAB_ID);
     if (!hasNonHomeTabs) {
-      const newTab: Tab = {
-        id: generateTabId(),
-        type: "chat",
-        title: "New Chat",
-      };
-      next = openTab(next, newTab);
+      next = openTab(next, createBlankChatTab());
       setTabState(next);
       setActivePath(null);
       setContent({ kind: "none" });
       setActiveSessionId(null);
       setActiveSubagentKey(null);
-      requestAnimationFrame(() => {
-        void chatRef.current?.newSession();
-      });
       return;
     }
     setTabState(next);
     if (next.activeTabId !== prev.activeTabId) {
       const newActive = next.tabs.find((t) => t.id === next.activeTabId);
       if (!newActive || newActive.id === HOME_TAB_ID) {
-        setActivePath(null);
-        setContent({ kind: "none" });
-      } else if (newActive.type === "chat") {
-        setActivePath(null);
-        setContent({ kind: "none" });
-        if (newActive.sessionId) {
-          setActiveSessionId(newActive.sessionId);
-          setActiveSubagentKey(null);
-          requestAnimationFrame(() => {
-            void chatRef.current?.loadSession(newActive.sessionId!);
-          });
-        }
-      } else if (newActive.path) {
-        const node = resolveNode(tree, newActive.path);
-        if (node) {
-          void loadContent(node);
-        }
+        const identity = resolveChatIdentityForTab(next.tabs.find((tab) => tab.type === "chat"));
+        setActiveSessionId(identity.sessionId);
+        setActiveSubagentKey(identity.subagentKey);
+        applyActivatedTab(undefined);
+      } else {
+        applyActivatedTab(newActive);
       }
     }
-  }, [tree, loadContent, tabState]);
+  }, [applyActivatedTab, tabState]);
 
   // Keep ref in sync so keyboard shortcut can close active tab
   useEffect(() => {
@@ -1081,12 +1236,16 @@ function WorkspacePageInner() {
   }, [tabState.activeTabId, handleTabClose]);
 
   const handleTabCloseOthers = useCallback((tabId: string) => {
-    setTabState((prev) => closeOtherTabs(prev, tabId));
-  }, []);
+    const next = closeOtherTabs(tabState, tabId);
+    setTabState(next);
+    applyActivatedTab(next.tabs.find((tab) => tab.id === next.activeTabId));
+  }, [applyActivatedTab, tabState]);
 
   const handleTabCloseToRight = useCallback((tabId: string) => {
-    setTabState((prev) => closeTabsToRight(prev, tabId));
-  }, []);
+    const next = closeTabsToRight(tabState, tabId);
+    setTabState(next);
+    applyActivatedTab(next.tabs.find((tab) => tab.id === next.activeTabId));
+  }, [applyActivatedTab, tabState]);
 
   const handleTabCloseAll = useCallback(() => {
     setTabState((prev) => {
@@ -1095,15 +1254,7 @@ function WorkspacePageInner() {
       setContent({ kind: "none" });
       setActiveSessionId(null);
       setActiveSubagentKey(null);
-      const newTab: Tab = {
-        id: generateTabId(),
-        type: "chat",
-        title: "New Chat",
-      };
-      return openTab(closed, newTab);
-    });
-    requestAnimationFrame(() => {
-      void chatRef.current?.newSession();
+      return openTab(closed, createBlankChatTab());
     });
   }, []);
 
@@ -1185,50 +1336,14 @@ function WorkspacePageInner() {
     [],
   );
 
-  // Open inline file-path mentions from chat.
-  // In chat mode, render a Dropbox-style preview in the right sidebar.
+  // Open inline file-path mentions from chat in a new workspace tab.
   const handleFilePathClickFromChat = useCallback(
     async (rawPath: string) => {
       const inputPath = normalizeChatPath(rawPath);
       if (!inputPath) {return false;}
 
-      // Desktop behavior: always use right-sidebar preview for chat path clicks.
-      const shouldPreviewInSidebar = !isMobile;
-
-      const openNode = async (node: TreeNode) => {
-        if (!shouldPreviewInSidebar) {
-          handleNodeSelect(node);
-          setShowChatSidebar(true);
-          return true;
-        }
-
-        // Ensure we are in main-chat layout so the preview panel is visible.
-        if (activePath || content.kind !== "none") {
-          setActivePath(null);
-          setContent({ kind: "none" });
-        }
-
-        setChatSidebarPreview({
-          status: "loading",
-          path: node.path,
-          filename: node.name,
-        });
-        const previewContent = await loadSidebarPreviewFromNode(node);
-        if (!previewContent) {
-          setChatSidebarPreview({
-            status: "error",
-            path: node.path,
-            filename: node.name,
-            message: "Could not preview this file.",
-          });
-          return false;
-        }
-        setChatSidebarPreview({
-          status: "ready",
-          path: node.path,
-          filename: node.name,
-          content: previewContent,
-        });
+      const openNode = (node: TreeNode) => {
+        handleNodeSelect(node);
         return true;
       };
 
@@ -1241,7 +1356,7 @@ function WorkspacePageInner() {
       ) {
         const node = resolveNode(tree, inputPath);
         if (node) {
-          return await openNode(node);
+          return openNode(node);
         }
       }
 
@@ -1262,24 +1377,14 @@ function WorkspacePageInner() {
           if (relPath) {
             const node = resolveNode(tree, relPath);
             if (node) {
-              return await openNode(node);
+              return openNode(node);
             }
           }
         }
 
         if (info.type === "directory") {
           const dirNode: TreeNode = { name: info.name, path: info.path, type: "folder" };
-          if (shouldPreviewInSidebar) {
-            return await openNode(dirNode);
-          }
-          setBrowseDir(info.path);
-          setActivePath(info.path);
-          setContent({
-            kind: "directory",
-            node: { name: info.name, path: info.path, type: "folder" },
-          });
-          setShowChatSidebar(true);
-          return true;
+          return openNode(dirNode);
         }
 
         if (info.type === "file") {
@@ -1288,16 +1393,7 @@ function WorkspacePageInner() {
             path: info.path,
             type: inferNodeTypeFromFileName(info.name),
           };
-          if (shouldPreviewInSidebar) {
-            return await openNode(fileNode);
-          }
-          const parentDir = info.path.split("/").slice(0, -1).join("/") || "/";
-          if (isAbsolutePath(info.path)) {
-            setBrowseDir(parentDir);
-          }
-          await loadContent(fileNode);
-          setShowChatSidebar(true);
-          return true;
+          return openNode(fileNode);
         }
       } catch {
         // Ignore -- chat message bubble shows inline error state.
@@ -1305,7 +1401,7 @@ function WorkspacePageInner() {
 
       return false;
     },
-    [activePath, content.kind, isMobile, tree, handleNodeSelect, workspaceRoot, loadSidebarPreviewFromNode, setBrowseDir, loadContent, router],
+    [tree, handleNodeSelect, workspaceRoot],
   );
 
   // Build the enhanced tree: real tree + Cron virtual folder at the bottom
@@ -1532,13 +1628,14 @@ function WorkspacePageInner() {
       }
     } else if (urlState.chat) {
       initialPathHandled.current = true;
-      setActiveSessionId(urlState.chat);
-      setActivePath(null);
-      setContent({ kind: "none" });
-      void chatRef.current?.loadSession(urlState.chat);
-
       if (urlState.subagent) {
-        setActiveSubagentKey(urlState.subagent);
+        openSubagentChatTab({
+          sessionKey: urlState.subagent,
+          parentSessionId: urlState.chat,
+          title: "Subagent",
+        });
+      } else {
+        openSessionChatTab(urlState.chat);
       }
     } else {
       // No path or chat param — mark hydration done (bare / or browse-only)
@@ -1611,12 +1708,15 @@ function WorkspacePageInner() {
         }
         setFileChatSessionId(urlState.fileChat);
       } else if (urlState.chat) {
-        setActiveSessionId(urlState.chat);
-        setActivePath(null);
-        setContent({ kind: "none" });
-        void chatRef.current?.loadSession(urlState.chat);
-        setActiveSubagentKey(urlState.subagent);
-        setTabState((prev) => activateTab(prev, HOME_TAB_ID));
+        if (urlState.subagent) {
+          openSubagentChatTab({
+            sessionKey: urlState.subagent,
+            parentSessionId: urlState.chat,
+            title: "Subagent",
+          });
+        } else {
+          openSessionChatTab(urlState.chat);
+        }
       } else {
         setActivePath(null);
         setContent({ kind: "none" });
@@ -1693,11 +1793,9 @@ function WorkspacePageInner() {
     setActivePath(null);
     setContent({ kind: "none" });
 
-    // Give ChatPanel a frame to mount, then send the message
-    requestAnimationFrame(() => {
-      void chatRef.current?.sendNewMessage(sendParam);
-    });
-  }, [searchParams, router]);
+    const tab = openBlankChatTab();
+    sendMessageInChatTab(tab.id, sendParam);
+  }, [openBlankChatTab, searchParams, router, sendMessageInChatTab]);
 
   const handleBreadcrumbNavigate = useCallback(
     (path: string) => {
@@ -1844,10 +1942,9 @@ function WorkspacePageInner() {
   const handleCronSendCommand = useCallback((message: string) => {
     setActivePath(null);
     setContent({ kind: "none" });
-    requestAnimationFrame(() => {
-      void chatRef.current?.sendNewMessage(message);
-    });
-  }, []);
+    const tab = openBlankChatTab();
+    sendMessageInChatTab(tab.id, message);
+  }, [openBlankChatTab, sendMessageInChatTab]);
 
   // Derive the active session's title for the header / right sidebar
   const activeSessionTitle = useMemo(() => {
@@ -1857,18 +1954,128 @@ function WorkspacePageInner() {
   }, [activeSessionId, sessions]);
 
   useEffect(() => {
-    if (!activeSessionTitle) return;
     setTabState((prev) => {
-      const active = prev.tabs.find((t) => t.id === prev.activeTabId);
-      if (active?.type === "chat" && active.title !== activeSessionTitle) {
-        return updateTabTitle(prev, active.id, activeSessionTitle);
+      let next = syncParentChatTabTitles(prev, sessions);
+      next = syncSubagentChatTabTitles(next, subagents);
+      if (!activeSessionTitle) {
+        return next;
       }
-      return prev;
+      const active = next.tabs.find((t) => t.id === next.activeTabId);
+      if (active?.type === "chat" && active.title !== activeSessionTitle && !active.sessionKey) {
+        return updateChatTabTitle(next, active.id, activeSessionTitle);
+      }
+      return next;
     });
-  }, [activeSessionTitle]);
+  }, [activeSessionTitle, sessions, subagents]);
 
-  // Whether to show the main ChatPanel (no file/content selected)
-  const showMainChat = !activePath || content.kind === "none";
+  const runningSubagentKeys = useMemo(
+    () => new Set(subagents.filter((subagent) => subagent.status === "running").map((subagent) => subagent.childSessionKey)),
+    [subagents],
+  );
+
+  const liveChatTabIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const tab of mainChatTabs) {
+      const runtime = chatRuntimeSnapshots[tab.id];
+      if (runtime?.isStreaming) {
+        ids.add(tab.id);
+        continue;
+      }
+      if (tab.sessionKey && (runningSubagentKeys.has(tab.sessionKey) || chatRunsSnapshot.subagentStatuses.get(tab.sessionKey) === "running")) {
+        ids.add(tab.id);
+        continue;
+      }
+      if (tab.sessionId && streamingSessionIds.has(tab.sessionId)) {
+        ids.add(tab.id);
+      }
+    }
+    return ids;
+  }, [chatRunsSnapshot.subagentStatuses, chatRuntimeSnapshots, mainChatTabs, runningSubagentKeys, streamingSessionIds]);
+
+  const optimisticallyStopParentSession = useCallback((sessionId: string) => {
+    setStreamingSessionIds((prev) => {
+      if (!prev.has(sessionId)) {
+        return prev;
+      }
+      const next = new Set(prev);
+      next.delete(sessionId);
+      return next;
+    });
+    setSubagents((prev) => prev.map((subagent) =>
+      subagent.parentSessionId === sessionId && subagent.status === "running"
+        ? { ...subagent, status: "completed" }
+        : subagent,
+    ));
+    setChatRuntimeSnapshots((prev) => {
+      const next: Record<string, ChatTabRuntimeSnapshot> = {};
+      for (const [tabId, snapshot] of Object.entries(prev)) {
+        next[tabId] = snapshot.sessionId === sessionId
+          ? { ...snapshot, isStreaming: false, isReconnecting: false, status: "ready" }
+          : snapshot;
+      }
+      return next;
+    });
+  }, []);
+
+  const optimisticallyStopSubagent = useCallback((sessionKey: string) => {
+    setSubagents((prev) => prev.map((subagent) =>
+      subagent.childSessionKey === sessionKey && subagent.status === "running"
+        ? { ...subagent, status: "completed" }
+        : subagent,
+    ));
+    setChatRuntimeSnapshots((prev) => {
+      const next: Record<string, ChatTabRuntimeSnapshot> = {};
+      for (const [tabId, snapshot] of Object.entries(prev)) {
+        next[tabId] = snapshot.sessionKey === sessionKey
+          ? { ...snapshot, isStreaming: false, isReconnecting: false, status: "ready" }
+          : snapshot;
+      }
+      return next;
+    });
+  }, []);
+
+  const stopParentSession = useCallback(async (sessionId: string) => {
+    optimisticallyStopParentSession(sessionId);
+    try {
+      await fetch("/api/chat/stop", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId, cascadeChildren: true }),
+      });
+    } catch {
+      // Best-effort optimistic stop; polling will reconcile state.
+    }
+  }, [optimisticallyStopParentSession]);
+
+  const stopSubagentSession = useCallback(async (sessionKey: string) => {
+    optimisticallyStopSubagent(sessionKey);
+    try {
+      await fetch("/api/chat/stop", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionKey }),
+      });
+    } catch {
+      // Best-effort optimistic stop; polling will reconcile state.
+    }
+  }, [optimisticallyStopSubagent]);
+
+  const handleStopChatTab = useCallback((tabId: string) => {
+    const tab = tabState.tabs.find((entry) => entry.id === tabId);
+    if (!tab || tab.type !== "chat") {
+      return;
+    }
+    if (tab.sessionKey) {
+      void stopSubagentSession(tab.sessionKey);
+      return;
+    }
+    if (tab.sessionId) {
+      void stopParentSession(tab.sessionId);
+    }
+  }, [stopParentSession, stopSubagentSession, tabState.tabs]);
+
+  // Whether to show the main chat workspace instead of file/object content.
+  const showMainChat = activeTab.type === "chat" || activeTab.id === HOME_TAB_ID || (!activePath || content.kind === "none");
 
   return (
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
@@ -1908,15 +2115,12 @@ function WorkspacePageInner() {
             chatActiveSubagentKey={activeSubagentKey}
             chatSessionsLoading={sessionsLoading}
             onSelectChatSession={(sessionId) => {
-              setActiveSessionId(sessionId);
-              setActiveSubagentKey(null);
-              void chatRef.current?.loadSession(sessionId);
+              const session = sessions.find((entry) => entry.id === sessionId);
+              openSessionChatTab(sessionId, session?.title);
               setSidebarOpen(false);
             }}
             onNewChatSession={() => {
-              setActiveSessionId(null);
-              setActiveSubagentKey(null);
-              void chatRef.current?.newSession();
+              openBlankChatTab();
               setSidebarOpen(false);
             }}
             onSelectChatSubagent={handleSelectSubagent}
@@ -1974,14 +2178,11 @@ function WorkspacePageInner() {
                 chatActiveSubagentKey={activeSubagentKey}
                 chatSessionsLoading={sessionsLoading}
                 onSelectChatSession={(sessionId) => {
-                  setActiveSessionId(sessionId);
-                  setActiveSubagentKey(null);
-                  void chatRef.current?.loadSession(sessionId);
+                  const session = sessions.find((entry) => entry.id === sessionId);
+                  openSessionChatTab(sessionId, session?.title);
                 }}
                 onNewChatSession={() => {
-                  setActiveSessionId(null);
-                  setActiveSubagentKey(null);
-                  void chatRef.current?.newSession();
+                  openBlankChatTab();
                 }}
                 onSelectChatSubagent={handleSelectSubagent}
                 onDeleteChatSession={handleDeleteSession}
@@ -1997,7 +2198,7 @@ function WorkspacePageInner() {
       {/* Main content */}
       <main className="flex-1 flex flex-col min-w-0 overflow-hidden" style={{ background: "var(--color-surface)" }}>
         <div className="flex flex-1 min-h-0">
-          <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
             {/* Mobile top bar — always visible on mobile */}
             {isMobile && (
               <div
@@ -2065,23 +2266,24 @@ function WorkspacePageInner() {
                 onCloseAll={handleTabCloseAll}
                 onReorder={handleTabReorder}
                 onTogglePin={handleTabTogglePin}
-                onNewTab={() => {
-                  const newTab: Tab = {
-                    id: generateTabId(),
-                    type: "chat",
-                    title: "New Chat",
-                  };
-                  setActivePath(null);
-                  setContent({ kind: "none" });
-                  setActiveSessionId(null);
-                  setActiveSubagentKey(null);
-                  setTabState((prev) => openTab(prev, newTab));
-                  requestAnimationFrame(() => {
-                    void chatRef.current?.newSession();
-                  });
-                }}
+                liveChatTabIds={liveChatTabIds}
+                onStopTab={handleStopChatTab}
+                onNewTab={openBlankChatTab}
                 rightContent={showMainChat ? (
                   <>
+                    {visibleMainChatTabId && liveChatTabIds.has(visibleMainChatTabId) && (
+                      <button
+                        type="button"
+                        onClick={() => handleStopChatTab(visibleMainChatTabId)}
+                        className="p-1.5 rounded-lg cursor-pointer"
+                        style={{ color: "var(--color-text-muted)" }}
+                        title="Stop active chat"
+                      >
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                          <rect x="6" y="6" width="12" height="12" rx="2" />
+                        </svg>
+                      </button>
+                    )}
                     <button
                       type="button"
                       onClick={() => setChatSidebarOpen((v) => !v)}
@@ -2096,7 +2298,7 @@ function WorkspacePageInner() {
                         <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
                       </svg>
                     </button>
-                    {activeSessionId && (
+                    {activeSessionId && !activeSubagentKey && (
                       <DropdownMenu>
                         <DropdownMenuTrigger
                           className="p-1.5 rounded-lg cursor-pointer"
@@ -2173,46 +2375,43 @@ function WorkspacePageInner() {
 
             {/* Content area */}
             <div className="flex-1 flex min-h-0">
-              {showMainChat ? (
-                <div className="flex-1 flex flex-col min-w-0" style={{ background: "var(--color-main-bg)" }}>
-                  <ChatPanel
-                    key={activeSubagent?.childSessionKey ?? "main"}
-                    ref={activeSubagent ? undefined : chatRef}
-                    sessionTitle={activeSessionTitle}
-                    initialSessionId={activeSessionId ?? undefined}
-                    onActiveSessionChange={activeSubagent ? undefined : (id) => {
-                      setActiveSessionId(id);
-                      setActiveSubagentKey(null);
-                      if (id) {
-                        setTabState((prev) => {
-                          const active = prev.tabs.find((t) => t.id === prev.activeTabId);
-                          if (active?.type === "chat" && !active.sessionId) {
-                            return {
-                              ...prev,
-                              tabs: prev.tabs.map((t) =>
-                                t.id === active.id ? { ...t, sessionId: id } : t,
-                              ),
-                            };
-                          }
-                          return prev;
-                        });
-                      }
-                    }}
-                    onSessionsChange={activeSubagent ? undefined : refreshSessions}
-                    onSubagentSpawned={activeSubagent ? undefined : handleSubagentSpawned}
-                    onSubagentClick={handleSubagentClickFromChat}
-                    onFilePathClick={handleFilePathClickFromChat}
-                    onDeleteSession={activeSubagent ? undefined : handleDeleteSession}
-                    onRenameSession={activeSubagent ? undefined : handleRenameSession}
-                    compact={isMobile}
-                    sessionKey={activeSubagent?.childSessionKey}
-                    subagentTask={activeSubagent?.task}
-                    subagentLabel={activeSubagent?.label}
-                    onBack={activeSubagent ? handleBackFromSubagent : undefined}
-                    hideHeaderActions={!isMobile}
-                  />
-                </div>
-              ) : (
+              <div
+                className={showMainChat ? "flex-1 flex min-h-0 min-w-0 flex-col overflow-hidden" : "hidden"}
+                style={{ background: "var(--color-main-bg)" }}
+              >
+                {mainChatTabs.map((tab) => {
+                  const subagent = tab.sessionKey
+                    ? subagents.find((entry) => entry.childSessionKey === tab.sessionKey)
+                    : null;
+                  const isVisible = tab.id === visibleMainChatTabId;
+                  return (
+                    <div
+                      key={tab.id}
+                      className={isVisible ? "flex-1 flex min-h-0 min-w-0 flex-col overflow-hidden" : "hidden"}
+                    >
+                      <ChatPanel
+                        ref={(handle) => setMainChatPanelRef(tab.id, handle)}
+                        sessionTitle={tab.title}
+                        initialSessionId={tab.sessionKey ? undefined : tab.sessionId ?? undefined}
+                        onActiveSessionChange={tab.sessionKey ? undefined : (id) => handleChatTabSessionChange(tab.id, id)}
+                        onSessionsChange={refreshSessions}
+                        onSubagentClick={handleSubagentClickFromChat}
+                        onFilePathClick={handleFilePathClickFromChat}
+                        onDeleteSession={tab.sessionKey ? undefined : handleDeleteSession}
+                        onRenameSession={tab.sessionKey ? undefined : handleRenameSession}
+                        compact={isMobile}
+                        sessionKey={tab.sessionKey ?? undefined}
+                        subagentTask={subagent?.task}
+                        subagentLabel={subagent?.label}
+                        onBack={tab.sessionKey ? handleBackFromSubagent : undefined}
+                        hideHeaderActions={!isMobile}
+                        onRuntimeStateChange={(runtime) => handleChatRuntimeStateChange(tab.id, runtime)}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+              {!showMainChat && (
                 <div className="flex-1 overflow-y-auto">
                   <ContentRenderer
                     content={content}
@@ -2259,7 +2458,7 @@ function WorkspacePageInner() {
                 transition: "width 200ms ease",
               }}
             >
-              <div className="flex flex-col h-full relative" style={{ width: chatSidebarWidth, minWidth: chatSidebarWidth }}>
+              <div className="flex h-full min-h-0 flex-col relative overflow-hidden" style={{ width: chatSidebarWidth, minWidth: chatSidebarWidth }}>
                 <ResizeHandle
                   mode="right"
                   containerRef={layoutRef}
@@ -2276,18 +2475,17 @@ function WorkspacePageInner() {
                   activeSubagentKey={activeSubagentKey}
                   loading={sessionsLoading}
                   onSelectSession={(sessionId) => {
-                    setActiveSessionId(sessionId);
-                    setActiveSubagentKey(null);
-                    void chatRef.current?.loadSession(sessionId);
+                    const session = sessions.find((entry) => entry.id === sessionId);
+                    openSessionChatTab(sessionId, session?.title);
                   }}
                   onNewSession={() => {
-                    setActiveSessionId(null);
-                    setActiveSubagentKey(null);
-                    void chatRef.current?.newSession();
+                    openBlankChatTab();
                   }}
                   onSelectSubagent={handleSelectSubagent}
                   onDeleteSession={handleDeleteSession}
                   onRenameSession={handleRenameSession}
+                  onStopSession={(sessionId) => { void stopParentSession(sessionId); }}
+                  onStopSubagent={(sessionKey) => { void stopSubagentSession(sessionKey); }}
                   embedded
                 />
               </div>
@@ -2304,7 +2502,7 @@ function WorkspacePageInner() {
                 transition: "width 200ms ease",
               }}
             >
-              <div className="flex flex-col h-full relative" style={{ width: rightSidebarWidth, minWidth: rightSidebarWidth }}>
+              <div className="flex h-full min-h-0 flex-col relative overflow-hidden" style={{ width: rightSidebarWidth, minWidth: rightSidebarWidth }}>
                 <ResizeHandle
                   mode="right"
                   containerRef={layoutRef}

--- a/apps/web/lib/chat-session-registry.ts
+++ b/apps/web/lib/chat-session-registry.ts
@@ -1,0 +1,61 @@
+export type ChatPanelRuntimeState = {
+  sessionId: string | null;
+  sessionKey: string | null;
+  isStreaming: boolean;
+  status: string;
+  isReconnecting: boolean;
+  loadingSession: boolean;
+};
+
+export type ChatTabRuntimeSnapshot = ChatPanelRuntimeState & {
+  tabId: string;
+};
+
+export type ChatRunsSnapshot = {
+  parentStatuses: Map<string, "running" | "waiting-for-subagents" | "completed" | "error">;
+  subagentStatuses: Map<string, "running" | "completed" | "error">;
+};
+
+export function mergeChatRuntimeSnapshot(
+  state: Record<string, ChatTabRuntimeSnapshot>,
+  snapshot: ChatTabRuntimeSnapshot,
+): Record<string, ChatTabRuntimeSnapshot> {
+  const current = state[snapshot.tabId];
+  if (
+    current &&
+    current.sessionId === snapshot.sessionId &&
+    current.sessionKey === snapshot.sessionKey &&
+    current.isStreaming === snapshot.isStreaming &&
+    current.status === snapshot.status &&
+    current.isReconnecting === snapshot.isReconnecting &&
+    current.loadingSession === snapshot.loadingSession
+  ) {
+    return state;
+  }
+  return {
+    ...state,
+    [snapshot.tabId]: snapshot,
+  };
+}
+
+export function removeChatRuntimeSnapshot(
+  state: Record<string, ChatTabRuntimeSnapshot>,
+  tabId: string,
+): Record<string, ChatTabRuntimeSnapshot> {
+  if (!(tabId in state)) {
+    return state;
+  }
+  const next = { ...state };
+  delete next[tabId];
+  return next;
+}
+
+export function createChatRunsSnapshot(params: {
+  parentRuns: Array<{ sessionId: string; status: "running" | "waiting-for-subagents" | "completed" | "error" }>;
+  subagents: Array<{ childSessionKey: string; status: "running" | "completed" | "error" }>;
+}): ChatRunsSnapshot {
+  return {
+    parentStatuses: new Map(params.parentRuns.map((run) => [run.sessionId, run.status])),
+    subagentStatuses: new Map(params.subagents.map((run) => [run.childSessionKey, run.status])),
+  };
+}

--- a/apps/web/lib/chat-tabs.test.ts
+++ b/apps/web/lib/chat-tabs.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { HOME_TAB, openTab, type TabState } from "./tab-state";
+import {
+  bindParentSessionToChatTab,
+  closeChatTabsForSession,
+  createBlankChatTab,
+  createParentChatTab,
+  createSubagentChatTab,
+  openOrFocusParentChatTab,
+  openOrFocusSubagentChatTab,
+  resolveChatIdentityForTab,
+  syncParentChatTabTitles,
+  syncSubagentChatTabTitles,
+} from "./chat-tabs";
+
+function baseState(): TabState {
+  return {
+    tabs: [HOME_TAB],
+    activeTabId: HOME_TAB.id,
+  };
+}
+
+describe("chat tab helpers", () => {
+  it("reuses an existing parent chat tab for the same session (prevents duplicate live tabs)", () => {
+    const existing = createParentChatTab({ sessionId: "parent-1", title: "Parent" });
+    const state = openTab(baseState(), existing);
+
+    const next = openOrFocusParentChatTab(state, { sessionId: "parent-1", title: "Renamed" });
+
+    expect(next.tabs.filter((tab) => tab.type === "chat")).toHaveLength(1);
+    expect(next.activeTabId).toBe(existing.id);
+  });
+
+  it("reuses an existing subagent tab for the same child session key (prevents duplicate child viewers)", () => {
+    const existing = createSubagentChatTab({
+      sessionKey: "agent:child-1:subagent:abc",
+      parentSessionId: "parent-1",
+      title: "Child",
+    });
+    const state = openTab(baseState(), existing);
+
+    const next = openOrFocusSubagentChatTab(state, {
+      sessionKey: "agent:child-1:subagent:abc",
+      parentSessionId: "parent-1",
+      title: "Child updated",
+    });
+
+    expect(next.tabs.filter((tab) => tab.type === "chat")).toHaveLength(1);
+    expect(next.activeTabId).toBe(existing.id);
+  });
+
+  it("binds a newly-created parent session id onto a draft chat tab without disturbing sibling tabs", () => {
+    const draft = createBlankChatTab();
+    const sibling = createParentChatTab({ sessionId: "existing-1", title: "Existing" });
+    const state = {
+      tabs: [HOME_TAB, draft, sibling],
+      activeTabId: draft.id,
+    } satisfies TabState;
+
+    const next = bindParentSessionToChatTab(state, draft.id, "new-session-1");
+
+    expect(next.tabs.find((tab) => tab.id === draft.id)?.sessionId).toBe("new-session-1");
+    expect(next.tabs.find((tab) => tab.id === sibling.id)?.sessionId).toBe("existing-1");
+  });
+
+  it("closes a deleted parent session and all of its subagent tabs (prevents orphan child tabs)", () => {
+    const parent = createParentChatTab({ sessionId: "parent-1", title: "Parent" });
+    const child = createSubagentChatTab({
+      sessionKey: "agent:child-1:subagent:abc",
+      parentSessionId: "parent-1",
+      title: "Child",
+    });
+    const unrelated = createParentChatTab({ sessionId: "parent-2", title: "Other" });
+    const state = {
+      tabs: [HOME_TAB, parent, child, unrelated],
+      activeTabId: child.id,
+    } satisfies TabState;
+
+    const next = closeChatTabsForSession(state, "parent-1");
+
+    expect(next.tabs.map((tab) => tab.id)).not.toContain(parent.id);
+    expect(next.tabs.map((tab) => tab.id)).not.toContain(child.id);
+    expect(next.tabs.map((tab) => tab.id)).toContain(unrelated.id);
+  });
+
+  it("syncs parent and subagent titles from persisted session metadata", () => {
+    const parent = createParentChatTab({ sessionId: "parent-1", title: "Draft title" });
+    const child = createSubagentChatTab({
+      sessionKey: "agent:child-1:subagent:abc",
+      parentSessionId: "parent-1",
+      title: "Child draft",
+    });
+    const state = {
+      tabs: [HOME_TAB, parent, child],
+      activeTabId: parent.id,
+    } satisfies TabState;
+
+    const parentSynced = syncParentChatTabTitles(state, [{ id: "parent-1", title: "Real title" }]);
+    const fullySynced = syncSubagentChatTabTitles(parentSynced, [
+      { childSessionKey: "agent:child-1:subagent:abc", task: "Long task", label: "Research branch" },
+    ]);
+
+    expect(fullySynced.tabs.find((tab) => tab.id === parent.id)?.title).toBe("Real title");
+    expect(fullySynced.tabs.find((tab) => tab.id === child.id)?.title).toBe("Research branch");
+  });
+
+  it("resolves chat identity for parent and subagent tabs", () => {
+    const parent = createParentChatTab({ sessionId: "parent-1", title: "Parent" });
+    const child = createSubagentChatTab({
+      sessionKey: "agent:child-1:subagent:abc",
+      parentSessionId: "parent-1",
+      title: "Child",
+    });
+
+    expect(resolveChatIdentityForTab(parent)).toEqual({
+      sessionId: "parent-1",
+      subagentKey: null,
+    });
+    expect(resolveChatIdentityForTab(child)).toEqual({
+      sessionId: "parent-1",
+      subagentKey: "agent:child-1:subagent:abc",
+    });
+  });
+});

--- a/apps/web/lib/chat-tabs.ts
+++ b/apps/web/lib/chat-tabs.ts
@@ -1,0 +1,178 @@
+import {
+  type Tab,
+  type TabState,
+  generateTabId,
+  openTab,
+} from "./tab-state";
+
+export function isChatTab(tab: Tab | undefined | null): tab is Tab {
+  return tab?.type === "chat";
+}
+
+export function isSubagentChatTab(tab: Tab | undefined | null): tab is Tab {
+  return Boolean(tab?.type === "chat" && tab.sessionKey);
+}
+
+export function createBlankChatTab(title = "New Chat"): Tab {
+  return {
+    id: generateTabId(),
+    type: "chat",
+    title,
+  };
+}
+
+export function createParentChatTab(params: {
+  sessionId: string;
+  title?: string;
+}): Tab {
+  return {
+    id: generateTabId(),
+    type: "chat",
+    title: params.title || "New Chat",
+    sessionId: params.sessionId,
+  };
+}
+
+export function createSubagentChatTab(params: {
+  sessionKey: string;
+  parentSessionId: string;
+  title?: string;
+}): Tab {
+  return {
+    id: generateTabId(),
+    type: "chat",
+    title: params.title || "Subagent",
+    sessionKey: params.sessionKey,
+    parentSessionId: params.parentSessionId,
+  };
+}
+
+export function bindParentSessionToChatTab(
+  state: TabState,
+  tabId: string,
+  sessionId: string | null,
+): TabState {
+  return {
+    ...state,
+    tabs: state.tabs.map((tab) =>
+      tab.id === tabId
+        ? {
+            ...tab,
+            sessionId: sessionId ?? undefined,
+            sessionKey: undefined,
+          }
+        : tab,
+    ),
+  };
+}
+
+export function updateChatTabTitle(
+  state: TabState,
+  tabId: string,
+  title: string,
+): TabState {
+  return {
+    ...state,
+    tabs: state.tabs.map((tab) =>
+      tab.id === tabId && tab.title !== title
+        ? { ...tab, title }
+        : tab,
+    ),
+  };
+}
+
+export function syncParentChatTabTitles(
+  state: TabState,
+  sessions: Array<{ id: string; title: string }>,
+): TabState {
+  const titleBySessionId = new Map(sessions.map((session) => [session.id, session.title]));
+  let changed = false;
+  const tabs = state.tabs.map((tab) => {
+    if (tab.type !== "chat" || !tab.sessionId) {
+      return tab;
+    }
+    const nextTitle = titleBySessionId.get(tab.sessionId);
+    if (!nextTitle || nextTitle === tab.title) {
+      return tab;
+    }
+    changed = true;
+    return { ...tab, title: nextTitle };
+  });
+  return changed ? { ...state, tabs } : state;
+}
+
+export function syncSubagentChatTabTitles(
+  state: TabState,
+  subagents: Array<{ childSessionKey: string; label?: string; task: string }>,
+): TabState {
+  const titleBySessionKey = new Map(
+    subagents.map((subagent) => [subagent.childSessionKey, subagent.label || subagent.task]),
+  );
+  let changed = false;
+  const tabs = state.tabs.map((tab) => {
+    if (tab.type !== "chat" || !tab.sessionKey) {
+      return tab;
+    }
+    const nextTitle = titleBySessionKey.get(tab.sessionKey);
+    if (!nextTitle || nextTitle === tab.title) {
+      return tab;
+    }
+    changed = true;
+    return { ...tab, title: nextTitle };
+  });
+  return changed ? { ...state, tabs } : state;
+}
+
+export function openOrFocusParentChatTab(
+  state: TabState,
+  params: { sessionId: string; title?: string },
+): TabState {
+  return openTab(state, createParentChatTab(params));
+}
+
+export function openOrFocusSubagentChatTab(
+  state: TabState,
+  params: { sessionKey: string; parentSessionId: string; title?: string },
+): TabState {
+  return openTab(state, createSubagentChatTab(params));
+}
+
+export function closeChatTabsForSession(
+  state: TabState,
+  sessionId: string,
+): TabState {
+  const tabs = state.tabs.filter((tab) => {
+    if (tab.pinned) {
+      return true;
+    }
+    if (tab.type !== "chat") {
+      return true;
+    }
+    return tab.sessionId !== sessionId && tab.parentSessionId !== sessionId;
+  });
+
+  const activeStillExists = tabs.some((tab) => tab.id === state.activeTabId);
+  return {
+    tabs,
+    activeTabId: activeStillExists ? state.activeTabId : tabs[tabs.length - 1]?.id ?? null,
+  };
+}
+
+export function resolveChatIdentityForTab(tab: Tab | undefined | null): {
+  sessionId: string | null;
+  subagentKey: string | null;
+} {
+  if (!tab || tab.type !== "chat") {
+    return { sessionId: null, subagentKey: null };
+  }
+  if (tab.sessionKey) {
+    return {
+      sessionId: tab.parentSessionId ?? null,
+      subagentKey: tab.sessionKey,
+    };
+  }
+  return {
+    sessionId: tab.sessionId ?? null,
+    subagentKey: null,
+  };
+}

--- a/apps/web/lib/tab-state.ts
+++ b/apps/web/lib/tab-state.ts
@@ -23,6 +23,8 @@ export type Tab = {
   icon?: string;
   path?: string;
   sessionId?: string;
+  sessionKey?: string;
+  parentSessionId?: string;
   pinned?: boolean;
 };
 
@@ -72,8 +74,8 @@ export function saveTabs(state: TabState, workspaceId?: string | null): void {
   if (typeof window === "undefined") return;
   try {
     const serializable: TabState = {
-      tabs: state.tabs.map(({ id, type, title, icon, path, sessionId, pinned }) => ({
-        id, type, title, icon, path, sessionId, pinned,
+      tabs: state.tabs.map(({ id, type, title, icon, path, sessionId, sessionKey, parentSessionId, pinned }) => ({
+        id, type, title, icon, path, sessionId, sessionKey, parentSessionId, pinned,
       })),
       activeTabId: state.activeTabId,
     };
@@ -91,12 +93,18 @@ export function findTabBySessionId(tabs: Tab[], sessionId: string): Tab | undefi
   return tabs.find((t) => t.type === "chat" && t.sessionId === sessionId);
 }
 
+export function findTabBySessionKey(tabs: Tab[], sessionKey: string): Tab | undefined {
+  return tabs.find((t) => t.type === "chat" && t.sessionKey === sessionKey);
+}
+
 export function openTab(state: TabState, tab: Tab): TabState {
   const existing = tab.path
     ? findTabByPath(state.tabs, tab.path)
-    : tab.sessionId
-      ? findTabBySessionId(state.tabs, tab.sessionId)
-      : undefined;
+    : tab.sessionKey
+      ? findTabBySessionKey(state.tabs, tab.sessionKey)
+      : tab.sessionId
+        ? findTabBySessionId(state.tabs, tab.sessionId)
+        : undefined;
 
   if (existing) {
     return { ...state, activeTabId: existing.id };


### PR DESCRIPTION
### changes

- Add `chat-tabs.ts` with helpers for creating/focusing/closing chat tabs (parent, subagent, blank)
- Add `chat-session-registry.ts` for per-tab streaming runtime state and run status snapshots
- Extend `tab-state.ts` with `sessionKey`, `parentSessionId` fields and `findTabBySessionKey`
- Refactor `workspace-content.tsx` to manage multiple `ChatPanel` refs keyed by tab ID with only the active one visible
- Add per-session stop controls in sidebar (`onStopSession`, `onStopSubagent`) and tab bar context menu
- Add `.dench-favicon-chat-live` CSS class for live streaming tab indicators (green dot)
- Fix chat panel scroll/layout with `min-h-0` / `overflow-hidden` on flex containers
- Always show `AttachedFilesCard` when attachments exist (removed `!richHtml` guard)
- Make file path clicks from chat open in workspace tabs instead of sidebar preview

### why

Users needed to run multiple concurrent chat sessions (including subagent conversations) and see/control each independently. The previous single-session model couldn't support parallel streaming or per-session stop.

### journey

<details>
<summary>Approaches considered & decisions made</summary>

- **Tab-per-session model**: Each chat session (parent or subagent) gets its own tab, enabling fast switching without losing scroll position or streaming state
- **ChatPanel per tab**: Rendering one `ChatPanel` per chat tab (hidden when not active) preserves each session's React state and streaming connection
- **Optimistic stop**: Stop controls optimistically update local state before the API responds, giving immediate feedback
- **Layout fixes**: Flex containers needed explicit `min-h-0` to allow ScrollArea to shrink and scroll properly
- **File path clicks**: Removed the sidebar preview in favor of opening files directly in the tree, matching user expectations

</details>

### validate

- [ ] Open multiple chat tabs and verify each streams independently
- [ ] Stop a streaming session from the sidebar stop button and from the tab bar context menu
- [ ] Verify subagent tabs appear when a parent session spawns subagents
- [ ] Scroll a long chat conversation and verify the scroll container works correctly
- [ ] Send a message with file attachments and verify they display on the message bubble
- [ ] Click a file path in a chat message and verify it opens in a workspace tab

### customer impact statement

Users can now run and view multiple concurrent chat sessions in tabs, with per-session stop controls and live streaming indicators.

### other notes

Stacked on #99 (stream status) → #98 (runs API) → #97 (workspace routing).

### stack

<!-- branch-stack -->

### ci / cd

**migration test**: check the box below to run migration tests:

- [ ] Run migration test on DB

**evals**: check the box below to run AI evals:

- [ ] Run evals