### PR TITLE
fix(cli): skip channel selection during OpenClaw onboarding

### DIFF
--- a/src/cli/bootstrap-external.ts
+++ b/src/cli/bootstrap-external.ts
@@ -3216,7 +3216,7 @@ export async function bootstrapCommand(
     onboardArgv.push("--skip-skills");
   }
 
-  onboardArgv.push("--accept-risk", "--skip-ui");
+  onboardArgv.push("--accept-risk", "--skip-ui", "--skip-channels");
   if (daemonless) {
     onboardArgv.push("--skip-health");
   }


### PR DESCRIPTION
## Summary
- Adds `--skip-channels` to the `openclaw onboard` invocation
- DenchClaw manages channel config independently, so the interactive channel wizard is unnecessary
- Sidesteps the upstream OpenClaw 2026.4.14 regression (openclaw/openclaw#66718) where channel metadata is undefined, causing a `.trim()` crash

## What's excluded
- npm install fallback and error handling improvements (separate PR)

## Verification
```
pnpm build  # passes
```

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CLI-flag addition affecting only the onboarding command flow; minimal surface area and no security/data-path changes.
> 
> **Overview**
> DenchClaw bootstrap now passes `--skip-channels` when invoking `openclaw onboard`, skipping the channel selection wizard alongside the existing `--accept-risk` and `--skip-ui` flags.
> 
> This reduces interactive friction and avoids failures caused by upstream channel-metadata issues during onboarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc255c2d723036153f24a383c8060b148e20f553. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->