### PR TITLE
fix(web): table "No results found" with entries + hyphenated object pivot views

### DIFF
--- a/apps/web/app/api/workspace/objects/[name]/fields/[fieldId]/route.ts
+++ b/apps/web/app/api/workspace/objects/[name]/fields/[fieldId]/route.ts
@@ -3,6 +3,7 @@ import {
 	duckdbQueryOnFile,
 	findDuckDBForObject,
 	findObjectDir,
+	pivotViewIdentifier,
 	readObjectYaml,
 	writeObjectYaml,
 } from "@/lib/workspace";
@@ -27,7 +28,7 @@ export async function PATCH(
 ) {
 	const { name, fieldId } = await params;
 
-	if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)) {
+	if (!/^[a-zA-Z_][a-zA-Z0-9_-]*$/.test(name)) {
 		return Response.json(
 			{ error: "Invalid object name" },
 			{ status: 400 },
@@ -119,7 +120,7 @@ export async function DELETE(
 ) {
 	const { name, fieldId } = await params;
 
-	if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)) {
+	if (!/^[a-zA-Z_][a-zA-Z0-9_-]*$/.test(name)) {
 		return Response.json(
 			{ error: "Invalid object name" },
 			{ status: 400 },
@@ -183,8 +184,10 @@ function regeneratePivotView(dbFile: string, objectName: string, objectId: strin
 		`SELECT name FROM fields WHERE object_id = '${sqlEscape(objectId)}' AND type != 'action' ORDER BY sort_order`,
 	);
 
+	const viewIdent = pivotViewIdentifier(objectName);
+
 	if (fields.length === 0) {
-		duckdbExecOnFile(dbFile, `DROP VIEW IF EXISTS v_${objectName}`);
+		duckdbExecOnFile(dbFile, `DROP VIEW IF EXISTS ${viewIdent}`);
 		return;
 	}
 
@@ -192,7 +195,7 @@ function regeneratePivotView(dbFile: string, objectName: string, objectId: strin
 
 	duckdbExecOnFile(
 		dbFile,
-		`CREATE OR REPLACE VIEW v_${objectName} AS
+		`CREATE OR REPLACE VIEW ${viewIdent} AS
 		 PIVOT (
 		   SELECT e.id as entry_id, e.created_at, e.updated_at,
 		          f.name as field_name, ef.value

--- a/apps/web/app/api/workspace/objects/[name]/fields/route.ts
+++ b/apps/web/app/api/workspace/objects/[name]/fields/route.ts
@@ -3,6 +3,7 @@ import {
 	duckdbQueryOnFile,
 	findDuckDBForObject,
 	findObjectDir,
+	pivotViewIdentifier,
 	readObjectYaml,
 	writeObjectYaml,
 } from "@/lib/workspace";
@@ -30,7 +31,7 @@ export async function POST(
 ) {
 	const { name } = await params;
 
-	if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)) {
+	if (!/^[a-zA-Z_][a-zA-Z0-9_-]*$/.test(name)) {
 		return Response.json({ error: "Invalid object name" }, { status: 400 });
 	}
 
@@ -130,10 +131,11 @@ function regeneratePivotView(dbFile: string, objectName: string, objectId: strin
 	if (fields.length === 0) return;
 
 	const fieldList = fields.map((f) => `'${sqlEscape(f.name)}'`).join(", ");
+	const viewIdent = pivotViewIdentifier(objectName);
 
 	duckdbExecOnFile(
 		dbFile,
-		`CREATE OR REPLACE VIEW v_${objectName} AS
+		`CREATE OR REPLACE VIEW ${viewIdent} AS
 		 PIVOT (
 		   SELECT e.id as entry_id, e.created_at, e.updated_at,
 		          f.name as field_name, ef.value

--- a/apps/web/app/api/workspace/objects/[name]/route.ts
+++ b/apps/web/app/api/workspace/objects/[name]/route.ts
@@ -3,6 +3,8 @@ import {
   parseRelationValue,
   resolveDuckdbBin,
   duckdbQueryOnFileAsync,
+  duckdbQueryOnFileAsyncStrict,
+  pivotViewIdentifier,
   discoverDuckDBPathsAsync,
   getObjectViews,
   duckdbExecOnFileAsync,
@@ -463,23 +465,43 @@ export async function GET(
     }
   }
 
-  // Try the PIVOT view first, then fall back to raw EAV query + client-side pivot
+  // Try the PIVOT view first, then fall back to raw EAV query + client-side pivot.
+  // IMPORTANT: use the *Strict* query variant here so DuckDB errors (e.g. missing
+  // view, bad identifier from hyphenated object names, concurrency hiccups) reject
+  // and actually trigger the fallback — the non-strict variant silently returns []
+  // and would leave the UI stuck on "No results found" while `objects.entry_count`
+  // still says otherwise.
+  const viewIdent = pivotViewIdentifier(name);
   let entries: Record<string, unknown>[] = [];
   let totalCount = 0;
+  let usedFallback = false;
 
   try {
-    // Get total count with same WHERE clause but no LIMIT/OFFSET
-    const countResult = await q<{ cnt: number }>(dbFile,
-      `SELECT COUNT(*) as cnt FROM v_${name}${whereClause}`,
+    const countResult = await duckdbQueryOnFileAsyncStrict<{ cnt: number }>(dbFile,
+      `SELECT COUNT(*) as cnt FROM ${viewIdent}${whereClause}`,
     );
-    totalCount = countResult[0]?.cnt ?? 0;
+    totalCount = Number(countResult[0]?.cnt ?? 0);
 
-    const pivotEntries = await q(dbFile,
-      `SELECT * FROM v_${name}${whereClause}${orderByClause}${limitClause}`,
+    let pivotEntries = await duckdbQueryOnFileAsyncStrict<Record<string, unknown>>(dbFile,
+      `SELECT * FROM ${viewIdent}${whereClause}${orderByClause}${limitClause}`,
     );
+
+    // Parallel DuckDB CLI processes against the same file can intermittently
+    // return empty JSON arrays even when data exists. Retry once on the
+    // obvious mismatch case (count says rows exist, first page is empty).
+    if (pivotEntries.length === 0 && totalCount > 0) {
+      await new Promise((r) => setTimeout(r, 120));
+      pivotEntries = await duckdbQueryOnFileAsyncStrict<Record<string, unknown>>(dbFile,
+        `SELECT * FROM ${viewIdent}${whereClause}${orderByClause}${limitClause}`,
+      );
+    }
+
     entries = pivotEntries;
   } catch {
-    // Pivot view might not exist or filter SQL may not apply; fall back
+    // Pivot view might not exist, may have been created with a stale schema,
+    // or may fail because of a view-identifier mismatch (e.g. object renamed).
+    // Fall back to reading the raw EAV tables and pivoting in JS.
+    usedFallback = true;
     const rawRows = await q<EavRow>(dbFile,
       `SELECT e.id as entry_id, e.created_at, e.updated_at,
               f.name as field_name, ef.value
@@ -491,6 +513,16 @@ export async function GET(
        LIMIT 5000`,
     );
     entries = pivotEavRows(rawRows);
+  }
+
+  if (usedFallback) {
+    // When falling back to raw EAV, derive totalCount from a COUNT(DISTINCT)
+    // over entries (which does not depend on the pivot view existing), so the
+    // UI footer / pagination match the rows the user actually sees.
+    const countRows = await q<{ cnt: number }>(dbFile,
+      `SELECT COUNT(*) as cnt FROM entries WHERE object_id = '${obj.id}'`,
+    );
+    totalCount = Number(countRows[0]?.cnt ?? entries.length);
   }
 
   const parsedFields = fields.map((f) => ({

--- a/apps/web/app/api/workspace/search-index/route.ts
+++ b/apps/web/app/api/workspace/search-index/route.ts
@@ -7,6 +7,7 @@ import {
   discoverDuckDBPaths,
   duckdbQueryOnFileAsync,
   isDatabaseFile,
+  pivotViewIdentifier,
 } from "@/lib/workspace";
 
 export const dynamic = "force-dynamic";
@@ -203,9 +204,12 @@ async function buildEntryItems(): Promise<SearchIndexItem[]> {
       .filter((f) => !["relation", "richtext"].includes(f.type))
       .slice(0, 4);
 
-    // Try PIVOT view first, then raw EAV (on the same DB)
+    // Try PIVOT view first, then raw EAV (on the same DB).
+    // Use pivotViewIdentifier so object names with hyphens (e.g. "ai-agent")
+    // resolve to the correct quoted identifier ("v_ai_agent") instead of
+    // producing invalid SQL.
     let entries: Record<string, unknown>[] = await duckdbQueryOnFileAsync(dbPath,
-      `SELECT * FROM v_${obj.name} ORDER BY created_at DESC LIMIT 500`,
+      `SELECT * FROM ${pivotViewIdentifier(obj.name)} ORDER BY created_at DESC LIMIT 500`,
     );
 
     if (entries.length === 0) {

--- a/apps/web/app/api/workspace/suggest-files/route.ts
+++ b/apps/web/app/api/workspace/suggest-files/route.ts
@@ -7,6 +7,7 @@ import {
 	discoverDuckDBPaths,
 	duckdbQueryOnFileAsync,
 	parseSimpleYaml,
+	pivotViewIdentifier,
 } from "@/lib/workspace";
 
 export const dynamic = "force-dynamic";
@@ -349,14 +350,17 @@ async function searchEntries(
 
 		if (objectMap.size === 0) {continue;}
 
-		// Step 2: build a single UNION ALL query searching all pivot views
-		// Wrap each SELECT in parens so per-view LIMIT is valid DuckDB syntax
+		// Step 2: build a single UNION ALL query searching all pivot views.
+		// Wrap each SELECT in parens so per-view LIMIT is valid DuckDB syntax.
+		// Use pivotViewIdentifier so hyphenated object names (e.g. "ai-agent")
+		// resolve to a valid quoted identifier instead of being parsed as
+		// `v_ai - agent`.
 		const unionParts: string[] = [];
 		for (const [name, { displayField }] of objectMap) {
 			const safeDisplay = sqlEscape(displayField);
 			unionParts.push(
 				`(SELECT '${sqlEscape(name)}' as _obj_name, entry_id, "${safeDisplay}" as _display
-				  FROM v_${name}
+				  FROM ${pivotViewIdentifier(name)}
 				  WHERE LOWER(CAST("${safeDisplay}" AS VARCHAR)) LIKE LOWER('${likePattern}')
 				  LIMIT ${max})`,
 			);

--- a/apps/web/lib/workspace.ts
+++ b/apps/web/lib/workspace.ts
@@ -1153,6 +1153,49 @@ export async function duckdbQueryOnFileAsync<T = Record<string, unknown>>(
   }
 }
 
+/**
+ * Like `duckdbQueryOnFileAsync`, but rethrows errors instead of silently
+ * returning `[]`. Use when callers need to distinguish "no rows" from "query
+ * failed" (e.g. to trigger an EAV fallback when a pivot view is missing or
+ * has a bad identifier).
+ */
+export async function duckdbQueryOnFileAsyncStrict<T = Record<string, unknown>>(
+  dbFilePath: string,
+  sql: string,
+): Promise<T[]> {
+  const bin = resolveDuckdbBin();
+  if (!bin) {
+    throw new Error("DuckDB CLI binary not found");
+  }
+
+  const escapedSql = sql.replace(/'/g, "'\\''");
+  const { stdout } = await execAsync(`'${bin}' -json '${dbFilePath}' '${escapedSql}'`, {
+    encoding: "utf-8",
+    timeout: 15_000,
+    maxBuffer: 10 * 1024 * 1024,
+    shell: "/bin/sh",
+  });
+
+  const trimmed = stdout.trim();
+  if (!trimmed || trimmed === "[]") {return [];}
+  return JSON.parse(trimmed) as T[];
+}
+
+/**
+ * Build a safe, quoted DuckDB identifier for an object's auto-generated PIVOT
+ * view. DuckDB object names may contain hyphens (e.g. `ai-agent`), which are
+ * parsed as the minus operator in unquoted identifiers. We normalize hyphens
+ * to underscores AND wrap the identifier in double quotes so it is always a
+ * single valid identifier regardless of what other characters appear.
+ *
+ * Example: `ai-agent` → `"v_ai_agent"`.
+ */
+export function pivotViewIdentifier(objectName: string): string {
+  const normalized = objectName.replace(/-/g, "_");
+  const escaped = normalized.replace(/"/g, '""');
+  return `"v_${escaped}"`;
+}
+
 export type ResolvedFilesystemPath = {
   absolutePath: string;
   kind: WorkspacePathKind;


### PR DESCRIPTION
## Summary

Fixes two related bugs in the workspace object table UI:

### Bug 1 — Table shows "No results found" despite entries existing

The object GET handler at `apps/web/app/api/workspace/objects/[name]/route.ts` relied on `duckdbQueryOnFileAsync` throwing to trigger its EAV fallback, but that helper silently swallows every error and returns `[]`. The catch block was dead code. When the pivot query intermittently failed (concurrency, bad identifier, missing view) the API returned `entries: []` with `totalCount` still pulled from a prior COUNT, producing the UI state where the header says "150 entries" but the table renders "No results found".

- New `duckdbQueryOnFileAsyncStrict` helper in `apps/web/lib/workspace.ts` that rethrows errors.
- Object GET handler now uses the strict variant so the EAV fallback actually fires on failure.
- Retry once after a short delay when `totalCount > 0` but the first page returns empty (fixes the intermittent parallel-CLI empty-array race).
- When the EAV fallback is used, recompute `totalCount` from the `entries` table so the footer/pagination match what the user sees.

### Bug 2 — Hyphenated folder names (e.g. `ai-agent`) don't resolve

View names were constructed as `v_${objectName}` with no normalization, so `SELECT * FROM v_ai-agent` was parsed as `v_ai MINUS agent` (invalid).

- New `pivotViewIdentifier(name)` helper that normalizes hyphens to underscores and double-quotes the identifier (`ai-agent` → `"v_ai_agent"`).
- Applied at every `v_${...}` construction site:
  - `apps/web/app/api/workspace/objects/[name]/route.ts` (COUNT + SELECT)
  - `apps/web/app/api/workspace/objects/[name]/fields/route.ts` (CREATE OR REPLACE VIEW)
  - `apps/web/app/api/workspace/objects/[name]/fields/[fieldId]/route.ts` (DROP VIEW + CREATE OR REPLACE VIEW)
  - `apps/web/app/api/workspace/search-index/route.ts`
  - `apps/web/app/api/workspace/suggest-files/route.ts`
- Relaxed the object-name regex on the field routes from `[a-zA-Z_][a-zA-Z0-9_]*` to `[a-zA-Z_][a-zA-Z0-9_-]*` so hyphenated objects can actually add/edit/delete fields (matches the main object route's regex). Without this, pivot views on hyphenated objects would never be regenerated.

## Test plan

- [ ] Open a workspace table (e.g. one that was previously showing the empty state) — entries should render.
- [ ] Open a workspace with an object named with a hyphen (e.g. `ai-agent`) — the pivot view should resolve to `"v_ai_agent"` and entries should render.
- [ ] Add/rename/delete a field on a hyphenated object — pivot view should be regenerated, no 400 errors.
- [ ] Mutate a row in a table where the pivot view fails transiently — fallback path should return the correct rows and `totalCount`.
- [ ] Sanity-check existing non-hyphenated objects (e.g. `people`, `company`) still render identically.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core workspace data-fetch and pivot-view generation/querying logic; errors could impact entry listing, pagination counts, and search/suggestions across objects, especially under concurrent DuckDB CLI access.
> 
> **Overview**
> Fixes workspace object table reads by making the PIVOT-view path *actually* fall back to EAV when DuckDB errors occur: adds `duckdbQueryOnFileAsyncStrict`, uses it for pivot `COUNT`/`SELECT`, retries once on the “count>0 but first page empty” case, and recomputes `totalCount` from `entries` when fallback is used.
> 
> Makes PIVOT views robust for hyphenated object names by introducing `pivotViewIdentifier()` (normalized + quoted view identifiers) and using it everywhere pivot views are created/queried/dropped (object GET, field add/rename/delete, search-index, and suggest-files). Also relaxes field-route object-name validation to allow hyphens so pivot views regenerate for those objects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a0037df60cbe97becbc75b6342212e5c18ae761. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->