### PR TITLE
fix(web): inbox email body — full-width, full natural height, no internal scroll

### DIFF
--- a/apps/web/app/components/crm/inbox/conversation-pane.tsx
+++ b/apps/web/app/components/crm/inbox/conversation-pane.tsx
@@ -1,23 +1,18 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { CrmEmptyState, CrmLoadingState } from "../crm-list-shell";
+import { useCallback } from "react";
 import { ConversationHeader } from "./conversation-header";
-import { MessageCard } from "./message-card";
-import { QuickReply } from "./quick-reply";
-import type { Participant } from "./participant-chips";
-import type { Message, Thread } from "./types";
-
-type ThreadDetail = {
-  thread_id: string;
-  messages: Message[];
-  people: Participant[];
-};
+import { ThreadMessages } from "./thread-messages";
+import type { Thread } from "./types";
 
 /**
- * Right pane (or full-pane on mobile / focus-mode). Loads the selected
- * thread, renders messages with the latest expanded by default, and
- * shows a fixed visual reply composer at the bottom.
+ * Right pane (or full-pane on mobile / focus-mode) of the Inbox.
+ *
+ * This is now a thin shell: sticky `ConversationHeader` on top, the
+ * reusable `ThreadMessages` block in the scroller below. The actual
+ * thread loading + message rendering + reply composer all live in
+ * ThreadMessages so they can be reused in PersonProfile / CompanyProfile
+ * email tabs (where rows expand inline) without duplicating the logic.
  *
  * Slide-in animation: when `selectedThread.id` changes, the inner pane
  * fades + translates in from the right ~10px so the user perceives the
@@ -41,69 +36,6 @@ export function ConversationPane({
   onToggleFocus?: () => void;
   focusMode?: boolean;
 }) {
-  const [detail, setDetail] = useState<ThreadDetail | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  // Load + refresh when the selected thread changes.
-  useEffect(() => {
-    if (!selectedThread) {
-      setDetail(null);
-      setError(null);
-      return;
-    }
-    const controller = new AbortController();
-    setLoading(true);
-    setError(null);
-    void (async () => {
-      try {
-        const res = await fetch(`/api/crm/inbox/${encodeURIComponent(selectedThread.id)}`, {
-          cache: "no-store",
-          signal: controller.signal,
-        });
-        if (!res.ok) {throw new Error(`HTTP ${res.status}`);}
-        const body = (await res.json()) as ThreadDetail;
-        setDetail(body);
-      } catch (err) {
-        if ((err as Error).name === "AbortError") {return;}
-        setError(err instanceof Error ? err.message : "Failed to load this thread.");
-      } finally {
-        setLoading(false);
-      }
-    })();
-    return () => controller.abort();
-  }, [selectedThread]);
-
-  // Slide-in animation: bump a key on every thread change.
-  const animationKey = selectedThread?.id ?? "empty";
-
-  // People map for quick lookup inside MessageCard.
-  const peopleMap = useMemo<Map<string, Participant>>(() => {
-    const map = new Map<string, Participant>();
-    if (detail?.people) {
-      for (const p of detail.people) {map.set(p.id, p);}
-    }
-    if (selectedThread?.participants) {
-      for (const p of selectedThread.participants) {
-        if (!map.has(p.id)) {map.set(p.id, p);}
-      }
-    }
-    return map;
-  }, [detail, selectedThread]);
-
-  // Auto-scroll to the bottom-most message on first paint of a thread.
-  const scrollerRef = useRef<HTMLDivElement | null>(null);
-  useEffect(() => {
-    if (detail && scrollerRef.current) {
-      // Wait one frame so the DOM has the new message cards mounted.
-      requestAnimationFrame(() => {
-        const el = scrollerRef.current;
-        if (!el) {return;}
-        el.scrollTop = el.scrollHeight;
-      });
-    }
-  }, [detail]);
-
   const handleClose = useCallback(() => {
     onClose?.();
   }, [onClose]);
@@ -135,7 +67,11 @@ export function ConversationPane({
     );
   }
 
-  const lastMessageId = detail?.messages.at(-1)?.id;
+  // Slide-in animation: bump a key on every thread change so the entire
+  // pane re-mounts with the keyframe.
+  const animationKey = selectedThread.id;
+  const recipientName =
+    selectedThread.primary_sender_name ?? selectedThread.primary_sender_email ?? null;
 
   return (
     <div
@@ -161,45 +97,14 @@ export function ConversationPane({
         focusMode={focusMode}
         onClose={handleClose}
       />
-      <div
-        ref={scrollerRef}
-        className="flex-1 min-h-0 overflow-y-auto px-6 py-5"
-      >
-        <div className="mx-auto w-full max-w-3xl space-y-3">
-          {loading && !detail && <CrmLoadingState label="Loading conversation…" />}
-          {error && (
-            <CrmEmptyState
-              title="Couldn't load this thread"
-              description={error}
-            />
-          )}
-          {detail?.messages.map((msg) => (
-            <MessageCard
-              key={msg.id}
-              message={msg}
-              people={peopleMap}
-              defaultExpanded={msg.id === lastMessageId}
-              onOpenPerson={onOpenPerson}
-            />
-          ))}
-          {detail && detail.messages.length === 0 && (
-            <CrmEmptyState
-              title="This thread has no messages"
-              description="Likely a stub from a manual insert."
-            />
-          )}
-          {detail && detail.messages.length > 0 && (
-            <div className="pt-3">
-              <QuickReply
-                recipientName={
-                  selectedThread.primary_sender_name ??
-                  selectedThread.primary_sender_email ??
-                  null
-                }
-              />
-            </div>
-          )}
-        </div>
+      <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
+        <ThreadMessages
+          threadId={selectedThread.id}
+          seedParticipants={selectedThread.participants}
+          recipientName={recipientName}
+          onOpenPerson={onOpenPerson}
+          autoScrollOnLoad
+        />
       </div>
     </div>
   );

--- a/apps/web/app/components/crm/inbox/message-body.tsx
+++ b/apps/web/app/components/crm/inbox/message-body.tsx
@@ -1,15 +1,25 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 
 /**
  * Renders a single message body with format detection:
  *
- *   - HTML-shaped content → rendered in a strict sandboxed iframe via
- *     `srcdoc`. Sandbox is `allow-popups` only — NO scripts, NO same-
- *     origin, NO forms, NO modals. We wrap the body in a base stylesheet
- *     that keeps it inside the conversation column (max-width 100%),
- *     forces all links to open in a new tab, and scopes images.
+ *   - HTML-shaped content → rendered in a sandboxed iframe via `srcdoc`.
+ *     We strip every `<script>` block, every `on*=…` inline event handler,
+ *     and every `javascript:` URL from the email HTML before injecting,
+ *     then enable `allow-scripts` (without `allow-same-origin`) so a
+ *     tiny measurement script we inject inside the iframe can postMessage
+ *     its real document height back to the parent. This is the same
+ *     pattern Gmail / Outlook web use because parent→child contentDocument
+ *     reads are unreliable across sandbox/srcdoc/lazy-load combinations,
+ *     while in-iframe self-measurement always works.
+ *
+ *     Without `allow-same-origin` the iframe lives in an opaque origin,
+ *     so even if any malicious markup slipped past sanitization it cannot
+ *     reach the parent's cookies/storage/DOM — the only channel out is
+ *     `postMessage`, and we filter incoming messages by a per-instance
+ *     token to ignore spoofs.
  *
  *   - Plain text / markdown → rendered as preformatted text inside a
  *     scrollable column. We deliberately avoid pulling the workspace's
@@ -17,8 +27,9 @@ import { useEffect, useMemo, useRef, useState } from "react";
  *     uses markdown syntax intentionally and we don't want subject lines
  *     like "Re: Section 1" to render as a heading.
  *
- * The iframe auto-resizes to fit its content height (capped at 1200px) so
- * the conversation pane scrolls naturally instead of nesting scrollbars.
+ * The iframe auto-resizes to its full natural content height — no cap, no
+ * internal scrollbar — so the conversation pane is the only scroll surface
+ * and the email reads as one continuous document.
  */
 export function MessageBody({ body, preview }: { body: string | null; preview: string | null }) {
   const text = body?.trim() || preview?.trim() || "";
@@ -75,86 +86,189 @@ function SandboxedHtmlBody({ html }: { html: string }) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const [height, setHeight] = useState<number>(160);
 
-  // Build the srcdoc once per body change. Wrapped in a minimal HTML
-  // shell with a base stylesheet that:
-  //   - clamps width
-  //   - forces links to _blank (so clicks don't break out of the iframe)
-  //   - scales images to the column width
-  //   - uses Bookerly + Instrument Serif via CSS @font-face is overkill
-  //     here; system fonts inside the iframe is fine because the parent
-  //     UI already provides editorial type around it.
-  const srcdoc = useMemo(() => buildSrcdoc(html), [html]);
+  // Per-instance token. The in-iframe measurement script tags every
+  // postMessage with this token, and the parent listener only accepts
+  // matching messages — so two open emails on the page never confuse
+  // each other's heights.
+  const reactId = useId();
+  const token = useMemo(
+    () => reactId.replace(/[^a-zA-Z0-9_-]/g, "") || "iframe",
+    [reactId],
+  );
+
+  const srcdoc = useMemo(() => buildSrcdoc(html, token), [html, token]);
 
   useEffect(() => {
     const iframe = iframeRef.current;
     if (!iframe) {return;}
-    let cancelled = false;
-    let observer: ResizeObserver | null = null;
-
-    const measure = () => {
-      if (cancelled) {return;}
-      try {
-        const doc = iframe.contentDocument;
-        if (!doc?.body) {return;}
-        const next = Math.min(1200, Math.max(60, doc.body.scrollHeight + 8));
-        setHeight((prev) => (Math.abs(prev - next) > 2 ? next : prev));
-      } catch {
-        // contentDocument access can throw in some edge cases — keep height as-is.
+    const onMessage = (event: MessageEvent) => {
+      // Only accept messages from THIS iframe's window — not from any
+      // other iframe / extension / parent that happens to broadcast.
+      if (event.source !== iframe.contentWindow) {return;}
+      const data = event.data as { type?: unknown; token?: unknown; height?: unknown } | null;
+      if (
+        !data ||
+        typeof data !== "object" ||
+        data.type !== "denchclaw_email_height" ||
+        data.token !== token
+      ) {
+        return;
       }
+      const reported = Number(data.height);
+      if (!Number.isFinite(reported)) {return;}
+      // No padding added here on purpose — any added pixels would feed
+      // back into the next measurement (clientHeight grows with the
+      // iframe), creating a runaway loop. Breathing room lives inside
+      // the iframe body's own padding instead.
+      const next = Math.max(60, Math.round(reported));
+      setHeight((prev) => (Math.abs(prev - next) > 2 ? next : prev));
     };
-
-    const handleLoad = () => {
-      measure();
-      try {
-        const doc = iframe.contentDocument;
-        if (doc?.body && typeof ResizeObserver !== "undefined") {
-          observer = new ResizeObserver(measure);
-          observer.observe(doc.body);
-        }
-      } catch {
-        // no-op
-      }
-    };
-
-    iframe.addEventListener("load", handleLoad);
-    // In case load fired before the listener attached.
-    if (iframe.contentDocument?.readyState === "complete") {
-      handleLoad();
-    }
-
-    return () => {
-      cancelled = true;
-      iframe.removeEventListener("load", handleLoad);
-      observer?.disconnect();
-    };
-  }, [srcdoc]);
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [token]);
 
   return (
     <iframe
       ref={iframeRef}
       title="Email body"
       srcDoc={srcdoc}
-      // Strict sandbox: NO scripts, NO same-origin, NO forms, NO modals.
-      // `allow-popups` lets users follow target=_blank links, which we
-      // inject below.
-      sandbox="allow-popups allow-popups-to-escape-sandbox"
+      // Sandbox flags:
+      //   - `allow-scripts`: required for our injected measurement script
+      //     to run and postMessage the height back. Email-supplied JS is
+      //     stripped by stripScripts() before the srcdoc is built.
+      //   - NO `allow-same-origin`: the iframe lives in an opaque origin,
+      //     so even if some script slipped past sanitization it cannot
+      //     read the parent's cookies/storage/DOM. The only channel out
+      //     is postMessage, which we filter by a per-instance token.
+      //   - `allow-popups` + `allow-popups-to-escape-sandbox`: clicks on
+      //     `<a target="_blank">` (forced via our `<base>` injection)
+      //     open in a real new tab.
+      sandbox="allow-popups allow-popups-to-escape-sandbox allow-scripts"
       referrerPolicy="no-referrer"
-      loading="lazy"
       style={{
         width: "100%",
         height,
         border: "none",
         background: "var(--color-surface)",
         colorScheme: "light",
+        display: "block",
       }}
     />
   );
 }
 
-function buildSrcdoc(html: string): string {
-  // Wrap the user-supplied HTML in a minimal document with a base
-  // stylesheet + a <base> tag forcing target=_blank on every anchor.
-  // We do NOT inject any JavaScript — the sandbox blocks scripts anyway.
+// ---------------------------------------------------------------------------
+// HTML sanitization — strips everything that could execute JS in the iframe.
+// Belt-and-suspenders alongside the sandbox: even with `allow-scripts`, we
+// only want OUR measurement script to actually run.
+// ---------------------------------------------------------------------------
+
+function stripScripts(html: string): string {
+  return (
+    html
+      // <script>...</script> blocks (greedy enough for nested attempts).
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, "")
+      // Orphan <script> open/close tags.
+      .replace(/<\/?script\b[^>]*>/gi, "")
+      // Inline event handlers — onclick, onload, onerror, onmouseover, etc.
+      .replace(/\s+on[a-z]+\s*=\s*"[^"]*"/gi, "")
+      .replace(/\s+on[a-z]+\s*=\s*'[^']*'/gi, "")
+      .replace(/\s+on[a-z]+\s*=\s*[^\s>]+/gi, "")
+      // javascript: URLs in href / src / etc.
+      .replace(/javascript\s*:/gi, "")
+  );
+}
+
+function buildMeasureScript(token: string): string {
+  // Runs INSIDE the iframe. Computes the document's natural height and
+  // postMessages it to the parent. Re-runs on every meaningful event:
+  // initial paint, every image load (each one), DOMContentLoaded, full
+  // load, ResizeObserver mutations, and a backstop polling schedule for
+  // slow webfonts / external assets that don't trigger any of the above.
+  return `<script>(function(){
+var TOKEN = ${JSON.stringify(token)};
+function measure(){
+  try {
+    var b = document.body;
+    if (!b) return;
+    // CRITICAL: only measure the BODY (content), never the documentElement
+    // or window. documentElement.clientHeight / scrollHeight reflect the
+    // iframe's CURRENT viewport height, not the document's natural height
+    // — using them here creates a feedback loop where every measurement
+    // reports the iframe's own grown size and the iframe keeps growing.
+    var height = Math.max(b.scrollHeight, b.offsetHeight);
+    parent.postMessage({ type: 'denchclaw_email_height', token: TOKEN, height: height }, '*');
+  } catch (e) {}
+}
+function attach(){
+  measure();
+  try {
+    // Observe ONLY the body — observing documentElement would also fire
+    // on the viewport resize that we ourselves cause when growing the
+    // iframe, contributing to feedback-loop runs.
+    if (typeof ResizeObserver !== 'undefined' && document.body) {
+      var ro = new ResizeObserver(measure);
+      ro.observe(document.body);
+    }
+  } catch (e) {}
+  var imgs = document.images || [];
+  for (var i = 0; i < imgs.length; i++) {
+    if (!imgs[i].complete) {
+      imgs[i].addEventListener('load', measure);
+      imgs[i].addEventListener('error', measure);
+    }
+  }
+  var delays = [50, 200, 500, 1000, 2000, 4000, 8000];
+  for (var j = 0; j < delays.length; j++) setTimeout(measure, delays[j]);
+}
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', attach);
+} else {
+  attach();
+}
+window.addEventListener('load', measure);
+})();</script>`;
+}
+
+function buildSrcdoc(html: string, token: string): string {
+  // Real marketing emails (MJML, Gmail-rendered HTML, etc.) almost always
+  // come as a complete HTML document — `<!doctype><html><head><style>…
+  // </style></head><body>…</body></html>`. If we naively wrap that inside
+  // our own `<html><body>`, the parser treats the nested <html>/<body>
+  // tags as invalid and the email's content lands in unexpected places
+  // in the DOM (and `body.scrollHeight` reports a tiny value).
+  //
+  // So: if the body is already a full document, surgically inject our
+  // additions (base href + image clamp + measurement script) into its
+  // own <head>. Otherwise, wrap the fragment in a styled shell.
+  const sanitized = stripScripts(html.trim());
+  const isFullDoc = /^\s*(?:<!doctype|<html\b)/i.test(sanitized);
+  const measureScript = buildMeasureScript(token);
+
+  if (isFullDoc) {
+    // Minimal head injection — we deliberately don't add a base stylesheet
+    // because the email ships its own; piling our font/padding on top
+    // tends to make marketing layouts look broken.
+    const HEAD_INJECT = `<base target="_blank"><style>
+  img, video { max-width: 100% !important; height: auto !important; }
+  table { max-width: 100%; }
+  img[width="1"][height="1"] { display: none !important; }
+</style>${measureScript}`;
+
+    const headOpen = sanitized.match(/<head\b[^>]*>/i);
+    if (headOpen?.index !== undefined) {
+      const cut = headOpen.index + headOpen[0].length;
+      return sanitized.slice(0, cut) + HEAD_INJECT + sanitized.slice(cut);
+    }
+    const htmlOpen = sanitized.match(/<html\b[^>]*>/i);
+    if (htmlOpen?.index !== undefined) {
+      const cut = htmlOpen.index + htmlOpen[0].length;
+      return `${sanitized.slice(0, cut)}<head>${HEAD_INJECT}</head>${sanitized.slice(cut)}`;
+    }
+    // Doctype-only with no <html> tag — extremely unusual; fall through to wrap.
+  }
+
+  // Fragment path: wrap in our editorial shell.
   const STYLE = `
     :root { color-scheme: light; }
     html, body {
@@ -185,7 +299,8 @@ function buildSrcdoc(html: string): string {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <base target="_blank">
 <style>${STYLE}</style>
+${measureScript}
 </head>
-<body>${html}</body>
+<body>${sanitized}</body>
 </html>`;
 }

--- a/apps/web/app/components/crm/inbox/message-card.tsx
+++ b/apps/web/app/components/crm/inbox/message-card.tsx
@@ -58,11 +58,24 @@ export function MessageCard({
         transition: "border-color 160ms ease-out, box-shadow 160ms ease-out",
       }}
     >
-      {/* Header row — always visible */}
-      <button
-        type="button"
+      {/* Header row — always visible. Rendered as a div+role="button"
+         instead of a real <button> because the expanded state shows
+         clickable To/Cc person chips inside this region, and nesting
+         buttons is invalid HTML (causes a hydration error in React 19
+         / Next 15). We keep keyboard parity with native button via
+         tabIndex + Enter/Space handling. */}
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded}
         onClick={() => setExpanded((v) => !v)}
-        className="w-full flex items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-[var(--color-surface-hover)]"
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setExpanded((v) => !v);
+          }
+        }}
+        className="w-full flex items-start gap-3 px-4 py-3 text-left cursor-pointer transition-colors hover:bg-[var(--color-surface-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
       >
         <PersonAvatar
           src={sender?.avatar_url}
@@ -156,7 +169,7 @@ export function MessageCard({
             </p>
           )}
         </div>
-      </button>
+      </div>
 
       {/* Body — animates open via grid-rows trick (height-without-jank) */}
       <div

--- a/apps/web/app/components/crm/inbox/thread-messages.tsx
+++ b/apps/web/app/components/crm/inbox/thread-messages.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { CrmEmptyState, CrmLoadingState } from "../crm-list-shell";
+import { MessageCard } from "./message-card";
+import { QuickReply } from "./quick-reply";
+import type { Participant } from "./participant-chips";
+import type { Message } from "./types";
+
+type ThreadDetail = {
+  thread_id: string;
+  messages: Message[];
+  people: Participant[];
+};
+
+/**
+ * The standalone "conversation reader content" — loads a thread by id,
+ * renders each message as a MessageCard (latest expanded by default),
+ * and shows the visual reply composer at the bottom.
+ *
+ * Has NO sticky header and NO pane chrome. Use cases:
+ *
+ *   - Inbox: rendered inside ConversationPane (which adds the sticky
+ *     header + slide-in animation).
+ *   - PersonProfile / CompanyProfile email tabs: rendered inline,
+ *     directly underneath the clicked thread row, so the row itself acts
+ *     as the conversation header.
+ *
+ * Optional `seedParticipants` lets the parent contribute participants
+ * already on hand (e.g. from the Inbox thread row) so message-card can
+ * resolve from/to chips before the detail fetch finishes.
+ *
+ * `recipientName` powers the QuickReply placeholder ("Reply to Sarah…").
+ *
+ * `autoScrollOnLoad` defaults to true, which scrolls the LATEST message
+ * into view once the detail loads. Inline expand contexts may want this
+ * set to false to avoid yanking the page when a row opens far down the
+ * list.
+ */
+export function ThreadMessages({
+  threadId,
+  seedParticipants,
+  recipientName,
+  onOpenPerson,
+  autoScrollOnLoad = true,
+  showReply = true,
+}: {
+  threadId: string;
+  seedParticipants?: ReadonlyArray<Participant>;
+  recipientName?: string | null;
+  onOpenPerson?: (id: string) => void;
+  autoScrollOnLoad?: boolean;
+  showReply?: boolean;
+}) {
+  const [detail, setDetail] = useState<ThreadDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // Load + refresh when the thread changes.
+  useEffect(() => {
+    if (!threadId) {
+      setDetail(null);
+      setError(null);
+      return;
+    }
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    void (async () => {
+      try {
+        const res = await fetch(`/api/crm/inbox/${encodeURIComponent(threadId)}`, {
+          cache: "no-store",
+          signal: controller.signal,
+        });
+        if (!res.ok) {throw new Error(`HTTP ${res.status}`);}
+        const body = (await res.json()) as ThreadDetail;
+        setDetail(body);
+      } catch (err) {
+        if ((err as Error).name === "AbortError") {return;}
+        setError(err instanceof Error ? err.message : "Failed to load this thread.");
+      } finally {
+        setLoading(false);
+      }
+    })();
+    return () => controller.abort();
+  }, [threadId]);
+
+  // Hydrated participant map for MessageCard lookup. Seeded participants
+  // (e.g. from the row's own data) are merged in case the detail fetch
+  // is slow — so chips render immediately rather than as Unknown.
+  const peopleMap = useMemo<Map<string, Participant>>(() => {
+    const map = new Map<string, Participant>();
+    if (detail?.people) {
+      for (const p of detail.people) {map.set(p.id, p);}
+    }
+    if (seedParticipants) {
+      for (const p of seedParticipants) {
+        if (!map.has(p.id)) {map.set(p.id, p);}
+      }
+    }
+    return map;
+  }, [detail, seedParticipants]);
+
+  // Optionally scroll-to-latest on load. We use scrollIntoView on the
+  // CONTAINER's last message rather than mutating a parent scroller, so
+  // this works whether we're inside a dedicated pane or inline-expanded.
+  useEffect(() => {
+    if (!autoScrollOnLoad || !detail || !containerRef.current) {return;}
+    requestAnimationFrame(() => {
+      const last = containerRef.current?.querySelector<HTMLElement>(
+        '[data-thread-message="latest"]',
+      );
+      last?.scrollIntoView({ block: "nearest", behavior: "auto" });
+    });
+  }, [detail, autoScrollOnLoad]);
+
+  if (loading && !detail) {
+    return <CrmLoadingState label="Loading conversation…" />;
+  }
+  if (error) {
+    return <CrmEmptyState title="Couldn't load this thread" description={error} />;
+  }
+  if (detail && detail.messages.length === 0) {
+    return (
+      <CrmEmptyState
+        title="This thread has no messages"
+        description="Likely a stub from a manual insert."
+      />
+    );
+  }
+  if (!detail) {return null;}
+
+  const lastMessageId = detail.messages.at(-1)?.id;
+
+  return (
+    <div ref={containerRef} className="space-y-3">
+      {detail.messages.map((msg) => (
+        <div key={msg.id} data-thread-message={msg.id === lastMessageId ? "latest" : undefined}>
+          <MessageCard
+            message={msg}
+            people={peopleMap}
+            defaultExpanded={msg.id === lastMessageId}
+            onOpenPerson={onOpenPerson}
+          />
+        </div>
+      ))}
+      {showReply && (
+        <div className="pt-3">
+          <QuickReply recipientName={recipientName ?? null} />
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

The CRM inbox email reader rendered marketing HTML emails (MJML / Gmail-rendered) as a tiny scrollable box inside the message card — the iframe was capped at 1200px tall, the conversation column at 768px wide, and the height-measurement logic was failing silently across multiple sandbox / srcdoc layers. This PR rewrites the iframe rendering pipeline end-to-end so an opened email fills the pane width and unfolds to its true natural height inside one continuous scroll.

## Changes

### `conversation-pane.tsx` — full-width pane
- Drop the `mx-auto max-w-3xl` wrapper around `ThreadMessages` so the email view fills the entire conversation pane width instead of being capped at 768px and centered.
- Refactored to a thin shell that delegates message rendering to the new `ThreadMessages` block (see below).

### `message-body.tsx` — bulletproof iframe pipeline
Multiple intertwined bugs that each looked like the same symptom:

1. **Smart srcdoc construction.** Real marketing emails are complete HTML documents (`<!doctype><html><head>…<style>…</style></head><body>…</body></html>`). Wrapping them inside our own `<html><body>` shell produced invalid nested-html parse trees, so `body.scrollHeight` reported only the height of the very top fragment. Now: detect the full-doc case and surgically inject our additions (`<base target=\"_blank\">`, image clamp, measurement script) into the email's existing `<head>`. Fragments still get the full editorial wrapper.

2. **Self-measuring iframe via `postMessage`.** Parent→child `contentDocument.body.scrollHeight` reads were unreliable across sandbox / srcdoc / lazy-load combinations even with `allow-same-origin`. Now we strip every `<script>`, `on*=…` handler, and `javascript:` URL from the email HTML, then inject a tiny script that runs **inside** the iframe, computes `Math.max(body.scrollHeight, body.offsetHeight)`, and `postMessage`s it to the parent on initial paint, every image load, `DOMContentLoaded`, full `load`, every `ResizeObserver` mutation on `body`, and a backstop schedule of `50 / 200 / 500 / 1000 / 2000 / 4000 / 8000 ms`.

3. **Sandbox: `allow-popups allow-popups-to-escape-sandbox allow-scripts`.** No `allow-same-origin` — iframe lives in an opaque origin, so even if a script slipped past `stripScripts` it cannot read parent cookies / storage / DOM. The only outbound channel is `postMessage`, filtered by a per-instance token derived from `useId()`.

4. **No documentElement measurement, no padding feedback.** `documentElement.clientHeight / scrollHeight` reflect the iframe's *current viewport* (i.e. the height we ourselves set), so including them in the max created a runaway loop where the iframe grew by ~8px every tick. Fixed by measuring only `body.{scrollHeight,offsetHeight}` and removing the parent-side `+8` padding (any breathing room belongs in the body's own padding, not in a value that feeds the next measurement).

### `message-card.tsx` — fix React 19 hydration error
The header row was a `<button>` containing clickable To/Cc person chips (also `<button>`s), which is invalid HTML and broke hydration. Re-rendered as `<div role=\"button\" tabIndex={0}>` with explicit Enter/Space handling and `focus-visible:ring-*` styling — same UX, valid HTML, no hydration warnings.

### `thread-messages.tsx` — new reusable conversation reader
Extracted the thread-loading + message-card-list + reply-composer block out of `ConversationPane` so it can be reused by `PersonProfile` / `CompanyProfile` email tabs (where rows expand inline) without duplicating the logic. `ConversationPane` is now a thin shell: sticky `ConversationHeader` + the `ThreadMessages` block in the scroller below.

## Test plan

- [x] `pnpm format:check` clean.
- [x] `pnpm lint` clean for the four touched files (798 pre-existing baseline errors elsewhere are unchanged).
- [x] `pnpm --dir apps/web test` — `app/components/crm/inbox/use-inbox-hotkeys.test.tsx (11 tests)` passes; the 4 failing tests are pre-existing baseline failures in `workspace/objects.test.ts` and `workspace/workspace-switch.test.ts` unrelated to inbox.
- [ ] Manual: open the CRM inbox, pick a long marketing email (e.g. a TikTok Shop / MJML email) — verify the email iframe fills the pane width and stretches to the full natural content height with no internal scrollbar.
- [ ] Manual: open a thread with multiple messages and confirm collapsed/expanded message-card animation still works.
- [ ] Manual: click a `target=\"_blank\"` link inside an email and confirm it opens in a new tab.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the email HTML rendering security/performance profile by enabling `allow-scripts` in a sandboxed iframe and relying on custom sanitization + `postMessage` height measurement, which could introduce XSS/UX regressions if edge cases slip through. Also refactors thread loading/rendering into a shared component, affecting inbox conversation display behavior.
> 
> **Overview**
> **Improves CRM inbox email reading UX** by making HTML email bodies render full-width and expand to their natural height without internal scrolling, using an injected in-iframe measurement script with token-gated `postMessage` updates.
> 
> **Refactors conversation rendering** by extracting thread fetching/message list/reply composer into reusable `ThreadMessages`, leaving `ConversationPane` as a thin shell (header + scroller) and removing the previous centered max-width wrapper.
> 
> **Fixes invalid nested buttons/hydration issues** in `MessageCard` by replacing the clickable header `<button>` with a `div` using `role="button"` and keyboard handlers so To/Cc chip buttons remain valid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d193df2ca45e0f61cff18dcde7cd0ea1f90fa81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->