### PR TITLE
test(web): fix v3.0.0 workspace tests

### DIFF
--- a/apps/web/app/api/workspace/objects.test.ts
+++ b/apps/web/app/api/workspace/objects.test.ts
@@ -17,6 +17,11 @@ vi.mock("@/lib/workspace", () => ({
   findDuckDBForObjectAsync: vi.fn(async () => null),
   getObjectViews: vi.fn(() => ({ views: [], activeView: null })),
   parseRelationValue: vi.fn((v: string | null) => (v ? [v] : [])),
+  pivotViewIdentifier: (objectName: string) => {
+    const normalized = objectName.replace(/-/g, "_");
+    const escaped = normalized.replace(/"/g, '""');
+    return `"v_${escaped}"`;
+  },
   resolveDuckdbBin: vi.fn(() => null),
   discoverDuckDBPaths: vi.fn(() => []),
   discoverDuckDBPathsAsync: vi.fn(async () => []),
@@ -39,6 +44,11 @@ describe("Workspace Objects API", () => {
       findDuckDBForObjectAsync: vi.fn(async () => null),
       getObjectViews: vi.fn(() => ({ views: [], activeView: null })),
       parseRelationValue: vi.fn((v: string | null) => (v ? [v] : [])),
+      pivotViewIdentifier: (objectName: string) => {
+        const normalized = objectName.replace(/-/g, "_");
+        const escaped = normalized.replace(/"/g, '""');
+        return `"v_${escaped}"`;
+      },
       resolveDuckdbBin: vi.fn(() => null),
       discoverDuckDBPaths: vi.fn(() => []),
       discoverDuckDBPathsAsync: vi.fn(async () => []),

--- a/apps/web/app/workspace/workspace-switch.test.ts
+++ b/apps/web/app/workspace/workspace-switch.test.ts
@@ -7,8 +7,6 @@ describe("resetWorkspaceStateOnSwitch", () => {
       setBrowseDir: vi.fn(),
       setActivePath: vi.fn(),
       setContent: vi.fn(),
-      setChatSidebarPreview: vi.fn(),
-      setShowChatSidebar: vi.fn(),
       setActiveSessionId: vi.fn(),
       setActiveSubagentKey: vi.fn(),
       resetMainChat: vi.fn(),
@@ -23,8 +21,6 @@ describe("resetWorkspaceStateOnSwitch", () => {
     expect(deps.setBrowseDir).toHaveBeenCalledWith(null);
     expect(deps.setActivePath).toHaveBeenCalledWith(null);
     expect(deps.setContent).toHaveBeenCalledWith({ kind: "none" });
-    expect(deps.setChatSidebarPreview).toHaveBeenCalledWith(null);
-    expect(deps.setShowChatSidebar).toHaveBeenCalledWith(true);
     expect(deps.setActiveSessionId).toHaveBeenCalledWith(null);
     expect(deps.setActiveSubagentKey).toHaveBeenCalledWith(null);
     expect(deps.resetMainChat).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Aligns web tests with the v3 workspace objects route (pivotViewIdentifier in mocks) and the workspace switch helper after the three-column layout removed legacy chat sidebar preview hooks.

Verification: `pnpm --dir apps/web test app/workspace/workspace-switch.test.ts app/api/workspace/objects.test.ts`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates test mocks/assertions to match recent workspace API and UI state changes; no production logic is modified.
> 
> **Overview**
> Updates web test suites to match recent workspace changes.
> 
> `objects.test.ts` extends the `@/lib/workspace` mock with `pivotViewIdentifier` so object API route tests reflect the v3 objects/fields pivot-view behavior. `workspace-switch.test.ts` drops expectations for legacy chat sidebar preview hooks, aligning with the current `resetWorkspaceStateOnSwitch` dependency shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3528ff8ddd428d8a64f4d13a74085c6bf8a4e54e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->