### PR TITLE
fix(web): differentiate dark mode sidebar and chat panel backgrounds

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -100,10 +100,10 @@
 
 .dark {
   /* Background / Surface — warm neutral, layered for depth */
-  --color-bg: #242424;
+  --color-bg: #222222;
   --color-surface: #2e2e2e;
-  --color-sidebar-bg: #242424;
-  --color-main-bg: #242424;
+  --color-sidebar-bg: #1c1c1c;
+  --color-main-bg: #282828;
   --color-surface-hover: #383838;
   --color-surface-raised: #333333;
 


### PR DESCRIPTION
## Summary
- In dark mode, `--color-sidebar-bg`, `--color-bg`, and `--color-main-bg` were all `#242424`, making sidebars and the main chat panel visually indistinguishable.
- Mirrors the light mode layering: sidebars darker (`#1c1c1c`), general bg slightly darker (`#222222`), main chat lighter (`#282828`).

## Test plan
- [x] Toggle to dark mode and verify sidebars are visually distinct from the main chat panel
- [x] Verify light mode is unaffected

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CSS token tweak limited to dark-mode background variables; risk is limited to unintended visual regressions in components that rely on these theme tokens.
> 
> **Overview**
> Improves dark-mode visual layering by adjusting theme background CSS variables in `apps/web/app/globals.css` so the sidebar, general background, and main content panel use distinct shades instead of the same color.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49b3c3c115f964526cbdf3be9762bbdd75729510. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->