### PR TITLE
feat(web): declutter workspace toolbar via gear-popover view settings

### DIFF
--- a/apps/web/app/components/workspace/data-table.tsx
+++ b/apps/web/app/components/workspace/data-table.tsx
@@ -105,6 +105,15 @@ export type DataTableProps<TData, TValue> = {
 	};
 	// server-side search callback (replaces client-side fuzzy filter)
 	onServerSearch?: (query: string) => void;
+	// When true, the built-in toolbar (search, columns, refresh, +Add) is not rendered.
+	// The parent is expected to provide equivalent controls externally.
+	hideToolbar?: boolean;
+	// Controlled global filter. When provided, overrides the internal state.
+	globalFilter?: string;
+	onGlobalFilterChange?: (value: string) => void;
+	// Controlled sticky-first-column. When provided, overrides the internal state.
+	stickyFirstColumnValue?: boolean;
+	onStickyFirstColumnChange?: (value: boolean) => void;
 };
 
 /* ─── Fuzzy filter ─── */
@@ -210,9 +219,26 @@ export function DataTable<TData, TValue>({
 	getRowId,
 	serverPagination,
 	onServerSearch,
+	hideToolbar = false,
+	globalFilter: globalFilterProp,
+	onGlobalFilterChange,
+	stickyFirstColumnValue,
+	onStickyFirstColumnChange,
 }: DataTableProps<TData, TValue>) {
 	const [sorting, setSorting] = useState<SortingState>([]);
-	const [globalFilter, setGlobalFilter] = useState("");
+	const [internalGlobalFilter, setInternalGlobalFilter] = useState("");
+	const globalFilter = globalFilterProp !== undefined ? globalFilterProp : internalGlobalFilter;
+	const setGlobalFilter = useCallback(
+		(v: string | ((prev: string) => string)) => {
+			const resolved = typeof v === "function" ? v(globalFilter) : v;
+			if (onGlobalFilterChange) {
+				onGlobalFilterChange(resolved);
+			} else {
+				setInternalGlobalFilter(resolved);
+			}
+		},
+		[globalFilter, onGlobalFilterChange],
+	);
 	const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
 	const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(initialColumnVisibility ?? {});
 	const [columnSizing, setColumnSizing] = useState<ColumnSizingState>(initialColumnSizing ?? {});
@@ -224,7 +250,20 @@ export function DataTable<TData, TValue>({
 		setColumnSizing(initialColumnSizing ?? {});
 	}, [initialColumnSizing]);
 	const [internalRowSelection, setInternalRowSelection] = useState<Record<string, boolean>>({});
-	const [stickyFirstColumn, setStickyFirstColumn] = useState(stickyFirstProp);
+	const [internalStickyFirstColumn, setInternalStickyFirstColumn] = useState(stickyFirstProp);
+	const stickyFirstColumn =
+		stickyFirstColumnValue !== undefined ? stickyFirstColumnValue : internalStickyFirstColumn;
+	const setStickyFirstColumn = useCallback(
+		(next: boolean | ((prev: boolean) => boolean)) => {
+			const resolved = typeof next === "function" ? next(stickyFirstColumn) : next;
+			if (onStickyFirstColumnChange) {
+				onStickyFirstColumnChange(resolved);
+			} else {
+				setInternalStickyFirstColumn(resolved);
+			}
+		},
+		[stickyFirstColumn, onStickyFirstColumnChange],
+	);
 	const [isScrolled, setIsScrolled] = useState(false);
 	const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: defaultPageSize });
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -238,12 +277,13 @@ export function DataTable<TData, TValue>({
 		return "";
 	}, []);
 
-	// Column order for DnD — include "select" at start and "actions" at end
+	// Column order for DnD — include "__rownum"/"select" at start and "actions" at end
 	// so TanStack doesn't push them to the end of the table
 	const buildColumnOrder = useCallback(
 		(dataCols: ColumnDef<TData, TValue>[]) => {
 			const dataOrder = dataCols.map(getColumnId);
 			const order: string[] = [];
+			order.push("__rownum");
 			if (enableRowSelection) {order.push("select");}
 			order.push(...dataOrder);
 			if (rowActions) {order.push("actions");}
@@ -256,7 +296,7 @@ export function DataTable<TData, TValue>({
 		buildColumnOrder(columns),
 	);
 
-	const FIXED_COL_IDS = new Set(["select", "actions", "__add_column"]);
+	const FIXED_COL_IDS = new Set(["__rownum", "select", "actions", "__add_column"]);
 
 	// Reconcile column order when columns change (preserves user DnD ordering)
 	useEffect(() => {
@@ -270,6 +310,7 @@ export function DataTable<TData, TValue>({
 				if (!existingDataSet.has(id)) prevDataOrder.push(id);
 			}
 			const result: string[] = [];
+			if (freshSet.has("__rownum")) result.push("__rownum");
 			if (freshSet.has("select")) result.push("select");
 			result.push(...prevDataOrder);
 			if (freshSet.has("actions")) result.push("actions");
@@ -304,6 +345,37 @@ export function DataTable<TData, TValue>({
 	const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
 		setIsScrolled(e.currentTarget.scrollLeft > 0);
 	}, []);
+
+	// Build row number column — always first, non-sortable, non-hideable
+	const rownumColumn: ColumnDef<TData> = {
+		id: "__rownum",
+		header: () => (
+			<span
+				className="text-[10px] tabular-nums opacity-50"
+				style={{ color: "var(--color-text-muted)" }}
+			>
+				#
+			</span>
+		),
+		cell: ({ row }) => {
+			const baseIdx = serverPagination
+				? (serverPagination.page - 1) * serverPagination.pageSize
+				: 0;
+			return (
+				<span
+					className="text-[11px] tabular-nums"
+					style={{ color: "var(--color-text-muted)", opacity: 0.55 }}
+				>
+					{baseIdx + row.index + 1}
+				</span>
+			);
+		},
+		size: 48,
+		minSize: 48,
+		enableSorting: false,
+		enableHiding: false,
+		enableResizing: false,
+	};
 
 	// Build selection column
 	const selectionColumn: ColumnDef<TData> | null = enableRowSelection
@@ -353,11 +425,12 @@ export function DataTable<TData, TValue>({
 
 	const allColumns = useMemo(() => {
 		const cols: ColumnDef<TData, TValue>[] = [];
+		cols.push(rownumColumn as ColumnDef<TData, TValue>);
 		if (selectionColumn) {cols.push(selectionColumn as ColumnDef<TData, TValue>);}
 		cols.push(...columns);
 		if (actionsColumn) {cols.push(actionsColumn as ColumnDef<TData, TValue>);}
 		return cols;
-	}, [columns, selectionColumn, actionsColumn]);
+	}, [columns, selectionColumn, actionsColumn, rownumColumn]);
 
 	// Server-side pagination state derived from props
 	const serverPaginationState = serverPagination
@@ -428,7 +501,7 @@ export function DataTable<TData, TValue>({
 	});
 
 	const selectedCount = Object.keys(rowSelectionState).filter((k) => rowSelectionState[k]).length;
-	const visibleColumns = table.getVisibleFlatColumns().filter((c) => c.id !== "select" && c.id !== "actions" && c.id !== "__add_column");
+	const visibleColumns = table.getVisibleFlatColumns().filter((c) => c.id !== "__rownum" && c.id !== "select" && c.id !== "actions" && c.id !== "__add_column");
 
 	// Column sizes as CSS variables for performant resize (TanStack recommended approach).
 	// Only th elements reference these vars; td widths are inherited via table-layout:fixed.
@@ -447,6 +520,7 @@ export function DataTable<TData, TValue>({
 	return (
 		<div className="w-full h-full flex flex-col overflow-hidden" style={{ overscrollBehavior: "contain" }}>
 			{/* Toolbar */}
+			{!hideToolbar && (
 			<div
 				className="flex items-center gap-3 px-3 py-2 shrink-0 flex-wrap backdrop-blur-md"
 				style={{ background: "var(--color-glass)", borderBottom: "1px solid var(--color-border)" }}
@@ -530,7 +604,7 @@ export function DataTable<TData, TValue>({
 							<div className="px-2 py-1.5 text-xs opacity-50">No toggleable columns</div>
 						) : (
 							table.getAllLeafColumns()
-								.filter((c) => c.id !== "select" && c.id !== "actions" && c.id !== "__add_column" && c.getCanHide())
+								.filter((c) => c.id !== "__rownum" && c.id !== "select" && c.id !== "actions" && c.id !== "__add_column" && c.getCanHide())
 								.map((column) => (
 									<DropdownMenuCheckboxItem
 										key={column.id}
@@ -573,6 +647,7 @@ export function DataTable<TData, TValue>({
 					</button>
 				)}
 			</div>
+			)}
 
 			{/* Table */}
 			<div
@@ -617,7 +692,10 @@ export function DataTable<TData, TValue>({
 									>
 										<SortableContext items={columnOrder.filter((id) => !FIXED_COL_IDS.has(id))} strategy={horizontalListSortingStrategy}>
 											{headerGroup.headers.map((header, colIdx) => {
-												const isFirstData = colIdx === (enableRowSelection ? 1 : 0);
+												// Layout: [__rownum, select?, ...data, actions?]
+												const firstDataIdx = 1 + (enableRowSelection ? 1 : 0);
+												const isRownumCol = header.id === "__rownum";
+												const isFirstData = colIdx === firstDataIdx;
 												const isSticky = stickyFirstColumn && isFirstData;
 												const isSelectCol = header.id === "select";
 												const isActionsCol = header.id === "actions";
@@ -644,18 +722,20 @@ export function DataTable<TData, TValue>({
 													: flexRender(header.column.columnDef.header, header.getContext());
 
 												const thClassName = cn(
-													"h-11 text-left align-middle font-medium text-xs uppercase tracking-wider whitespace-nowrap p-0 group select-none relative box-border",
+													"h-11 text-left align-middle font-medium text-[12px] whitespace-nowrap p-0 group select-none relative box-border",
+													isRownumCol && "text-right",
 													!isLastCol && "border-r",
 													isSticky && isScrolled && "border-r-2!",
 												);
 
 												const innerClassName = cn(
-													"flex items-center gap-1 h-full px-4 transition-colors",
+													"flex items-center gap-1.5 h-full transition-colors",
+													isRownumCol ? "px-3 justify-end" : "px-4",
 													canSort && "cursor-pointer hover:bg-[var(--color-surface-hover)]",
 													isSorted && "bg-[var(--color-surface-hover)]",
 												);
 
-											const resizeHandle = !isSelectCol && !isAddCol && header.column.getCanResize() ? (
+											const resizeHandle = !isSelectCol && !isAddCol && !isRownumCol && header.column.getCanResize() ? (
 												<div
 													data-resize-handle
 													onMouseDown={header.getResizeHandler()}
@@ -669,7 +749,7 @@ export function DataTable<TData, TValue>({
 												/>
 											) : null;
 
-											if (enableColumnReordering && !isSelectCol && !isActionsCol && !isAddCol) {
+											if (enableColumnReordering && !isSelectCol && !isActionsCol && !isAddCol && !isRownumCol) {
 												return (
 													<SortableHeader
 														key={header.id}
@@ -744,48 +824,46 @@ export function DataTable<TData, TValue>({
 			{/* Pagination footer */}
 			{!loading && data.length > 0 && (
 				<div
-					className="flex items-center justify-between px-3 py-2 text-xs shrink-0 backdrop-blur-xl"
+					className="flex items-center justify-between px-3 py-1 text-[11px] shrink-0 backdrop-blur-xl"
 					style={{
 						borderTop: "1px solid var(--color-border)",
 						color: "var(--color-text-muted)",
 						background: "var(--color-glass)",
 					}}
 				>
-					<span className="text-xs font-medium">
+					<span className="tabular-nums">
 						{serverPagination
-							? `Showing ${(serverPagination.page - 1) * serverPagination.pageSize + 1}–${Math.min(serverPagination.page * serverPagination.pageSize, serverPagination.totalCount)} of ${serverPagination.totalCount} results`
-							: `Showing ${table.getRowModel().rows.length} of ${data.length} results`}
-						{selectedCount > 0 && ` (${selectedCount} selected)`}
+							? `${(serverPagination.page - 1) * serverPagination.pageSize + 1}–${Math.min(serverPagination.page * serverPagination.pageSize, serverPagination.totalCount)} / ${serverPagination.totalCount}`
+							: `${table.getRowModel().rows.length} / ${data.length}`}
+						{selectedCount > 0 && ` · ${selectedCount} selected`}
 					</span>
-					<div className="flex items-center gap-3">
-						<div className="flex items-center gap-2">
-							<span className="text-xs font-medium">Rows per page</span>
-							<select
-								value={serverPagination ? serverPagination.pageSize : pagination.pageSize}
-								onChange={(e) => {
-									const newSize = Number(e.target.value);
-									if (serverPagination) {
-										serverPagination.onPageSizeChange(newSize);
-									} else {
-										setPagination((p) => ({ ...p, pageSize: newSize, pageIndex: 0 }));
-									}
-								}}
-								className="h-7 px-2 py-0 rounded-full text-xs outline-none shadow-[0_0_21px_0_rgba(0,0,0,0.05)] transition-colors"
-								style={{
-									background: "var(--color-surface)",
-									color: "var(--color-text)",
-									border: "1px solid var(--color-border)",
-								}}
-							>
-								{[20, 50, 100, 250, 500].map((size) => (
-									<option key={size} value={size}>{size}</option>
-								))}
-							</select>
-						</div>
-						<span className="text-xs font-medium min-w-[80px] text-center">
-							Page {serverPagination ? serverPagination.page : pagination.pageIndex + 1} of {table.getPageCount()}
+					<div className="flex items-center gap-2">
+						<select
+							value={serverPagination ? serverPagination.pageSize : pagination.pageSize}
+							onChange={(e) => {
+								const newSize = Number(e.target.value);
+								if (serverPagination) {
+									serverPagination.onPageSizeChange(newSize);
+								} else {
+									setPagination((p) => ({ ...p, pageSize: newSize, pageIndex: 0 }));
+								}
+							}}
+							className="h-6 px-1.5 py-0 rounded-md text-[11px] outline-none transition-colors cursor-pointer"
+							style={{
+								background: "var(--color-surface)",
+								color: "var(--color-text)",
+								border: "1px solid var(--color-border)",
+							}}
+							title="Rows per page"
+						>
+							{[20, 50, 100, 250, 500].map((size) => (
+								<option key={size} value={size}>{size}/page</option>
+							))}
+						</select>
+						<span className="tabular-nums min-w-[48px] text-center">
+							{serverPagination ? serverPagination.page : pagination.pageIndex + 1}/{table.getPageCount()}
 						</span>
-						<div className="flex gap-1">
+						<div className="flex gap-0.5">
 							{serverPagination ? (
 								<>
 									<PaginationButton onClick={() => serverPagination.onPageChange(1)} disabled={serverPagination.page <= 1} label="&laquo;" />
@@ -833,25 +911,23 @@ function DataTableBodyInner({
 	onRowClick,
 	getFirstDataColumnFaviconUrl,
 }: DataTableBodyProps) {
+	// Layout: [__rownum, select?, ...data, actions?]
+	const firstDataIdx = 1 + (enableRowSelection ? 1 : 0);
 	return (
 		<tbody className="[&_tr:last-child]:border-0">
 			{table.getRowModel().rows.map((row, rowIdx) => {
 				const isSelected = row.getIsSelected();
 				const visibleCells = row.getVisibleCells();
 				const isActive = activeRowId != null && getRowId != null && getRowId(row.original) === activeRowId;
-				const baseBg = isActive
-					? "var(--color-accent-light)"
-					: isSelected
-						? "var(--color-accent-light)"
-						: rowIdx % 2 === 0
-							? "var(--color-surface)"
-							: "var(--color-bg)";
+				// Subtle zebra: white (surface) for even rows, slightly off-white (bg) for odd rows.
+				const altBg = rowIdx % 2 === 0 ? "var(--color-surface)" : "var(--color-bg)";
+				const baseBg = isActive || isSelected ? "var(--color-accent-light)" : altBg;
 				return (
 					<tr
 						key={row.id}
 						data-state={isSelected ? "selected" : isActive ? "active" : undefined}
 						className={cn(
-							"border-b transition-all duration-150 group/row",
+							"border-b transition-colors duration-100 group/row",
 							onRowClick && "cursor-pointer",
 							isSelected && "data-[state=selected]:bg-(--color-accent-light)",
 						)}
@@ -866,12 +942,12 @@ function DataTableBodyInner({
 						}}
 						onMouseLeave={(e) => {
 							if (!isSelected && !isActive)
-								{(e.currentTarget as HTMLElement).style.background =
-									rowIdx % 2 === 0 ? "var(--color-surface)" : "var(--color-bg)";}
+								{(e.currentTarget as HTMLElement).style.background = altBg;}
 						}}
 					>
 						{visibleCells.map((cell, colIdx) => {
-							const isFirstData = colIdx === (enableRowSelection ? 1 : 0);
+							const isRownumCol = cell.column.id === "__rownum";
+							const isFirstData = colIdx === firstDataIdx;
 							const isSticky = stickyFirstColumn && isFirstData;
 							const isSelectCol = cell.column.id === "select";
 							const isLastCol = colIdx === visibleCells.length - 1;
@@ -879,11 +955,11 @@ function DataTableBodyInner({
 								? getFirstDataColumnFaviconUrl?.(row, table)
 								: undefined;
 
-							const rowBg = baseBg;
-							const altBg = rowIdx % 2 === 0 ? "var(--color-surface)" : "var(--color-bg)";
+							// Sticky cells need an explicit background so content scrolling
+							// underneath them doesn't show through. Match the row's zebra shade.
 							const stickyBg = (isActive || isSelected)
-								? `linear-gradient(var(--color-accent-light), var(--color-accent-light)), linear-gradient(${altBg}, ${altBg})`
-								: rowBg;
+								? "var(--color-accent-light)"
+								: altBg;
 
 							const cellStyle: React.CSSProperties = {
 								borderColor: "var(--color-border)",
@@ -911,7 +987,12 @@ function DataTableBodyInner({
 								<td
 									key={cell.id}
 									className={cn(
-										"px-3 py-1.5 align-middle whitespace-nowrap text-xs border-b transition-colors box-border",
+										"align-middle whitespace-nowrap text-[13px] border-b transition-colors box-border",
+										isRownumCol
+											? "px-3 py-3 text-right"
+											: isSelectCol
+												? "px-3 py-3"
+												: "px-4 py-3",
 										!isLastCol && "border-r",
 										isSticky && isScrolled && "border-r-2!",
 									)}
@@ -919,7 +1000,7 @@ function DataTableBodyInner({
 								>
 									<div className="overflow-hidden">
 										{firstDataColumnFaviconUrl ? (
-											<div className="flex min-w-0 items-center gap-1.5">
+											<div className="flex min-w-0 items-center gap-2">
 												<span className="pointer-events-none shrink-0">
 													<UrlFavicon src={firstDataColumnFaviconUrl} />
 												</span>
@@ -957,7 +1038,7 @@ function PaginationButton({ onClick, disabled, label }: { onClick: () => void; d
 			type="button"
 			onClick={onClick}
 			disabled={disabled}
-			className="h-7 w-7 rounded-full flex items-center justify-center text-xs disabled:opacity-30 cursor-pointer transition-colors backdrop-blur-sm shadow-[0_0_21px_0_rgba(0,0,0,0.05)]"
+			className="h-6 w-6 rounded-md flex items-center justify-center text-[11px] disabled:opacity-30 cursor-pointer transition-colors"
 			style={{ color: "var(--color-text-muted)", border: "1px solid var(--color-border)", background: "var(--color-surface)" }}
 			// biome-ignore lint: using html entity label
 			dangerouslySetInnerHTML={{ __html: label }}

--- a/apps/web/app/components/workspace/object-filter-bar.tsx
+++ b/apps/web/app/components/workspace/object-filter-bar.tsx
@@ -10,7 +10,6 @@ import {
 	defaultOperatorForFieldType,
 	isFilterGroup,
 	filterId,
-	describeRule,
 	emptyFilterGroup,
 } from "@/lib/object-filters";
 
@@ -738,275 +737,340 @@ export function ObjectFilterBar({
 		return groups;
 	}, [fields]);
 
+	const ruleCount = filters.rules.filter((r) => !isFilterGroup(r)).length;
+
 	return (
-		<div className="space-y-2">
-			{/* Toolbar row */}
-			<div
-				className="flex items-center gap-2 flex-wrap"
+		<div className="flex items-center gap-1.5 flex-shrink-0">
+			{/* Filter pill — opens a popover containing the rules editor */}
+			<FilterPopover
+				ruleCount={ruleCount}
+				hasFilters={hasFilters}
+				filters={filters}
+				fields={fields}
+				groupedFields={groupedFields}
+				members={members}
+				addRule={addRule}
+				updateRule={updateRule}
+				removeRule={removeRule}
+				clearAll={clearAll}
+				toggleConjunction={toggleConjunction}
+				fieldPickerOpen={fieldPickerOpen}
+				setFieldPickerOpen={setFieldPickerOpen}
+			/>
+
+			{/* Views pill — saved views dropdown (largely unchanged) */}
+			<Dropdown
+				trigger={
+					<button
+						type="button"
+						className="flex items-center gap-1 h-7 px-2 rounded-md text-xs transition-colors cursor-pointer flex-shrink-0"
+						style={{
+							color: activeViewName ? "var(--color-accent)" : "var(--color-text-muted)",
+							border: `1px solid ${activeViewName ? "var(--color-accent)" : "var(--color-border)"}`,
+							background: activeViewName ? "var(--color-accent-light, rgba(99,102,241,0.1))" : "transparent",
+						}}
+						title={activeViewName ? `Active view: ${activeViewName}` : "Saved views"}
+					>
+						<BookmarkIcon />
+						<span className="hidden md:inline">{activeViewName ?? "Views"}</span>
+						<ChevronDownIcon />
+					</button>
+				}
+				open={viewsOpen}
+				onOpenChange={setViewsOpen}
+				align="right"
 			>
-				{/* Filter icon + label */}
-				<span
-					className="flex items-center gap-1.5 text-xs font-medium"
-					style={{ color: "var(--color-text-muted)" }}
-				>
-					<FilterIcon />
-					Filters
-				</span>
-
-				{/* AND/OR toggle (only when 2+ rules) */}
-				{filters.rules.length >= 2 && (
-					<button
-						type="button"
-						onClick={toggleConjunction}
-						className="px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider transition-colors cursor-pointer"
-						style={{
-							background: "var(--color-accent-light, rgba(99,102,241,0.1))",
-							color: "var(--color-accent)",
-							border: "1px solid var(--color-accent)",
-						}}
-						title={`Matching ${filters.conjunction === "and" ? "ALL" : "ANY"} rules. Click to toggle.`}
-					>
-						{filters.conjunction}
-					</button>
+				{savedViews.length === 0 && (
+					<div className="px-3 py-2 text-xs" style={{ color: "var(--color-text-muted)" }}>
+						No saved views
+					</div>
 				)}
-
-				{/* Active filter chips */}
-				{filters.rules.map((rule) => {
-					if (isFilterGroup(rule)) {return null;}
-					return (
-						<span
-							key={rule.id}
-							className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] max-w-[180px] sm:max-w-[250px] truncate"
-							style={{
-								background: "var(--color-accent-light, rgba(99,102,241,0.1))",
-								color: "var(--color-accent)",
-								border: "1px solid var(--color-accent)",
+				{savedViews.map((view) => (
+					<div key={view.name} className="flex items-center group">
+						<DropdownItem
+							onClick={() => {
+								onLoadView(view);
+								setViewsOpen(false);
 							}}
-							title={describeRule(rule)}
+							active={activeViewName === view.name}
 						>
-							<span className="truncate">{describeRule(rule)}</span>
-							<button
-								type="button"
-								onClick={() => removeRule(rule.id)}
-								className="flex-shrink-0 cursor-pointer p-0.5 rounded-full transition-colors"
-								style={{ color: "var(--color-accent)" }}
-							>
-								<XIcon size={10} />
-							</button>
-						</span>
-					);
-				})}
-
-				{/* Add filter button */}
-				<Dropdown
-					trigger={
-						<button
-							type="button"
-							className="flex items-center gap-1 px-2 py-1 rounded-md text-xs transition-colors cursor-pointer"
-							style={{
-								color: "var(--color-text-muted)",
-								border: "1px dashed var(--color-border)",
-							}}
-						>
-							<PlusIcon /> Add filter
-						</button>
-					}
-					open={fieldPickerOpen}
-					onOpenChange={setFieldPickerOpen}
-				>
-					{Object.entries(groupedFields).map(([type, typeFields]) => (
-						<div key={type}>
-							<div
-								className="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider"
-								style={{ color: "var(--color-text-muted)" }}
-							>
-								{FIELD_TYPE_ICONS[type] ?? "?"} {type}
-							</div>
-							{typeFields.map((f) => (
-								<DropdownItem key={f.name} onClick={() => addRule(f.name)}>
-									{f.name}
-								</DropdownItem>
-							))}
-						</div>
-					))}
-				</Dropdown>
-
-				{/* Clear all */}
-				{hasFilters && (
-					<button
-						type="button"
-						onClick={clearAll}
-						className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] transition-colors cursor-pointer"
-						style={{
-							color: "var(--color-accent)",
-							background: "var(--color-accent-light, rgba(99,102,241,0.1))",
-						}}
-					>
-						<XIcon size={10} />
-						Clear all
-					</button>
-				)}
-
-				{/* Spacer */}
-				<div className="flex-1" />
-
-				{/* Saved views */}
-				<Dropdown
-					trigger={
-						<button
-							type="button"
-							className="flex items-center gap-1 px-2 py-1 rounded-md text-xs transition-colors cursor-pointer"
-							style={{
-								color: activeViewName ? "var(--color-accent)" : "var(--color-text-muted)",
-								border: `1px solid ${activeViewName ? "var(--color-accent)" : "var(--color-border)"}`,
-								background: activeViewName ? "var(--color-accent-light, rgba(99,102,241,0.1))" : "transparent",
-							}}
-						>
-							<BookmarkIcon />
-							{activeViewName ?? "Views"}
-							<ChevronDownIcon />
-						</button>
-					}
-					open={viewsOpen}
-					onOpenChange={setViewsOpen}
-					align="right"
-				>
-					{savedViews.length === 0 && (
-						<div className="px-3 py-2 text-xs" style={{ color: "var(--color-text-muted)" }}>
-							No saved views
-						</div>
-					)}
-					{savedViews.map((view) => (
-						<div key={view.name} className="flex items-center group">
-							<DropdownItem
-								onClick={() => {
-									onLoadView(view);
-									setViewsOpen(false);
-								}}
-								active={activeViewName === view.name}
-							>
-								<span className="flex-1 truncate">{view.name}</span>
-								{view.view_type && view.view_type !== "table" && (
-									<span
-										className="text-[9px] px-1.5 py-0.5 rounded ml-1 capitalize"
-										style={{
-											background: "var(--color-surface-hover)",
-											color: "var(--color-text-muted)",
-										}}
-									>
-										{view.view_type}
-									</span>
-								)}
-								{view.filters && view.filters.rules.length > 0 && (
-									<span
-										className="text-[10px] ml-1"
-										style={{ color: "var(--color-text-muted)" }}
-									>
-										{view.filters.rules.length} filter{view.filters.rules.length !== 1 ? "s" : ""}
-									</span>
-								)}
-							</DropdownItem>
-							<button
-								type="button"
-								onClick={(e) => {
-									e.stopPropagation();
-									onDeleteView(view.name);
-								}}
-								className="px-2 py-1 md:opacity-0 md:group-hover:opacity-100 transition-opacity cursor-pointer"
-								style={{ color: "var(--color-text-muted)" }}
-								title="Delete view"
-							>
-								<TrashIcon />
-							</button>
-						</div>
-					))}
-					<div className="border-t my-1" style={{ borderColor: "var(--color-border)" }} />
-
-					{hasFilters && !saveDialogOpen && (
-						<DropdownItem onClick={() => setSaveDialogOpen(true)}>
-							<BookmarkIcon />
-							Save current filters as view...
+							<span className="flex-1 truncate">{view.name}</span>
+							{view.view_type && view.view_type !== "table" && (
+								<span
+									className="text-[9px] px-1.5 py-0.5 rounded ml-1 capitalize"
+									style={{
+										background: "var(--color-surface-hover)",
+										color: "var(--color-text-muted)",
+									}}
+								>
+									{view.view_type}
+								</span>
+							)}
+							{view.filters && view.filters.rules.length > 0 && (
+								<span
+									className="text-[10px] ml-1"
+									style={{ color: "var(--color-text-muted)" }}
+								>
+									{view.filters.rules.length} filter{view.filters.rules.length !== 1 ? "s" : ""}
+								</span>
+							)}
 						</DropdownItem>
-					)}
+						<button
+							type="button"
+							onClick={(e) => {
+								e.stopPropagation();
+								onDeleteView(view.name);
+							}}
+							className="px-2 py-1 md:opacity-0 md:group-hover:opacity-100 transition-opacity cursor-pointer"
+							style={{ color: "var(--color-text-muted)" }}
+							title="Delete view"
+						>
+							<TrashIcon />
+						</button>
+					</div>
+				))}
+				<div className="border-t my-1" style={{ borderColor: "var(--color-border)" }} />
 
-					{saveDialogOpen && (
-						<div className="px-3 py-2 flex items-center gap-1">
-							<input
-								ref={saveInputRef}
-								type="text"
-								value={saveViewName}
-								onChange={(e) => setSaveViewName(e.target.value)}
+				{hasFilters && !saveDialogOpen && (
+					<DropdownItem onClick={() => setSaveDialogOpen(true)}>
+						<BookmarkIcon />
+						Save current filters as view...
+					</DropdownItem>
+				)}
+
+				{saveDialogOpen && (
+					<div className="px-3 py-2 flex items-center gap-1">
+						<input
+							ref={saveInputRef}
+							type="text"
+							value={saveViewName}
+							onChange={(e) => setSaveViewName(e.target.value)}
 							onKeyDown={(e) => {
 								if (e.key === "Enter") {handleSaveView();}
 								if (e.key === "Escape") {setSaveDialogOpen(false);}
 							}}
-								placeholder="View name..."
-								className="px-2 py-1 rounded-md text-xs outline-none flex-1"
-								style={{
-									background: "var(--color-bg)",
-									border: "1px solid var(--color-border)",
-									color: "var(--color-text)",
-								}}
-							/>
+							placeholder="View name..."
+							className="px-2 py-1 rounded-md text-xs outline-none flex-1"
+							style={{
+								background: "var(--color-bg)",
+								border: "1px solid var(--color-border)",
+								color: "var(--color-text)",
+							}}
+						/>
+						<button
+							type="button"
+							onClick={handleSaveView}
+							className="px-2 py-1 rounded-md text-xs transition-colors cursor-pointer"
+							style={{
+								background: "var(--color-accent)",
+								color: "white",
+							}}
+						>
+							Save
+						</button>
+					</div>
+				)}
+
+				{activeViewName && (
+					<>
+						<div className="border-t my-1" style={{ borderColor: "var(--color-border)" }} />
+						<DropdownItem onClick={() => {
+							clearAll();
+							setViewsOpen(false);
+						}}>
+							<XIcon size={12} />
+							Clear active view
+						</DropdownItem>
+					</>
+				)}
+			</Dropdown>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// FilterPopover — compact pill button + popover with rules editor
+// ---------------------------------------------------------------------------
+
+function FilterPopover({
+	ruleCount,
+	hasFilters,
+	filters,
+	fields,
+	groupedFields,
+	members,
+	addRule,
+	updateRule,
+	removeRule,
+	clearAll,
+	toggleConjunction,
+	fieldPickerOpen,
+	setFieldPickerOpen,
+}: {
+	ruleCount: number;
+	hasFilters: boolean;
+	filters: FilterGroup;
+	fields: Field[];
+	groupedFields: Record<string, Field[]>;
+	members?: Array<{ id: string; name: string }>;
+	addRule: (fieldName: string) => void;
+	updateRule: (id: string, updates: Partial<FilterRule>) => void;
+	removeRule: (id: string) => void;
+	clearAll: () => void;
+	toggleConjunction: () => void;
+	fieldPickerOpen: boolean;
+	setFieldPickerOpen: (open: boolean) => void;
+}) {
+	const [open, setOpen] = useState(false);
+	const ref = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (!open) {return;}
+		const handler = (e: MouseEvent) => {
+			const target = e.target as Node;
+			if (ref.current && !ref.current.contains(target)) {
+				setOpen(false);
+			}
+		};
+		document.addEventListener("mousedown", handler);
+		return () => document.removeEventListener("mousedown", handler);
+	}, [open]);
+
+	return (
+		<div className="relative" ref={ref}>
+			<button
+				type="button"
+				onClick={() => setOpen((v) => !v)}
+				className="flex items-center gap-1 h-7 px-2 rounded-md text-xs transition-colors cursor-pointer flex-shrink-0"
+				style={{
+					color: hasFilters ? "var(--color-accent)" : "var(--color-text-muted)",
+					border: `1px solid ${hasFilters ? "var(--color-accent)" : "var(--color-border)"}`,
+					background: hasFilters ? "var(--color-accent-light, rgba(99,102,241,0.1))" : "transparent",
+				}}
+				title={hasFilters ? `${ruleCount} active filter${ruleCount !== 1 ? "s" : ""}` : "Add a filter"}
+			>
+				<FilterIcon />
+				<span className="hidden md:inline">
+					{hasFilters ? `Filter · ${ruleCount}` : "Filter"}
+				</span>
+			</button>
+
+			{open && (
+				<div
+					className="absolute right-0 top-full mt-1 z-50 rounded-lg border shadow-lg p-3 min-w-[300px] sm:min-w-[420px] max-w-[calc(100vw-2rem)] flex flex-col gap-2"
+					style={{
+						borderColor: "var(--color-border)",
+						background: "var(--color-surface)",
+						boxShadow: "0 8px 24px rgba(0,0,0,0.12)",
+					}}
+				>
+					<div className="flex items-center justify-between">
+						<div
+							className="text-[10px] font-semibold uppercase tracking-wider"
+							style={{ color: "var(--color-text-muted)" }}
+						>
+							Filters
+						</div>
+						{filters.rules.length >= 2 && (
 							<button
 								type="button"
-								onClick={handleSaveView}
-								className="px-2 py-1 rounded-md text-xs transition-colors cursor-pointer"
+								onClick={toggleConjunction}
+								className="px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider transition-colors cursor-pointer"
 								style={{
-									background: "var(--color-accent)",
-									color: "white",
+									background: "var(--color-accent-light, rgba(99,102,241,0.1))",
+									color: "var(--color-accent)",
+									border: "1px solid var(--color-accent)",
 								}}
+								title={`Matching ${filters.conjunction === "and" ? "ALL" : "ANY"} rules. Click to toggle.`}
 							>
-								Save
+								Match {filters.conjunction === "and" ? "ALL" : "ANY"}
 							</button>
+						)}
+					</div>
+
+					{hasFilters ? (
+						<div className="flex flex-col gap-1.5">
+							{filters.rules.map((rule, idx) => {
+								if (isFilterGroup(rule)) {return null;}
+								const field = fields.find((f) => f.name === rule.field);
+								return (
+									<div key={rule.id} className="flex items-center gap-1.5">
+										<span
+											className="text-[10px] font-semibold uppercase w-10 text-center flex-shrink-0"
+											style={{ color: "var(--color-text-muted)" }}
+										>
+											{idx === 0 ? "Where" : filters.conjunction}
+										</span>
+										<FilterRuleRow
+											rule={rule}
+											field={field}
+											fields={fields}
+											members={members}
+											onUpdate={(updates) => updateRule(rule.id, updates)}
+											onRemove={() => removeRule(rule.id)}
+										/>
+									</div>
+								);
+							})}
+						</div>
+					) : (
+						<div
+							className="text-[11px] py-1"
+							style={{ color: "var(--color-text-muted)" }}
+						>
+							No filters applied. Add one below.
 						</div>
 					)}
 
-					{activeViewName && (
-						<>
-							<div className="border-t my-1" style={{ borderColor: "var(--color-border)" }} />
-							<DropdownItem onClick={() => {
-								clearAll();
-								setViewsOpen(false);
-							}}>
-								<XIcon size={12} />
-								Clear active view
-							</DropdownItem>
-						</>
-					)}
-				</Dropdown>
-			</div>
-
-			{/* Expanded filter rule editors (shown when rules exist) */}
-			{hasFilters && (
-				<div className="space-y-1.5 pl-5">
-					{filters.rules.map((rule, idx) => {
-						if (isFilterGroup(rule)) {return null;}
-						const field = fields.find((f) => f.name === rule.field);
-						return (
-							<div key={rule.id} className="flex items-center gap-1.5">
-								{idx > 0 && (
-									<span
-										className="text-[10px] font-semibold uppercase w-8 text-center flex-shrink-0"
+					<div className="flex items-center gap-2 pt-1">
+						<Dropdown
+							trigger={
+								<button
+									type="button"
+									className="flex items-center gap-1 px-2 py-1 rounded-md text-xs transition-colors cursor-pointer"
+									style={{
+										color: "var(--color-text-muted)",
+										border: "1px dashed var(--color-border)",
+									}}
+								>
+									<PlusIcon /> Add filter
+								</button>
+							}
+							open={fieldPickerOpen}
+							onOpenChange={setFieldPickerOpen}
+						>
+							{Object.entries(groupedFields).map(([type, typeFields]) => (
+								<div key={type}>
+									<div
+										className="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider"
 										style={{ color: "var(--color-text-muted)" }}
 									>
-										{filters.conjunction}
-									</span>
-								)}
-								{idx === 0 && (
-									<span className="w-8 flex-shrink-0" />
-								)}
-								<FilterRuleRow
-									rule={rule}
-									field={field}
-									fields={fields}
-									members={members}
-									onUpdate={(updates) => updateRule(rule.id, updates)}
-									onRemove={() => removeRule(rule.id)}
-								/>
-							</div>
-						);
-					})}
+										{FIELD_TYPE_ICONS[type] ?? "?"} {type}
+									</div>
+									{typeFields.map((f) => (
+										<DropdownItem key={f.name} onClick={() => addRule(f.name)}>
+											{f.name}
+										</DropdownItem>
+									))}
+								</div>
+							))}
+						</Dropdown>
+
+						{hasFilters && (
+							<button
+								type="button"
+								onClick={clearAll}
+								className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] transition-colors cursor-pointer"
+								style={{
+									color: "var(--color-accent)",
+									background: "var(--color-accent-light, rgba(99,102,241,0.1))",
+								}}
+							>
+								<XIcon size={10} />
+								Clear all
+							</button>
+						)}
+					</div>
 				</div>
 			)}
 		</div>

--- a/apps/web/app/components/workspace/object-table.tsx
+++ b/apps/web/app/components/workspace/object-table.tsx
@@ -70,6 +70,16 @@ type ObjectTableProps = {
 	serverPagination?: ServerPaginationProps;
 	/** Server-side search callback. */
 	onServerSearch?: (query: string) => void;
+	/** When true, the DataTable's internal toolbar (search, columns, refresh, +Add) is suppressed. */
+	hideInternalToolbar?: boolean;
+	/** Controlled global filter value. When provided, the DataTable uses this instead of its own state. */
+	globalFilter?: string;
+	onGlobalFilterChange?: (value: string) => void;
+	/** If provided, the table's +Add action delegates to this callback instead of opening the built-in modal. */
+	onAddRequest?: () => void;
+	/** Controlled sticky-first-column toggle. */
+	stickyFirstColumnValue?: boolean;
+	onStickyFirstColumnChange?: (value: boolean) => void;
 };
 
 type EntryRow = Record<string, unknown> & { entry_id?: string };
@@ -77,7 +87,7 @@ type EntryRowCell = ReturnType<Row<EntryRow>["getVisibleCells"]>[number];
 
 const CREATED_AT_KEYS = ["created_at", "Created", "createdAt", "created"] as const;
 const UPDATED_AT_KEYS = ["updated_at", "Updated", "updatedAt", "updated"] as const;
-const FIXED_TABLE_COLUMN_IDS = new Set(["select", "actions", "__add_column"]);
+const FIXED_TABLE_COLUMN_IDS = new Set(["__rownum", "select", "actions", "__add_column"]);
 
 /* ─── Helpers ─── */
 
@@ -672,6 +682,12 @@ export function ObjectTable({
 	onColumnSizingChanged,
 	serverPagination,
 	onServerSearch,
+	hideInternalToolbar,
+	globalFilter,
+	onGlobalFilterChange,
+	onAddRequest,
+	stickyFirstColumnValue,
+	onStickyFirstColumnChange,
 }: ObjectTableProps) {
 	const [rowSelection, setRowSelection] = useState<Record<string, boolean>>({});
 	const [showAddModal, setShowAddModal] = useState(false);
@@ -992,10 +1008,14 @@ export function ObjectTable({
 		return cols;
 	}, [dataFields, actionFields, activeReverseRelations, objectName, members, relationLabels, onNavigateToObject, onNavigateToEntry, onRefresh, showToast, renamingFieldId, handleRenameColumn, handleDeleteColumn, handleMoveColumn]);
 
-	// Add entry handler — opens modal instead of creating empty entry
+	// Add entry handler — delegates to parent when provided, otherwise opens local modal.
 	const handleAdd = useCallback(() => {
-		setShowAddModal(true);
-	}, []);
+		if (onAddRequest) {
+			onAddRequest();
+		} else {
+			setShowAddModal(true);
+		}
+	}, [onAddRequest]);
 
 	const getSelectedEntryIds = useCallback(() => {
 		return Object.keys(rowSelection)
@@ -1119,6 +1139,8 @@ export function ObjectTable({
 			addButtonLabel="+ Add"
 			rowActions={getRowActions}
 			stickyFirstColumn
+			stickyFirstColumnValue={stickyFirstColumnValue}
+			onStickyFirstColumnChange={onStickyFirstColumnChange}
 			activeRowId={activeEntryId}
 			getRowId={(row) => String(row.entry_id ?? "")}
 			initialColumnVisibility={columnVisibility}
@@ -1127,6 +1149,9 @@ export function ObjectTable({
 			onColumnSizingChange={onColumnSizingChanged}
 			serverPagination={serverPagination}
 			onServerSearch={onServerSearch}
+			hideToolbar={hideInternalToolbar}
+			globalFilter={globalFilter}
+			onGlobalFilterChange={onGlobalFilterChange}
 			getFirstDataColumnFaviconUrl={getFirstUrlColumnFaviconUrl}
 		/>
 
@@ -1166,7 +1191,7 @@ export function ObjectTable({
 
 /* ─── Add Entry Modal ─── */
 
-function AddEntryModal({
+export function AddEntryModal({
 	objectName,
 	fields,
 	members,

--- a/apps/web/app/components/workspace/view-settings-popover.tsx
+++ b/apps/web/app/components/workspace/view-settings-popover.tsx
@@ -19,6 +19,24 @@ type ViewSettingsPopoverProps = {
 	settings: ViewTypeSettings;
 	fields: Field[];
 	onSettingsChange: (settings: ViewTypeSettings) => void;
+	/** Optional description shown at the top of the popover. */
+	description?: string;
+	/** Currently selected display field name. */
+	displayField?: string;
+	/** Fields eligible to be the display field. */
+	displayFieldCandidates?: Field[];
+	/** Called when the user selects a new display field. */
+	onDisplayFieldChange?: (name: string) => void;
+	/** Whether the display field is currently being updated on the server. */
+	updatingDisplayField?: boolean;
+	/** Column visibility map (fieldId -> visible). When provided, a Columns section is rendered. */
+	columnVisibility?: Record<string, boolean>;
+	/** Called when the user toggles a column's visibility. */
+	onColumnVisibilityChange?: (next: Record<string, boolean>) => void;
+	/** Whether the first column is frozen/sticky. */
+	stickyFirstColumn?: boolean;
+	/** Called when the user toggles the freeze first column option. */
+	onStickyFirstColumnChange?: (next: boolean) => void;
 };
 
 // ---------------------------------------------------------------------------
@@ -297,11 +315,160 @@ function GearIcon() {
 	);
 }
 
+function SectionLabel({ children }: { children: React.ReactNode }) {
+	return (
+		<div
+			className="text-[10px] font-semibold uppercase tracking-wider"
+			style={{ color: "var(--color-text-muted)" }}
+		>
+			{children}
+		</div>
+	);
+}
+
+function DescriptionSection({ description }: { description: string }) {
+	return (
+		<div className="flex flex-col gap-1">
+			<SectionLabel>About</SectionLabel>
+			<p
+				className="text-[12px] leading-snug"
+				style={{ color: "var(--color-text)" }}
+			>
+				{description}
+			</p>
+		</div>
+	);
+}
+
+function DisplayFieldSection({
+	displayField,
+	candidates,
+	onChange,
+	updating,
+}: {
+	displayField: string | undefined;
+	candidates: Field[];
+	onChange: (name: string) => void;
+	updating: boolean;
+}) {
+	return (
+		<div className="flex flex-col gap-1">
+			<SectionLabel>Display field</SectionLabel>
+			<div className="flex items-center gap-1.5">
+				<select
+					value={displayField ?? ""}
+					onChange={(e) => onChange(e.target.value)}
+					disabled={updating}
+					className="text-[12px] rounded-md border px-2 py-1.5 flex-1 outline-none cursor-pointer"
+					style={{
+						borderColor: "var(--color-border)",
+						color: "var(--color-text)",
+						background: "var(--color-surface)",
+						opacity: updating ? 0.5 : 1,
+					}}
+				>
+					{candidates.map((f) => (
+						<option key={f.id} value={f.name}>
+							{f.name}
+						</option>
+					))}
+				</select>
+				{updating && (
+					<div
+						className="w-3 h-3 border border-t-transparent rounded-full animate-spin shrink-0"
+						style={{ borderColor: "var(--color-text-muted)" }}
+					/>
+				)}
+			</div>
+		</div>
+	);
+}
+
+function ColumnsSection({
+	fields,
+	columnVisibility,
+	onColumnVisibilityChange,
+	stickyFirstColumn,
+	onStickyFirstColumnChange,
+}: {
+	fields: Field[];
+	columnVisibility: Record<string, boolean>;
+	onColumnVisibilityChange: (next: Record<string, boolean>) => void;
+	stickyFirstColumn?: boolean;
+	onStickyFirstColumnChange?: (next: boolean) => void;
+}) {
+	const toggle = (fieldId: string) => {
+		const current = columnVisibility[fieldId] !== false;
+		onColumnVisibilityChange({ ...columnVisibility, [fieldId]: !current });
+	};
+
+	return (
+		<div className="flex flex-col gap-1.5">
+			<SectionLabel>Columns</SectionLabel>
+			{onStickyFirstColumnChange && (
+				<label
+					className="flex items-center gap-2 text-[12px] cursor-pointer"
+					style={{ color: "var(--color-text)" }}
+				>
+					<input
+						type="checkbox"
+						checked={Boolean(stickyFirstColumn)}
+						onChange={(e) => onStickyFirstColumnChange(e.target.checked)}
+						className="cursor-pointer"
+					/>
+					Freeze first column
+				</label>
+			)}
+			<div
+				className="flex flex-col gap-1 max-h-48 overflow-y-auto rounded-md border p-1.5"
+				style={{ borderColor: "var(--color-border)" }}
+			>
+				{fields.length === 0 ? (
+					<div
+						className="text-[11px] px-1 py-0.5"
+						style={{ color: "var(--color-text-muted)" }}
+					>
+						No columns
+					</div>
+				) : (
+					fields.map((field) => {
+						const visible = columnVisibility[field.id] !== false;
+						return (
+							<label
+								key={field.id}
+								className="flex items-center gap-2 text-[12px] cursor-pointer px-1 py-0.5 rounded hover:bg-[var(--color-surface-hover)]"
+								style={{ color: "var(--color-text)" }}
+							>
+								<input
+									type="checkbox"
+									checked={visible}
+									onChange={() => toggle(field.id)}
+									className="cursor-pointer"
+								/>
+								<span className="truncate">{field.name}</span>
+							</label>
+						);
+					})
+				)}
+			</div>
+		</div>
+	);
+}
+
 export function ViewSettingsPopover({
 	viewType,
 	settings,
 	fields,
 	onSettingsChange,
+	description,
+	displayField,
+	displayFieldCandidates,
+	onDisplayFieldChange,
+	updatingDisplayField,
+	columnVisibility,
+	onColumnVisibilityChange,
+	stickyFirstColumn,
+	onStickyFirstColumnChange,
 }: ViewSettingsPopoverProps) {
 	const [open, setOpen] = useState(false);
 	const popoverRef = useRef<HTMLDivElement>(null);
@@ -317,11 +484,21 @@ export function ViewSettingsPopover({
 		return () => document.removeEventListener("mousedown", handler);
 	}, [open]);
 
-	// Table has no settings
-	if (viewType === "table") {return null;}
+	const hasDescription = Boolean(description && description.trim());
+	const hasDisplayField =
+		Boolean(displayFieldCandidates && displayFieldCandidates.length > 0 && onDisplayFieldChange);
+	const hasColumns = Boolean(onColumnVisibilityChange && viewType === "table");
+	const effectiveColumnVisibility = columnVisibility ?? {};
+
+	const viewTypeHasSettings = viewType !== "table";
+
+	const hasAnyContent =
+		hasDescription || hasDisplayField || hasColumns || viewTypeHasSettings;
+
+	if (!hasAnyContent) {return null;}
 
 	const panelTitle: Record<ViewType, string> = {
-		table: "",
+		table: "Table Settings",
 		kanban: "Board Settings",
 		calendar: "Calendar Settings",
 		timeline: "Timeline Settings",
@@ -334,16 +511,17 @@ export function ViewSettingsPopover({
 			<button
 				type="button"
 				onClick={() => setOpen(!open)}
-				className="p-1.5 rounded-md hover:bg-[var(--color-surface-hover)] transition-colors"
+				className="flex items-center justify-center w-7 h-7 rounded-md hover:bg-[var(--color-surface-hover)] transition-colors cursor-pointer"
 				style={{ color: "var(--color-text-muted)" }}
 				title="View settings"
+				aria-label="View settings"
 			>
 				<GearIcon />
 			</button>
 
 			{open && (
 				<div
-					className="absolute right-0 top-full mt-1 z-50 rounded-lg border shadow-lg p-3 min-w-[200px] sm:min-w-[240px] max-w-[calc(100vw-2rem)] flex flex-col gap-3"
+					className="absolute right-0 top-full mt-1 z-50 rounded-lg border shadow-lg p-3 min-w-[220px] sm:min-w-[260px] max-w-[calc(100vw-2rem)] flex flex-col gap-3"
 					style={{
 						borderColor: "var(--color-border)",
 						background: "var(--color-surface)",
@@ -353,6 +531,17 @@ export function ViewSettingsPopover({
 					<div className="text-[11px] font-semibold" style={{ color: "var(--color-text)" }}>
 						{panelTitle[viewType]}
 					</div>
+
+					{hasDescription && <DescriptionSection description={description!} />}
+
+					{hasDisplayField && (
+						<DisplayFieldSection
+							displayField={displayField}
+							candidates={displayFieldCandidates!}
+							onChange={onDisplayFieldChange!}
+							updating={Boolean(updatingDisplayField)}
+						/>
+					)}
 
 					{viewType === "kanban" && (
 						<KanbanSettings settings={settings} fields={fields} onSettingsChange={onSettingsChange} />
@@ -368,6 +557,16 @@ export function ViewSettingsPopover({
 					)}
 					{viewType === "list" && (
 						<ListSettings settings={settings} fields={fields} onSettingsChange={onSettingsChange} />
+					)}
+
+					{hasColumns && (
+						<ColumnsSection
+							fields={fields}
+							columnVisibility={effectiveColumnVisibility}
+							onColumnVisibilityChange={onColumnVisibilityChange!}
+							stickyFirstColumn={stickyFirstColumn}
+							onStickyFirstColumnChange={onStickyFirstColumnChange}
+						/>
 					)}
 				</div>
 			)}

--- a/apps/web/app/components/workspace/view-type-switcher.tsx
+++ b/apps/web/app/components/workspace/view-type-switcher.tsx
@@ -76,7 +76,7 @@ type ViewTypeSwitcherProps = {
 
 export function ViewTypeSwitcher({ value, onChange }: ViewTypeSwitcherProps) {
 	return (
-		<div className="flex items-center gap-1">
+		<div className="flex items-center gap-0.5">
 			{VIEW_TYPES.map((vt) => {
 				const meta = VIEW_TYPE_META[vt];
 				const Icon = meta.icon;
@@ -86,16 +86,15 @@ export function ViewTypeSwitcher({ value, onChange }: ViewTypeSwitcherProps) {
 						key={vt}
 						type="button"
 						onClick={() => onChange(vt)}
-						className="flex items-center gap-1.5 px-2.5 py-1 text-[12px] rounded-md transition-colors cursor-pointer"
+						className="flex items-center justify-center w-7 h-7 rounded-md transition-colors cursor-pointer"
 						style={{
 							background: isActive ? "var(--color-surface-hover)" : "transparent",
 							color: isActive ? "var(--color-text)" : "var(--color-text-muted)",
-							fontWeight: isActive ? 500 : 400,
 						}}
 						title={meta.label}
+						aria-label={meta.label}
 					>
 						<Icon />
-						<span className="hidden sm:inline">{meta.label}</span>
 					</button>
 				);
 			})}


### PR DESCRIPTION
## Summary

Move secondary table chrome (filter pills, column toggles, freeze-first-column, display-field) from the per-view toolbar into the gear popover so the data gets back the visual weight it deserves. Also exports the `AddEntryModal` so wrapper shells (e.g. the upcoming CRM profile views in PR3) can render the modal without owning the entire table.

## What changed

- **`view-settings-popover.tsx`**: new sections — description, display-field, columns checklist, freeze-first-column. All optional so unchanged callers stay working.
- **`data-table.tsx`**: new optional props — `hideToolbar`, controlled `globalFilter`/`onGlobalFilterChange`, `stickyFirstColumnValue`/`onStickyFirstColumnChange` — for wrappers to drive their own composer.
- **`object-table.tsx`**: forwards the new ObjectTable wrapper props through to DataTable; exports `AddEntryModal` for the upcoming CRM profile views.
- **`object-filter-bar.tsx`** + **`view-type-switcher.tsx`**: layout polish + label alignment to match the reduced toolbar.

No new dependencies. Backwards compatible.

## Test plan

- [x] `pnpm format:check` clean
- [x] `pnpm web:build` green
- [x] `pnpm --dir apps/web test` — 1317 tests pass; the 3 pre-existing failures in `app/api/workspace/objects.test.ts` (missing `pivotViewIdentifier` mock since #185) are unchanged from `v3.0.0`
- [x] Manual: `pnpm web:dev` → table view shows uncluttered toolbar; gear popover surfaces filter/columns/sticky/display-field

## Source

Driven by transcript [Workspace UI declutter request](cdea54d2-ecde-437c-97be-bfd64ab37893) (Apr 16, 2:11pm).


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily UI/component-API changes, but it alters `DataTable` column ordering (adds a fixed `__rownum` column) and introduces new controlled props that could affect table interactions if wired incorrectly.
> 
> **Overview**
> Declutters the workspace header by turning filters into a compact pill/popover (`ObjectFilterBar`) and making the view-type switcher icon-only.
> 
> Enhances `ViewSettingsPopover` to optionally show description, display-field selection, and (for table views) column visibility + “freeze first column” controls.
> 
> Upgrades `DataTable`/`ObjectTable` to support external orchestration: adds `hideToolbar`, controlled `globalFilter` and sticky-first-column props, and an optional `onAddRequest` flow; also adds a fixed row-number column (`__rownum`) and tightens pagination/footer styling. `AddEntryModal` is now exported for reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69e0170ef8218a2eb93a8c4c2e8eb91be0a9da3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->