### PR TITLE
fix: correct indentation in reports execute route

### DIFF
--- a/apps/web/app/api/workspace/reports/execute/route.ts
+++ b/apps/web/app/api/workspace/reports/execute/route.ts
@@ -44,7 +44,7 @@ export async function POST(req: Request) {
   const finalSql = injectFilters(sql, filterClauses);
 
   try {
-		const rows = await duckdbQueryAsync(finalSql);
+    const rows = await duckdbQueryAsync(finalSql);
     trackServer("report_executed");
     return Response.json({ rows, sql: finalSql });
   } catch (err) {


### PR DESCRIPTION
Replace tab character with spaces on line 47 in `apps/web/app/api/workspace/reports/execute/route.ts` for consistency with the rest of the file.

Made with [Cursor](https://cursor.com)