### PR TITLE
fix(cli): make CLI cross-platform compatible with Windows

### DIFF
--- a/src/cli/bootstrap-external.ts
+++ b/src/cli/bootstrap-external.ts
@@ -9,6 +9,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { confirm, isCancel, select, spinner, text } from "@clack/prompts";
@@ -229,23 +230,10 @@ type DenchCloudBootstrapSelection = {
   catalog?: DenchCloudCatalogLoadResult;
 };
 
-function resolveCommandForPlatform(command: string): string {
-  if (process.platform !== "win32") {
-    return command;
-  }
-  if (path.extname(command)) {
-    return command;
-  }
-  const normalized = path.basename(command).toLowerCase();
-  if (
-    normalized === "npm" ||
-    normalized === "pnpm" ||
-    normalized === "npx" ||
-    normalized === "yarn"
-  ) {
-    return `${command}.cmd`;
-  }
-  return command;
+const IS_WINDOWS = process.platform === "win32";
+
+function platformSpawnOptions(): { shell: boolean; windowsHide: boolean } {
+  return { shell: IS_WINDOWS, windowsHide: IS_WINDOWS };
 }
 
 async function runCommandWithTimeout(
@@ -264,10 +252,11 @@ async function runCommandWithTimeout(
   }
   const stdio: StdioOptions = options.ioMode === "inherit" ? "inherit" : ["ignore", "pipe", "pipe"];
   return await new Promise<SpawnResult>((resolve, reject) => {
-    const child = spawn(resolveCommandForPlatform(command), args, {
+    const child = spawn(command, args, {
       cwd: options.cwd,
       env: options.env ?? process.env,
       stdio,
+      ...platformSpawnOptions(),
     });
     let stdout = "";
     let stderr = "";
@@ -1129,8 +1118,9 @@ async function runOpenClawWithProgress(params: {
   s.start(params.startMessage);
 
   const result = await new Promise<SpawnResult>((resolve, reject) => {
-    const child = spawn(resolveCommandForPlatform(params.openclawCommand), params.args, {
+    const child = spawn(params.openclawCommand, params.args, {
       stdio: ["ignore", "pipe", "pipe"],
+      ...platformSpawnOptions(),
     });
     let stdout = "";
     let stderr = "";
@@ -1831,7 +1821,7 @@ function readLogTail(logPath: string, maxLines = 16): string | undefined {
 }
 
 function resolveLatestRuntimeLogPath(): string | undefined {
-  const runtimeLogDir = "/tmp/openclaw";
+  const runtimeLogDir = path.join(os.tmpdir(), "openclaw");
   if (!existsSync(runtimeLogDir)) {
     return undefined;
   }
@@ -3481,11 +3471,11 @@ export async function bootstrapCommand(
       runtime.log(
         theme.warn("Global OpenClaw was installed, but `openclaw` is not on shell PATH."),
       );
-      runtime.log(
-        theme.muted(
-          `Add this to your shell profile, then open a new terminal: export PATH="${installResult.globalBinDir}:$PATH"`,
-        ),
-      );
+      const pathHint =
+        IS_WINDOWS
+          ? `To add to PATH, run in PowerShell: $env:Path = "${installResult.globalBinDir};$env:Path"`
+          : `Add this to your shell profile, then open a new terminal: export PATH="${installResult.globalBinDir}:$PATH"`;
+      runtime.log(theme.muted(pathHint));
     }
 
     runtime.log(theme.muted(`Workspace seed: ${describeWorkspaceSeedResult(workspaceSeed)}`));

--- a/src/cli/ports.ts
+++ b/src/cli/ports.ts
@@ -1,6 +1,8 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { resolveLsofCommandSync } from "../infra/ports-lsof.js";
 import { sleep } from "../utils.js";
+
+const IS_WINDOWS = process.platform === "win32";
 
 export type PortProcess = { pid: number; command?: string };
 
@@ -30,7 +32,35 @@ export function parseLsofOutput(output: string): PortProcess[] {
   return results;
 }
 
-export function listPortListeners(port: number): PortProcess[] {
+export function parseNetstatOutput(output: string, port: number): PortProcess[] {
+  const seen = new Set<number>();
+  const results: PortProcess[] = [];
+  for (const line of output.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed.includes("LISTENING")) continue;
+    const columns = trimmed.split(/\s+/);
+    const localAddr = columns[1];
+    if (!localAddr) continue;
+    const addrPort = Number.parseInt(localAddr.slice(localAddr.lastIndexOf(":") + 1), 10);
+    if (addrPort !== port) continue;
+    const pid = Number.parseInt(columns[columns.length - 1], 10);
+    if (!Number.isFinite(pid) || pid <= 0 || seen.has(pid)) continue;
+    seen.add(pid);
+    results.push({ pid });
+  }
+  return results;
+}
+
+function listPortListenersWindows(port: number): PortProcess[] {
+  try {
+    const out = execSync(`netstat -ano -p TCP`, { encoding: "utf-8", windowsHide: true });
+    return parseNetstatOutput(out, port);
+  } catch {
+    return [];
+  }
+}
+
+function listPortListenersUnix(port: number): PortProcess[] {
   try {
     const lsof = resolveLsofCommandSync();
     const out = execFileSync(lsof, ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-FpFc"], {
@@ -45,16 +75,44 @@ export function listPortListeners(port: number): PortProcess[] {
     }
     if (status === 1) {
       return [];
-    } // no listeners
+    }
     throw err instanceof Error ? err : new Error(String(err));
   }
+}
+
+export function listPortListeners(port: number): PortProcess[] {
+  return IS_WINDOWS ? listPortListenersWindows(port) : listPortListenersUnix(port);
+}
+
+function terminatePid(pid: number): void {
+  if (IS_WINDOWS) {
+    try {
+      execSync(`taskkill /pid ${pid} /f /t`, { stdio: "ignore", windowsHide: true });
+    } catch {
+      process.kill(pid);
+    }
+    return;
+  }
+  process.kill(pid, "SIGTERM");
+}
+
+function forceKillPid(pid: number): void {
+  if (IS_WINDOWS) {
+    try {
+      execSync(`taskkill /pid ${pid} /f /t`, { stdio: "ignore", windowsHide: true });
+    } catch {
+      process.kill(pid);
+    }
+    return;
+  }
+  process.kill(pid, "SIGKILL");
 }
 
 export function forceFreePort(port: number): PortProcess[] {
   const listeners = listPortListeners(port);
   for (const proc of listeners) {
     try {
-      process.kill(proc.pid, "SIGTERM");
+      terminatePid(proc.pid);
     } catch (err) {
       throw new Error(
         `failed to kill pid ${proc.pid}${proc.command ? ` (${proc.command})` : ""}: ${String(err)}`,
@@ -65,10 +123,14 @@ export function forceFreePort(port: number): PortProcess[] {
   return listeners;
 }
 
-function killPids(listeners: PortProcess[], signal: NodeJS.Signals) {
+function killPids(listeners: PortProcess[], signal: "SIGTERM" | "SIGKILL") {
   for (const proc of listeners) {
     try {
-      process.kill(proc.pid, signal);
+      if (signal === "SIGKILL") {
+        forceKillPid(proc.pid);
+      } else {
+        terminatePid(proc.pid);
+      }
     } catch (err) {
       throw new Error(
         `failed to kill pid ${proc.pid}${proc.command ? ` (${proc.command})` : ""}: ${String(err)}`,
@@ -83,9 +145,9 @@ export async function forceFreePortAndWait(
   opts: {
     /** Total wait budget across signals. */
     timeoutMs?: number;
-    /** Poll interval for checking whether lsof reports listeners. */
+    /** Poll interval for checking whether listeners remain. */
     intervalMs?: number;
-    /** How long to wait after SIGTERM before escalating to SIGKILL. */
+    /** How long to wait after SIGTERM before escalating to SIGKILL (Unix only). */
     sigtermTimeoutMs?: number;
   } = {},
 ): Promise<ForceFreePortResult> {
@@ -96,6 +158,24 @@ export async function forceFreePortAndWait(
   const killed = forceFreePort(port);
   if (killed.length === 0) {
     return { killed, waitedMs: 0, escalatedToSigkill: false };
+  }
+
+  if (IS_WINDOWS) {
+    let waitedMs = 0;
+    const tries = intervalMs > 0 ? Math.ceil(timeoutMs / intervalMs) : 0;
+    for (let i = 0; i < tries; i++) {
+      if (listPortListeners(port).length === 0) {
+        return { killed, waitedMs, escalatedToSigkill: false };
+      }
+      await sleep(intervalMs);
+      waitedMs += intervalMs;
+    }
+    if (listPortListeners(port).length === 0) {
+      return { killed, waitedMs, escalatedToSigkill: false };
+    }
+    throw new Error(
+      `port ${port} still has listeners after --force: ${listPortListeners(port).map((p) => p.pid).join(", ")}`,
+    );
   }
 
   let waitedMs = 0;

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -165,6 +165,7 @@ async function delegateToGlobalOpenClaw(argv: string[]): Promise<number> {
         DENCHCLAW_DELEGATED: "1",
         OPENCLAW_DELEGATED: "1",
       },
+      ...(process.platform === "win32" ? { shell: true, windowsHide: true } : {}),
     });
 
     child.once("error", (error) => {

--- a/src/cli/web-runtime-command.ts
+++ b/src/cli/web-runtime-command.ts
@@ -133,7 +133,10 @@ async function openUrl(url: string): Promise<boolean> {
   const [cmd, ...args] = argv;
   if (!cmd) return false;
   return new Promise<boolean>((resolve) => {
-    const child = spawn(cmd, args, { stdio: "ignore" });
+    const child = spawn(cmd, args, {
+      stdio: "ignore",
+      ...(process.platform === "win32" ? { shell: true, windowsHide: true } : {}),
+    });
     const timer = setTimeout(() => {
       child.kill();
       resolve(false);
@@ -175,6 +178,7 @@ async function runOpenClawUpdateWithProgress(openclawCommand: string): Promise<v
     const child = spawn(openclawCommand, ["update", "--yes"], {
       stdio: ["ignore", "pipe", "pipe"],
       env: process.env,
+      ...(process.platform === "win32" ? { shell: true, windowsHide: true } : {}),
     });
     let stdout = "";
     let stderr = "";

--- a/src/cli/web-runtime.ts
+++ b/src/cli/web-runtime.ts
@@ -1,4 +1,4 @@
-import { spawn, execFileSync } from "node:child_process";
+import { spawn, execFileSync, execSync } from "node:child_process";
 import {
   cpSync,
   existsSync,
@@ -164,23 +164,10 @@ function writeJsonFile(filePath: string, value: unknown): void {
   writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
 }
 
-function resolveCommandForPlatform(command: string): string {
-  if (process.platform !== "win32") {
-    return command;
-  }
-  if (path.extname(command)) {
-    return command;
-  }
-  const normalized = path.basename(command).toLowerCase();
-  if (
-    normalized === "npm" ||
-    normalized === "pnpm" ||
-    normalized === "npx" ||
-    normalized === "yarn"
-  ) {
-    return `${command}.cmd`;
-  }
-  return command;
+const IS_WINDOWS = process.platform === "win32";
+
+function platformSpawnOptions(): { shell: boolean; windowsHide: boolean } {
+  return { shell: IS_WINDOWS, windowsHide: IS_WINDOWS };
 }
 
 function isProcessAlive(pid: number): boolean {
@@ -194,6 +181,29 @@ function isProcessAlive(pid: number): boolean {
 }
 
 async function terminatePidWithEscalation(pid: number): Promise<void> {
+  if (IS_WINDOWS) {
+    try {
+      execSync(`taskkill /pid ${pid} /f /t`, { stdio: "ignore", windowsHide: true });
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code === "ESRCH") {
+        return;
+      }
+      try {
+        process.kill(pid);
+      } catch {
+        // already gone
+      }
+    }
+    for (let i = 0; i < 8; i += 1) {
+      if (!isProcessAlive(pid)) {
+        return;
+      }
+      await sleep(100);
+    }
+    return;
+  }
+
   try {
     process.kill(pid, "SIGTERM");
   } catch (error) {
@@ -458,6 +468,9 @@ export function evaluateMajorVersionTransition(params: {
 }
 
 function resolveProcessCwd(pid: number): string | undefined {
+  if (IS_WINDOWS) {
+    return undefined;
+  }
   try {
     const lsof = resolveLsofCommandSync();
     const output = execFileSync(lsof, ["-nP", "-a", "-p", String(pid), "-d", "cwd", "-Fn"], {
@@ -900,6 +913,7 @@ export function startManagedWebRuntime(params: {
   const child = spawn(process.execPath, [runtimeServerPath], {
     cwd: path.dirname(runtimeServerPath),
     detached: true,
+    windowsHide: true,
     stdio: ["ignore", outFd, errFd],
     env: {
       ...process.env,
@@ -1046,9 +1060,10 @@ export async function runOpenClawCommand(params: {
   env?: NodeJS.ProcessEnv;
 }): Promise<{ code: number; stdout: string; stderr: string }> {
   return await new Promise((resolve, reject) => {
-    const child = spawn(resolveCommandForPlatform(params.openclawCommand), params.args, {
+    const child = spawn(params.openclawCommand, params.args, {
       stdio: ["ignore", "pipe", "pipe"],
       env: params.env ? { ...process.env, ...params.env } : process.env,
+      ...platformSpawnOptions(),
     });
     let stdout = "";
     let stderr = "";

--- a/src/infra/ports-lsof.ts
+++ b/src/infra/ports-lsof.ts
@@ -16,6 +16,9 @@ async function canExecute(path: string): Promise<boolean> {
 }
 
 export async function resolveLsofCommand(): Promise<string> {
+  if (process.platform === "win32") {
+    throw new Error("lsof is not available on Windows; use netstat-based port listing instead");
+  }
   for (const candidate of LSOF_CANDIDATES) {
     if (await canExecute(candidate)) {
       return candidate;
@@ -25,6 +28,9 @@ export async function resolveLsofCommand(): Promise<string> {
 }
 
 export function resolveLsofCommandSync(): string {
+  if (process.platform === "win32") {
+    throw new Error("lsof is not available on Windows; use netstat-based port listing instead");
+  }
   for (const candidate of LSOF_CANDIDATES) {
     try {
       fs.accessSync(candidate, fs.constants.X_OK);


### PR DESCRIPTION
## Summary

- Replace the `resolveCommandForPlatform` pattern (which only appended `.cmd` for npm/pnpm/npx/yarn) with `shell: true` on Windows for all `spawn` calls, so any `.cmd`/`.bat` wrapper (including `openclaw`) resolves correctly via `PATHEXT`
- Add Windows port listener discovery via `netstat -ano` as a fallback for Unix-only `lsof`, and guard all `lsof` call sites to skip or throw on Windows
- Replace the `SIGTERM` then `SIGKILL` escalation pattern with `taskkill /f /t` on Windows, since `process.kill(pid, "SIGTERM")` is not supported there
- Add `windowsHide: true` to detached spawns to prevent console window flashes on Windows
- Replace hardcoded `/tmp/openclaw` with `path.join(os.tmpdir(), "openclaw")` for cross-platform temp directory resolution
- Show PowerShell `$env:Path` instructions on Windows instead of Unix `export PATH=...` syntax

## Files changed

| File | Changes |
|------|---------|
| `src/cli/bootstrap-external.ts` | `platformSpawnOptions()` helper, `os.tmpdir()` fix, Windows PATH instructions |
| `src/cli/run-main.ts` | `shell: true` + `windowsHide: true` for `spawn("openclaw", ...)` |
| `src/cli/web-runtime-command.ts` | Windows spawn options for URL opener and openclaw update spawns |
| `src/cli/web-runtime.ts` | `platformSpawnOptions()`, `windowsHide` on detached spawn, Windows `taskkill` in `terminatePidWithEscalation`, `resolveProcessCwd` guard |
| `src/cli/ports.ts` | `netstat -ano` fallback, `taskkill`-based kill, platform-branched `forceFreePortAndWait` |
| `src/infra/ports-lsof.ts` | Early throw on Windows to prevent accidental `lsof` usage |

## Test plan

- [x] All 216 CLI tests pass (`npx vitest run src/cli/ src/infra/ports-lsof.ts`)
- [ ] Smoke test on macOS: `npx denchclaw bootstrap` starts correctly
- [ ] Smoke test on Windows: `npx denchclaw bootstrap` starts correctly, no ENOENT on `openclaw`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple CLI runtime/process-management paths (spawning, killing processes, and port listener detection) where platform-specific edge cases can break bootstrap/start/stop flows, especially on Windows.
> 
> **Overview**
> Improves Windows cross-platform behavior across the CLI by standardizing `spawn` options (`shell: true`, `windowsHide: true`) and removing the bespoke `.cmd` command resolution logic.
> 
> Adds Windows implementations for port listener discovery (`netstat -ano`) and process termination (`taskkill`), and guards Unix-only `lsof` call sites to throw/skip on Windows. Also replaces hardcoded `/tmp/openclaw` with `os.tmpdir()` and updates PATH remediation messaging to show PowerShell instructions on Windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bd648344e51056d0c40c905cc595c6a29e43129. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->