### PR TITLE
fix(cli): pass safe cwd to spawned openclaw children

### DIFF
--- a/apps/web/lib/integrations.ts
+++ b/apps/web/lib/integrations.ts
@@ -1,8 +1,23 @@
 import { execFile } from "node:child_process";
 import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { resolveOpenClawStateDir } from "@/lib/workspace";
+
+/**
+ * Returns a guaranteed-valid working directory for spawning child processes.
+ * Falls back to the user's home dir when the current process's cwd has been
+ * deleted (e.g. tmp dirs, deleted project folders), which would otherwise make
+ * spawned Node.js children crash with `ENOENT: uv_cwd` before they even start.
+ */
+function safeChildCwd(): string {
+  try {
+    return process.cwd();
+  } catch {
+    return homedir();
+  }
+}
 
 export type DenchIntegrationId = "exa" | "apollo" | "elevenlabs";
 
@@ -1011,6 +1026,7 @@ export async function refreshIntegrationsRuntime(): Promise<IntegrationRuntimeRe
     await execFileAsync("openclaw", ["--profile", profile, "gateway", "restart"], {
       timeout: 30_000,
       env: process.env,
+      cwd: safeChildCwd(),
     });
     return {
       attempted: true,

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { homedir } from "node:os";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { isTruthyEnvValue, normalizeEnv } from "../infra/env.js";
@@ -10,6 +11,20 @@ import { getCommandPath, getPrimaryCommand, hasHelpOrVersion } from "./argv.js";
 import { emitCliBanner } from "./banner.js";
 import { resolveCliName } from "./cli-name.js";
 import { normalizeWindowsArgv } from "./windows-argv.js";
+
+/**
+ * Returns a guaranteed-valid working directory for the spawned child. When the
+ * current process's cwd has been deleted (tmp dirs, deleted project folders),
+ * `process.cwd()` throws ENOENT and the spawned Node.js child crashes before
+ * it can do anything useful. Falling back to the user's home dir prevents that.
+ */
+function safeChildCwd(): string {
+  try {
+    return process.cwd();
+  } catch {
+    return homedir();
+  }
+}
 
 export function rewriteUpdateFlagArgv(argv: string[]): string[] {
   const index = argv.indexOf("--update");
@@ -160,6 +175,7 @@ async function delegateToGlobalOpenClaw(argv: string[]): Promise<number> {
   return await new Promise<number>((resolve, reject) => {
     const child = spawn("openclaw", delegatedArgv, {
       stdio: "inherit",
+      cwd: safeChildCwd(),
       env: {
         ...process.env,
         DENCHCLAW_DELEGATED: "1",


### PR DESCRIPTION
## Problem

Users in Dench Cloud see this error every time they switch models:

> Switched to Claude Opus 4.6, but the gateway restart did not complete: Command failed: openclaw --profile dench gateway restart
> node:internal/bootstrap/switches/does_own_process_state:142
> cachedCwd = rawMethods.cwd();
>             ^
> Error: ENOENT: no such file or directory, uv_cwd

The model switch itself works (config is saved), but the gateway restart crashes, so the new model doesn't take effect until the user manually clicks **Settings → Infrastructure → Restart gateway**.

## Root cause

When the parent process's working directory has been deleted (tmp dirs, deleted project folders, certain sandbox lifecycles), `process.cwd()` throws `ENOENT`. Any Node.js child spawned without an explicit `cwd` inherits the parent's broken cwd and crashes immediately on its `cachedCwd = rawMethods.cwd()` startup line — before reaching its own logic.

Two places in this repo spawn `openclaw` without an explicit cwd:

1. **`apps/web/lib/integrations.ts:1011`** — `refreshIntegrationsRuntime()` spawns `openclaw gateway restart` after model switches, API key saves, and integration toggles. **This is the bug users are hitting.**
2. **`src/cli/run-main.ts:161`** — `delegateToGlobalOpenClaw()` spawns the global `openclaw` CLI when denchclaw is invoked as a delegation entry. Same root cause.

## Fix

Adds a small `safeChildCwd()` helper to both files that returns `process.cwd()` when valid and falls back to the user's home directory when it throws. Each spawn call now passes `cwd: safeChildCwd()`, guaranteeing the spawned child always starts in a real, existing directory.

The `openclaw` CLI doesn't depend on cwd for `gateway restart` (it operates on `~/.openclaw-dench/` for state), so falling back to home is functionally equivalent to the user's actual cwd for this code path.

## Test plan

- [x] Existing `apps/web/lib/integrations.test.ts` (14 tests) still pass
- [ ] After deploy, switch model in Dench Cloud → no manual restart needed
- [ ] After deploy, save API key → no manual restart needed
- [ ] After deploy, toggle integration → no manual restart needed

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds multiple new Node.js API routes that build dynamic SQL for DuckDB-backed CRM data plus new onboarding state/sync endpoints, increasing surface area for query correctness and edge cases. Also changes workspace init/tree/search and chat-panel session behavior, which could affect navigation and UX flows.
> 
> **Overview**
> Introduces a **CRM surface area** in the web app: new `/api/crm/*` endpoints for listing and drilling into `people`, `companies`, `inbox` (threads + hydrated messages), and `calendar`, plus a scaffolded `POST /api/crm/enrich/:type/:id` that currently returns `501` deferred.
> 
> Adds **CRM UI components** (Companies list/profile, Calendar view, shared shells, favicon/strength chips, inbox component shims) and wires URL-synced filtering/pagination patterns for list views.
> 
> Expands **onboarding APIs** to manage identity capture, Dench Cloud key/model setup (including mirroring auth into `auth-profiles.json`), connection writes for Gmail/Calendar, and sync start/progress (SSE) with optional cleanup/restart semantics.
> 
> Updates workspace behavior: `workspace/init` now attempts `ensureLatestSchema()` after seeding, `search-index` always includes CRM nav shortcuts and indexes CRM-hidden objects, and `workspace/tree` hides CRM-only objects via DB `hidden_in_sidebar` (with a hardcoded fallback). Chat panel behavior is adjusted to remove file-scoped sessions and re-announce file context when the selected file changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4858803f0e1ace979efcbad079e4efef744425cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->