### PR TITLE
feat(web): CRM helper libs (merge, phones, display names)

### DIFF
--- a/apps/web/lib/object-display-name.test.ts
+++ b/apps/web/lib/object-display-name.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+  displayObjectName,
+  displayObjectNameSingular,
+  splitObjectTokens,
+} from "./object-display-name";
+
+describe("splitObjectTokens", () => {
+  it("splits snake_case", () => {
+    expect(splitObjectTokens("vc_lead")).toEqual(["vc", "lead"]);
+    expect(splitObjectTokens("yc_outreach")).toEqual(["yc", "outreach"]);
+  });
+
+  it("splits kebab-case", () => {
+    expect(splitObjectTokens("vc-lead")).toEqual(["vc", "lead"]);
+    expect(splitObjectTokens("my-company-list")).toEqual(["my", "company", "list"]);
+  });
+
+  it("splits camelCase and PascalCase", () => {
+    expect(splitObjectTokens("vcLead")).toEqual(["vc", "lead"]);
+    expect(splitObjectTokens("MyCompany")).toEqual(["my", "company"]);
+    expect(splitObjectTokens("personOfInterest")).toEqual(["person", "of", "interest"]);
+  });
+
+  it("normalizes mixed input casing", () => {
+    expect(splitObjectTokens("Yc_founder")).toEqual(["yc", "founder"]);
+    expect(splitObjectTokens("VC_Lead")).toEqual(["vc", "lead"]);
+  });
+
+  it("handles all-caps acronym runs in PascalCase", () => {
+    expect(splitObjectTokens("URLPath")).toEqual(["url", "path"]);
+    expect(splitObjectTokens("APIKey")).toEqual(["api", "key"]);
+  });
+
+  it("collapses repeated and surrounding separators", () => {
+    expect(splitObjectTokens("  VC___Lead  ")).toEqual(["vc", "lead"]);
+    expect(splitObjectTokens("--vc--lead--")).toEqual(["vc", "lead"]);
+  });
+
+  it("returns [] for empty / nullish", () => {
+    expect(splitObjectTokens("")).toEqual([]);
+    expect(splitObjectTokens("   ")).toEqual([]);
+    expect(splitObjectTokens(null as unknown as string)).toEqual([]);
+    expect(splitObjectTokens(undefined as unknown as string)).toEqual([]);
+  });
+});
+
+describe("displayObjectName (plural)", () => {
+  it("handles the headline cases from the spec", () => {
+    expect(displayObjectName("vc_lead")).toBe("VC Leads");
+    expect(displayObjectName("Yc_founder")).toBe("YC Founders");
+    expect(displayObjectName("my_company")).toBe("My Companies");
+  });
+
+  it("does not all-cap regular words like 'My'", () => {
+    expect(displayObjectName("my_company")).toBe("My Companies");
+    expect(displayObjectName("my_lead")).toBe("My Leads");
+  });
+
+  it("supports kebab-case and camelCase identifiers", () => {
+    expect(displayObjectName("vc-lead")).toBe("VC Leads");
+    expect(displayObjectName("vcLead")).toBe("VC Leads");
+    expect(displayObjectName("MyCompany")).toBe("My Companies");
+  });
+
+  it("uses irregular plurals for the last token", () => {
+    expect(displayObjectName("person")).toBe("People");
+    expect(displayObjectName("contact_person")).toBe("Contact People");
+    expect(displayObjectName("child")).toBe("Children");
+    expect(displayObjectName("datum")).toBe("Data");
+  });
+
+  it("leaves already-plural inputs alone", () => {
+    expect(displayObjectName("people")).toBe("People");
+    expect(displayObjectName("companies")).toBe("Companies");
+    expect(displayObjectName("vc_leads")).toBe("VC Leads");
+    expect(displayObjectName("yc_companies")).toBe("YC Companies");
+  });
+
+  it("uppercases known acronyms regardless of position", () => {
+    expect(displayObjectName("ai_agent")).toBe("AI Agents");
+    expect(displayObjectName("api_key")).toBe("API Keys");
+    expect(displayObjectName("crm_event")).toBe("CRM Events");
+    expect(displayObjectName("ceo")).toBe("CEOs");
+    expect(displayObjectName("ceos")).toBe("CEOs");
+    expect(displayObjectName("api")).toBe("APIs");
+    expect(displayObjectName("apis")).toBe("APIs");
+    expect(displayObjectName("vc")).toBe("VCs");
+  });
+
+  it("handles single-token, multi-token, and consonant-y endings", () => {
+    expect(displayObjectName("influencer")).toBe("Influencers");
+    expect(displayObjectName("opportunity")).toBe("Opportunities");
+    expect(displayObjectName("address")).toBe("Addresses");
+    expect(displayObjectName("process")).toBe("Processes");
+    expect(displayObjectName("box")).toBe("Boxes");
+    expect(displayObjectName("dish")).toBe("Dishes");
+    expect(displayObjectName("yc_outreach")).toBe("YC Outreaches");
+  });
+
+  it("returns input untouched if nothing splits out", () => {
+    expect(displayObjectName("")).toBe("");
+  });
+});
+
+describe("displayObjectNameSingular", () => {
+  it("returns singular forms of headline cases", () => {
+    expect(displayObjectNameSingular("vc_lead")).toBe("VC Lead");
+    expect(displayObjectNameSingular("Yc_founder")).toBe("YC Founder");
+    expect(displayObjectNameSingular("my_company")).toBe("My Company");
+  });
+
+  it("singularizes already-plural inputs", () => {
+    expect(displayObjectNameSingular("people")).toBe("Person");
+    expect(displayObjectNameSingular("companies")).toBe("Company");
+    expect(displayObjectNameSingular("opportunities")).toBe("Opportunity");
+    expect(displayObjectNameSingular("addresses")).toBe("Address");
+    expect(displayObjectNameSingular("boxes")).toBe("Box");
+    expect(displayObjectNameSingular("dishes")).toBe("Dish");
+  });
+
+  it("leaves already-singular inputs alone", () => {
+    expect(displayObjectNameSingular("vc_lead")).toBe("VC Lead");
+    expect(displayObjectNameSingular("influencer")).toBe("Influencer");
+    expect(displayObjectNameSingular("address")).toBe("Address");
+  });
+
+  it("preserves acronyms in non-final tokens", () => {
+    expect(displayObjectNameSingular("api_key")).toBe("API Key");
+    expect(displayObjectNameSingular("crm_event")).toBe("CRM Event");
+  });
+
+  it("recovers acronym uppercase when last token is a plural acronym", () => {
+    expect(displayObjectNameSingular("ceos")).toBe("CEO");
+    expect(displayObjectNameSingular("apis")).toBe("API");
+    expect(displayObjectNameSingular("vc_ceos")).toBe("VC CEO");
+  });
+});

--- a/apps/web/lib/object-display-name.ts
+++ b/apps/web/lib/object-display-name.ts
@@ -1,0 +1,211 @@
+/**
+ * Display-name helpers for CRM object table identifiers.
+ *
+ * Workspace tables are stored using machine-friendly identifiers
+ * (`vc_lead`, `Yc_founder`, `myCompany`, ...) but the UI should always
+ * show a human-friendly label. These helpers normalize those identifiers
+ * into a single house style:
+ *
+ *   vc_lead       → "VC Leads"   /  singular: "VC Lead"
+ *   Yc_founder    → "YC Founders" /  singular: "YC Founder"
+ *   my_company    → "My Companies" / singular: "My Company"
+ *   yc-outreach   → "YC Outreaches" / singular: "YC Outreach"
+ *   personOfInterest → "Persons Of Interest" — last token pluralized
+ *
+ * Rules:
+ *  - Split on `_`, `-`, and camelCase boundaries.
+ *  - Tokens that match a known acronym (vc, yc, ai, api, …) are uppercased.
+ *  - Other tokens get title-cased.
+ *  - Pluralization (when applicable) is applied to the LAST token only.
+ *  - Already-plural inputs (`people`, `companies`, `leads`) stay plural.
+ *
+ * Raw identifiers are still the source of truth for API calls and routing —
+ * these helpers are display-only.
+ */
+
+const KNOWN_ACRONYMS: ReadonlySet<string> = new Set([
+  // venture / fundraising
+  "vc", "yc", "ipo", "kpi", "kyc", "roi", "mrr", "arr",
+  // tech
+  "ai", "ml", "llm", "nlp", "api", "sdk", "url", "uri", "uuid",
+  "ios", "css", "html", "json", "yaml", "sql",
+  // markets
+  "b2b", "b2c", "saas", "iaas", "paas",
+  // titles
+  "ceo", "cto", "cfo", "coo", "cmo", "cro", "vp",
+  // sales / cs
+  "sdr", "bdr", "ae", "am", "csm", "crm", "erp",
+  // misc business
+  "hr", "pr", "it", "ip", "id", "qa", "qc", "ux", "ui",
+  "sla", "nda", "msa",
+  // geos
+  "us", "uk", "eu", "uae", "usa",
+]);
+
+const IRREGULAR_PLURALS: ReadonlyMap<string, string> = new Map([
+  ["person", "people"],
+  ["man", "men"],
+  ["woman", "women"],
+  ["child", "children"],
+  ["mouse", "mice"],
+  ["goose", "geese"],
+  ["foot", "feet"],
+  ["tooth", "teeth"],
+  ["datum", "data"],
+  ["criterion", "criteria"],
+  ["phenomenon", "phenomena"],
+  ["leaf", "leaves"],
+  ["life", "lives"],
+  ["wife", "wives"],
+  ["knife", "knives"],
+]);
+
+const IRREGULAR_SINGULARS: ReadonlyMap<string, string> = new Map(
+  Array.from(IRREGULAR_PLURALS.entries(), ([s, p]) => [p, s]),
+);
+
+/**
+ * Singular nouns that *look* plural (end in `s`/`es`) but aren't, so the
+ * "already plural" heuristic shouldn't skip them. Add to this set if a
+ * common CRM term gets mangled.
+ */
+const SINGULAR_LOOKING_PLURAL: ReadonlySet<string> = new Set([
+  "address", "process", "status", "lens", "series", "species",
+  "news", "analysis", "basis", "thesis", "axis",
+  "business", "boss", "class", "glass", "miss", "pass",
+]);
+
+/**
+ * Split a CRM identifier into lowercase tokens.
+ *
+ *   "vc_lead"        → ["vc", "lead"]
+ *   "vc-lead"        → ["vc", "lead"]
+ *   "vcLead"         → ["vc", "lead"]
+ *   "Yc_founder"     → ["yc", "founder"]
+ *   "myCompany"      → ["my", "company"]
+ *   "  VC___Lead  "  → ["vc", "lead"]
+ */
+export function splitObjectTokens(raw: string): string[] {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) return [];
+  return trimmed
+    // camelCase / PascalCase: insert separator before any uppercase that
+    // follows a lowercase or digit, or before an uppercase that's followed
+    // by a lowercase (handles "URLPath" → "URL Path").
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    // Snake / kebab / whitespace separators all collapse to spaces.
+    .replace(/[_\-\s]+/g, " ")
+    .trim()
+    .toLowerCase()
+    .split(" ")
+    .filter(Boolean);
+}
+
+/** Format a single lowercase token: acronym → upper, else title-case. */
+function formatToken(token: string): string {
+  if (!token) return "";
+  if (KNOWN_ACRONYMS.has(token)) return token.toUpperCase();
+  return token.charAt(0).toUpperCase() + token.slice(1);
+}
+
+/** Format the LAST token in plural mode, preserving acronym uppercase
+ *  when the singular form is a known acronym ("ceo" → "CEOs"). */
+function formatLastTokenPlural(token: string): string {
+  if (!token) return "";
+  if (KNOWN_ACRONYMS.has(token)) return `${token.toUpperCase()}s`;
+  if (looksAlreadyPlural(token)) {
+    const singular = singularizeWord(token);
+    if (KNOWN_ACRONYMS.has(singular)) {
+      const suffix = token.slice(singular.length);
+      return `${singular.toUpperCase()}${suffix}`;
+    }
+    return formatToken(token);
+  }
+  const plural = pluralizeWord(token);
+  return plural.charAt(0).toUpperCase() + plural.slice(1);
+}
+
+/** Format the LAST token in singular mode. Recovers acronym-ness even
+ *  when the input is a plural acronym ("ceos" → "CEO"). */
+function formatLastTokenSingular(token: string): string {
+  if (!token) return "";
+  if (KNOWN_ACRONYMS.has(token)) return token.toUpperCase();
+  const singular = singularizeWord(token);
+  if (KNOWN_ACRONYMS.has(singular)) return singular.toUpperCase();
+  return formatToken(singular);
+}
+
+/** Heuristic: does this lowercase word look already-plural? */
+function looksAlreadyPlural(word: string): boolean {
+  if (!word) return false;
+  if (IRREGULAR_SINGULARS.has(word)) return true;
+  if (SINGULAR_LOOKING_PLURAL.has(word)) return false;
+  if (word.endsWith("ies")) return true;
+  if (word.endsWith("ses") || word.endsWith("xes") || word.endsWith("zes")) return true;
+  if (word.endsWith("ches") || word.endsWith("shes")) return true;
+  // Generic "ends in s" — but don't treat 2-letter words (e.g. "is", "us") as plural.
+  if (word.endsWith("s") && word.length > 2 && !word.endsWith("ss")) return true;
+  return false;
+}
+
+/** Pluralize a lowercase English word using simple rules + irregulars. */
+function pluralizeWord(word: string): string {
+  if (!word) return word;
+  if (looksAlreadyPlural(word)) return word;
+  const irregular = IRREGULAR_PLURALS.get(word);
+  if (irregular) return irregular;
+  if (/(s|x|z|ch|sh)$/.test(word)) return `${word}es`;
+  if (/[^aeiou]y$/.test(word)) return `${word.slice(0, -1)}ies`;
+  return `${word}s`;
+}
+
+/** Singularize a lowercase English word using simple rules + irregulars. */
+function singularizeWord(word: string): string {
+  if (!word) return word;
+  const irregular = IRREGULAR_SINGULARS.get(word);
+  if (irregular) return irregular;
+  if (SINGULAR_LOOKING_PLURAL.has(word)) return word;
+  if (word.endsWith("ies") && word.length > 3) return `${word.slice(0, -3)}y`;
+  if (word.endsWith("sses")) return word.slice(0, -2); // addresses → address
+  if (
+    (word.endsWith("ches") || word.endsWith("shes") || word.endsWith("xes") || word.endsWith("zes")) &&
+    word.length > 3
+  ) {
+    return word.slice(0, -2);
+  }
+  if (word.endsWith("s") && !word.endsWith("ss") && word.length > 2) return word.slice(0, -1);
+  return word;
+}
+
+/**
+ * Pretty plural form for an object identifier.
+ *
+ * Used for sidebar nav, page headers, tab titles, and any "search across
+ * the collection" label.
+ */
+export function displayObjectName(raw: string): string {
+  const tokens = splitObjectTokens(raw);
+  if (tokens.length === 0) return raw ?? "";
+  const last = tokens.length - 1;
+  const formatted = tokens.map((t, i) =>
+    i === last ? formatLastTokenPlural(t) : formatToken(t),
+  );
+  return formatted.join(" ");
+}
+
+/**
+ * Pretty singular form for an object identifier.
+ *
+ * Used for action verbs ("Add VC Lead", "Select Company", "Go to YC Founder")
+ * and per-record chip labels.
+ */
+export function displayObjectNameSingular(raw: string): string {
+  const tokens = splitObjectTokens(raw);
+  if (tokens.length === 0) return raw ?? "";
+  const last = tokens.length - 1;
+  const formatted = tokens.map((t, i) =>
+    i === last ? formatLastTokenSingular(t) : formatToken(t),
+  );
+  return formatted.join(" ");
+}

--- a/apps/web/lib/people-merge.test.ts
+++ b/apps/web/lib/people-merge.test.ts
@@ -1,0 +1,500 @@
+/**
+ * Integration tests for `mergeDuplicatePeople`.
+ *
+ * These spin up a real DuckDB file in a temp directory (using the same CLI
+ * the production sync code uses) so we exercise the actual SQL we generate,
+ * not a mock. The seed schema from `assets/seed/schema.sql` provides every
+ * object/field id we reference, so test inserts can use the same
+ * `seed_*` ids as production code.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { execSync } from "node:child_process";
+
+import { findDuplicateGroups, mergeDuplicatePeople } from "./people-merge";
+import { clearCrmFieldMapCache } from "./crm-queries";
+import { duckdbExecOnFileAsync, duckdbQueryAsync, resolveDuckdbBin } from "./workspace";
+
+// ---------------------------------------------------------------------------
+// Test fixture: temp workspace + seeded DuckDB
+// ---------------------------------------------------------------------------
+
+let tempHome = "";
+let workspaceDir = "";
+let dbPath = "";
+
+const SCHEMA_PATH = resolve(__dirname, "../../../assets/seed/schema.sql");
+
+const PEOPLE_OBJECT = "seed_obj_people_00000000000000";
+const FLD_FULLNAME = "seed_fld_people_fullname_000000";
+const FLD_EMAIL = "seed_fld_people_email_000000000";
+const FLD_PHONE = "seed_fld_people_phone_000000000";
+const FLD_COMPANY = "seed_fld_people_company_0000000";
+const FLD_SOURCE = "seed_fld_people_source_00000000";
+const FLD_JOBTITLE = "seed_fld_people_jobtitle_000000";
+
+const FLD_INTERACTION_PERSON = "seed_fld_inter_person_000000000";
+const FLD_INTERACTION_TYPE = "seed_fld_inter_type_00000000000";
+const FLD_INTERACTION_OCCURRED = "seed_fld_inter_occurred_0000000";
+const INTERACTION_OBJECT = "seed_obj_interaction_00000000000";
+
+const FLD_EMTHREAD_PARTICIPANTS = "seed_fld_emthread_people_00000";
+const FLD_EMTHREAD_SUBJECT = "seed_fld_emthread_subject_0000";
+const FLD_EMTHREAD_GMAIL_ID = "seed_fld_emthread_threadid_000";
+const EMAIL_THREAD_OBJECT = "seed_obj_email_thread_000000000";
+
+const FLD_EMMSG_FROM = "seed_fld_emmsg_from_00000000000";
+const FLD_EMMSG_GMAIL_ID = "seed_fld_emmsg_msgid_0000000000";
+const EMAIL_MESSAGE_OBJECT = "seed_obj_email_message_00000000";
+
+function sql(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+async function exec(statement: string): Promise<void> {
+  const ok = await duckdbExecOnFileAsync(dbPath, statement);
+  if (!ok) {
+    throw new Error(`SQL exec failed: ${statement.slice(0, 200)}…`);
+  }
+}
+
+async function insertPerson(params: {
+  id: string;
+  createdAt: string;
+  email?: string | null;
+  phone?: string | null;
+  fullName?: string | null;
+  company?: string | null;
+  source?: string | null;
+  jobTitle?: string | null;
+}): Promise<void> {
+  const stmts: string[] = [];
+  stmts.push(
+    `INSERT INTO entries (id, object_id, created_at, updated_at) VALUES (${sql(params.id)}, ${sql(
+      PEOPLE_OBJECT,
+    )}, TIMESTAMP ${sql(params.createdAt)}, TIMESTAMP ${sql(params.createdAt)});`,
+  );
+  const pushField = (fieldId: string, value: string | null | undefined) => {
+    if (value === null || value === undefined) {return;}
+    stmts.push(
+      `INSERT INTO entry_fields (entry_id, field_id, value) VALUES (${sql(params.id)}, ${sql(
+        fieldId,
+      )}, ${sql(value)});`,
+    );
+  };
+  pushField(FLD_FULLNAME, params.fullName);
+  pushField(FLD_EMAIL, params.email);
+  pushField(FLD_PHONE, params.phone);
+  pushField(FLD_COMPANY, params.company);
+  pushField(FLD_SOURCE, params.source);
+  pushField(FLD_JOBTITLE, params.jobTitle);
+  await exec(stmts.join("\n"));
+}
+
+async function countPeople(): Promise<number> {
+  const rows = await duckdbQueryAsync<{ n: number }>(
+    `SELECT COUNT(*) AS n FROM entries WHERE object_id = ${sql(PEOPLE_OBJECT)};`,
+  );
+  return Number(rows[0]?.n ?? 0);
+}
+
+async function readPersonField(
+  entryId: string,
+  fieldId: string,
+): Promise<string | null> {
+  const rows = await duckdbQueryAsync<{ value: string | null }>(
+    `SELECT value FROM entry_fields WHERE entry_id = ${sql(entryId)} AND field_id = ${sql(
+      fieldId,
+    )};`,
+  );
+  return rows[0]?.value ?? null;
+}
+
+async function entryExists(entryId: string): Promise<boolean> {
+  const rows = await duckdbQueryAsync<{ n: number }>(
+    `SELECT COUNT(*) AS n FROM entries WHERE id = ${sql(entryId)};`,
+  );
+  return Number(rows[0]?.n ?? 0) > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(async () => {
+  if (!resolveDuckdbBin()) {
+    throw new Error(
+      "duckdb CLI not found — install it (e.g. `brew install duckdb`) to run people-merge tests.",
+    );
+  }
+
+  tempHome = mkdtempSync(join(tmpdir(), "denchclaw-people-merge-"));
+  process.env.OPENCLAW_HOME = tempHome;
+  workspaceDir = join(tempHome, ".openclaw-dench", "workspace-test");
+  mkdirSync(workspaceDir, { recursive: true });
+  process.env.OPENCLAW_WORKSPACE = workspaceDir;
+  dbPath = join(workspaceDir, "workspace.duckdb");
+
+  // Apply the full seed schema. We pipe via stdin (not -c) because the
+  // schema file has multiple statements and contains single quotes that
+  // a `-c` arg would mangle through shell escaping.
+  const bin = resolveDuckdbBin()!;
+  const schema = readFileSync(SCHEMA_PATH, "utf-8");
+  execSync(`${bin} ${dbPath}`, { input: schema, encoding: "utf-8", timeout: 30_000 });
+
+  clearCrmFieldMapCache();
+});
+
+afterEach(() => {
+  delete process.env.OPENCLAW_HOME;
+  delete process.env.OPENCLAW_WORKSPACE;
+  if (tempHome) {
+    rmSync(tempHome, { recursive: true, force: true });
+    tempHome = "";
+  }
+  clearCrmFieldMapCache();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("findDuplicateGroups", () => {
+  it("returns [] when no duplicates exist", async () => {
+    await insertPerson({
+      id: "test_p_unique_aaaaaaaaaaaaaaaa",
+      createdAt: "2026-01-01 10:00:00",
+      email: "alone@kubeace.com",
+    });
+    const groups = await findDuplicateGroups();
+    expect(groups).toEqual([]);
+  });
+
+  it("groups two rows whose emails differ only by +tag", async () => {
+    await insertPerson({
+      id: "test_p_dileep_a_aaaaaaaaaaaaaa",
+      createdAt: "2026-01-01 10:00:00",
+      email: "dileep@kubeace.com",
+    });
+    await insertPerson({
+      id: "test_p_dileep_b_bbbbbbbbbbbbbb",
+      createdAt: "2026-01-02 10:00:00",
+      email: "dileep+work@kubeace.com",
+    });
+    const groups = await findDuplicateGroups();
+    expect(groups).toHaveLength(1);
+    expect(groups[0].canonicalId).toBe("test_p_dileep_a_aaaaaaaaaaaaaa");
+    expect(groups[0].loserIds).toEqual(["test_p_dileep_b_bbbbbbbbbbbbbb"]);
+  });
+
+  it("groups two rows that share a normalized phone but not email", async () => {
+    // Use phone numbers that don't collide with seed people (Sarah/James/Maria
+    // /Alex/Priya use 555-234/876/345/567/789-XXXX); 5559991234 is unique.
+    await insertPerson({
+      id: "test_p_phone_a_aaaaaaaaaaaaaaa",
+      createdAt: "2026-01-01 10:00:00",
+      email: "alpha@example.com",
+      phone: "+1 (555) 999-1234",
+    });
+    await insertPerson({
+      id: "test_p_phone_b_bbbbbbbbbbbbbbb",
+      createdAt: "2026-01-02 10:00:00",
+      email: "beta@example.org",
+      phone: "5559991234",
+    });
+    const groups = await findDuplicateGroups();
+    expect(groups).toHaveLength(1);
+    expect(groups[0].canonicalId).toBe("test_p_phone_a_aaaaaaaaaaaaaaa");
+    expect(groups[0].loserIds).toEqual(["test_p_phone_b_bbbbbbbbbbbbbbb"]);
+  });
+
+  it("transitively groups A↔B by email and B↔C by phone into a single component", async () => {
+    await insertPerson({
+      id: "test_p_a_aaaaaaaaaaaaaaaaaaaaa",
+      createdAt: "2026-01-01 10:00:00",
+      email: "shared@kubeace.com",
+    });
+    await insertPerson({
+      id: "test_p_b_bbbbbbbbbbbbbbbbbbbbb",
+      createdAt: "2026-01-02 10:00:00",
+      email: "shared+x@kubeace.com",
+      phone: "555-999-1234",
+    });
+    await insertPerson({
+      id: "test_p_c_ccccccccccccccccccccc",
+      createdAt: "2026-01-03 10:00:00",
+      phone: "+1 555 999 1234",
+    });
+    const groups = await findDuplicateGroups();
+    expect(groups).toHaveLength(1);
+    expect(groups[0].canonicalId).toBe("test_p_a_aaaaaaaaaaaaaaaaaaaaa");
+    expect(new Set(groups[0].loserIds)).toEqual(
+      new Set(["test_p_b_bbbbbbbbbbbbbbbbbbbbb", "test_p_c_ccccccccccccccccccccc"]),
+    );
+  });
+});
+
+describe("mergeDuplicatePeople", () => {
+  it("no-op when there are no duplicates", async () => {
+    await insertPerson({
+      id: "test_p_solo_aaaaaaaaaaaaaaaaaa",
+      createdAt: "2026-01-01 10:00:00",
+      email: "solo@kubeace.com",
+    });
+    const before = await countPeople();
+    const report = await mergeDuplicatePeople();
+    expect(report.groupsFound).toBe(0);
+    expect(report.rowsMerged).toBe(0);
+    expect(await countPeople()).toBe(before);
+  });
+
+  it("collapses email-+tag duplicates onto the older entry", async () => {
+    await insertPerson({
+      id: "test_p_dileep_a_aaaaaaaaaaaaaa",
+      createdAt: "2026-01-01 10:00:00",
+      email: "dileep@kubeace.com",
+      fullName: "Dileep K",
+    });
+    await insertPerson({
+      id: "test_p_dileep_b_bbbbbbbbbbbbbb",
+      createdAt: "2026-01-02 10:00:00",
+      email: "dileep+work@kubeace.com",
+    });
+
+    const beforeCount = await countPeople();
+    const report = await mergeDuplicatePeople();
+
+    expect(report.groupsFound).toBe(1);
+    expect(report.rowsMerged).toBe(1);
+    expect(await entryExists("test_p_dileep_a_aaaaaaaaaaaaaa")).toBe(true);
+    expect(await entryExists("test_p_dileep_b_bbbbbbbbbbbbbb")).toBe(false);
+    expect(await countPeople()).toBe(beforeCount - 1);
+  });
+
+  it("merges by phone when emails differ but normalized phone matches", async () => {
+    await insertPerson({
+      id: "test_p_phone_a_aaaaaaaaaaaaaaa",
+      createdAt: "2026-01-01 10:00:00",
+      email: "alpha@example.com",
+      phone: "+1 (555) 999-1234",
+    });
+    await insertPerson({
+      id: "test_p_phone_b_bbbbbbbbbbbbbbb",
+      createdAt: "2026-01-02 10:00:00",
+      email: "beta@example.org",
+      phone: "5559991234",
+    });
+
+    const report = await mergeDuplicatePeople();
+    expect(report.rowsMerged).toBe(1);
+    expect(await entryExists("test_p_phone_a_aaaaaaaaaaaaaaa")).toBe(true);
+    expect(await entryExists("test_p_phone_b_bbbbbbbbbbbbbbb")).toBe(false);
+  });
+
+  it("transitively collapses 3-way (A↔B by email, B↔C by phone) into one canonical", async () => {
+    await insertPerson({
+      id: "test_p_a_aaaaaaaaaaaaaaaaaaaaa",
+      createdAt: "2026-01-01 10:00:00",
+      email: "shared@kubeace.com",
+    });
+    await insertPerson({
+      id: "test_p_b_bbbbbbbbbbbbbbbbbbbbb",
+      createdAt: "2026-01-02 10:00:00",
+      email: "shared+x@kubeace.com",
+      phone: "555-999-1234",
+    });
+    await insertPerson({
+      id: "test_p_c_ccccccccccccccccccccc",
+      createdAt: "2026-01-03 10:00:00",
+      phone: "+1 555 999 1234",
+    });
+
+    const report = await mergeDuplicatePeople();
+    expect(report.groupsFound).toBe(1);
+    expect(report.rowsMerged).toBe(2);
+    expect(await entryExists("test_p_a_aaaaaaaaaaaaaaaaaaaaa")).toBe(true);
+    expect(await entryExists("test_p_b_bbbbbbbbbbbbbbbbbbbbb")).toBe(false);
+    expect(await entryExists("test_p_c_ccccccccccccccccccccc")).toBe(false);
+  });
+
+  it("copies loser fields onto canonical only when canonical has no value", async () => {
+    // Canonical: has Source=Gmail (older), no name, no Job Title.
+    await insertPerson({
+      id: "test_p_canon_aaaaaaaaaaaaaaaaa",
+      createdAt: "2026-01-01 10:00:00",
+      email: "user@kubeace.com",
+      source: "Gmail",
+    });
+    // Loser: has name + Job Title + a different Source.
+    await insertPerson({
+      id: "test_p_loser_bbbbbbbbbbbbbbbbb",
+      createdAt: "2026-01-02 10:00:00",
+      email: "user+work@kubeace.com",
+      fullName: "User McUserface",
+      source: "Calendar",
+      jobTitle: "Eng",
+    });
+
+    await mergeDuplicatePeople();
+
+    // Source: canonical wins because it already had a value.
+    expect(await readPersonField("test_p_canon_aaaaaaaaaaaaaaaaa", FLD_SOURCE)).toBe("Gmail");
+    // Full Name: canonical was empty, loser's value gets copied across.
+    expect(await readPersonField("test_p_canon_aaaaaaaaaaaaaaaaa", FLD_FULLNAME)).toBe(
+      "User McUserface",
+    );
+    // Job Title: only the loser had it, so it lands on canonical.
+    expect(await readPersonField("test_p_canon_aaaaaaaaaaaaaaaaa", FLD_JOBTITLE)).toBe("Eng");
+  });
+
+  it("rewrites a many_to_one relation (interaction.Person) onto the canonical", async () => {
+    await insertPerson({
+      id: "test_p_canon_aaaaaaaaaaaaaaaaa",
+      createdAt: "2026-01-01 10:00:00",
+      email: "user@kubeace.com",
+    });
+    await insertPerson({
+      id: "test_p_loser_bbbbbbbbbbbbbbbbb",
+      createdAt: "2026-01-02 10:00:00",
+      email: "user+x@kubeace.com",
+    });
+    // Interaction whose Person points at the loser.
+    const interactionId = "test_int_aaaaaaaaaaaaaaaaaaaaaa";
+    await exec(
+      [
+        `INSERT INTO entries (id, object_id, created_at) VALUES (${sql(
+          interactionId,
+        )}, ${sql(INTERACTION_OBJECT)}, TIMESTAMP '2026-01-03 10:00:00');`,
+        `INSERT INTO entry_fields (entry_id, field_id, value) VALUES (${sql(
+          interactionId,
+        )}, ${sql(FLD_INTERACTION_TYPE)}, 'Email');`,
+        `INSERT INTO entry_fields (entry_id, field_id, value) VALUES (${sql(
+          interactionId,
+        )}, ${sql(FLD_INTERACTION_OCCURRED)}, '2026-01-03T10:00:00.000Z');`,
+        `INSERT INTO entry_fields (entry_id, field_id, value) VALUES (${sql(
+          interactionId,
+        )}, ${sql(FLD_INTERACTION_PERSON)}, ${sql(
+          "test_p_loser_bbbbbbbbbbbbbbbbb",
+        )});`,
+      ].join("\n"),
+    );
+
+    const report = await mergeDuplicatePeople();
+    expect(report.relationsRemapped).toBeGreaterThanOrEqual(1);
+
+    // The interaction's Person field should now point at the canonical.
+    expect(await readPersonField(interactionId, FLD_INTERACTION_PERSON)).toBe(
+      "test_p_canon_aaaaaaaaaaaaaaaaa",
+    );
+  });
+
+  it("rewrites many_to_many JSON arrays and dedupes when both ids are present", async () => {
+    await insertPerson({
+      id: "test_p_canon_aaaaaaaaaaaaaaaaa",
+      createdAt: "2026-01-01 10:00:00",
+      email: "user@kubeace.com",
+    });
+    await insertPerson({
+      id: "test_p_loser_bbbbbbbbbbbbbbbbb",
+      createdAt: "2026-01-02 10:00:00",
+      email: "user+x@kubeace.com",
+    });
+    // A third unrelated person who's also in the thread participants.
+    await insertPerson({
+      id: "test_p_other_ccccccccccccccccc",
+      createdAt: "2026-01-01 10:00:00",
+      email: "other@example.com",
+    });
+
+    // Thread containing canonical + loser + other in Participants.
+    const threadId = "test_thr_aaaaaaaaaaaaaaaaaaaaaa";
+    const participantsJson = JSON.stringify([
+      "test_p_canon_aaaaaaaaaaaaaaaaa",
+      "test_p_loser_bbbbbbbbbbbbbbbbb",
+      "test_p_other_ccccccccccccccccc",
+    ]);
+    await exec(
+      [
+        `INSERT INTO entries (id, object_id, created_at) VALUES (${sql(threadId)}, ${sql(
+          EMAIL_THREAD_OBJECT,
+        )}, TIMESTAMP '2026-01-03 10:00:00');`,
+        `INSERT INTO entry_fields (entry_id, field_id, value) VALUES (${sql(threadId)}, ${sql(
+          FLD_EMTHREAD_SUBJECT,
+        )}, 'Test thread');`,
+        `INSERT INTO entry_fields (entry_id, field_id, value) VALUES (${sql(threadId)}, ${sql(
+          FLD_EMTHREAD_GMAIL_ID,
+        )}, 'gmail-thread-1');`,
+        `INSERT INTO entry_fields (entry_id, field_id, value) VALUES (${sql(threadId)}, ${sql(
+          FLD_EMTHREAD_PARTICIPANTS,
+        )}, ${sql(participantsJson)});`,
+      ].join("\n"),
+    );
+
+    await mergeDuplicatePeople();
+
+    const stored = await readPersonField(threadId, FLD_EMTHREAD_PARTICIPANTS);
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored as string) as string[];
+    expect(parsed).toContain("test_p_canon_aaaaaaaaaaaaaaaaa");
+    expect(parsed).toContain("test_p_other_ccccccccccccccccc");
+    expect(parsed).not.toContain("test_p_loser_bbbbbbbbbbbbbbbbb");
+    // Dedupe: canonical should appear exactly once, even though the original
+    // array had both canonical + loser before remap.
+    expect(parsed.filter((id) => id === "test_p_canon_aaaaaaaaaaaaaaaaa")).toHaveLength(1);
+  });
+
+  it("is idempotent — second run reports rowsMerged: 0", async () => {
+    await insertPerson({
+      id: "test_p_dileep_a_aaaaaaaaaaaaaa",
+      createdAt: "2026-01-01 10:00:00",
+      email: "dileep@kubeace.com",
+    });
+    await insertPerson({
+      id: "test_p_dileep_b_bbbbbbbbbbbbbb",
+      createdAt: "2026-01-02 10:00:00",
+      email: "dileep+work@kubeace.com",
+    });
+
+    const first = await mergeDuplicatePeople();
+    expect(first.rowsMerged).toBe(1);
+    const second = await mergeDuplicatePeople();
+    expect(second.groupsFound).toBe(0);
+    expect(second.rowsMerged).toBe(0);
+  });
+
+  it("merges email_message.From (many_to_one to people) onto the canonical", async () => {
+    await insertPerson({
+      id: "test_p_canon_aaaaaaaaaaaaaaaaa",
+      createdAt: "2026-01-01 10:00:00",
+      email: "user@kubeace.com",
+    });
+    await insertPerson({
+      id: "test_p_loser_bbbbbbbbbbbbbbbbb",
+      createdAt: "2026-01-02 10:00:00",
+      email: "user+x@kubeace.com",
+    });
+    const messageId = "test_msg_aaaaaaaaaaaaaaaaaaaaaa";
+    await exec(
+      [
+        `INSERT INTO entries (id, object_id, created_at) VALUES (${sql(messageId)}, ${sql(
+          EMAIL_MESSAGE_OBJECT,
+        )}, TIMESTAMP '2026-01-03 10:00:00');`,
+        `INSERT INTO entry_fields (entry_id, field_id, value) VALUES (${sql(messageId)}, ${sql(
+          FLD_EMMSG_GMAIL_ID,
+        )}, 'gmail-msg-1');`,
+        `INSERT INTO entry_fields (entry_id, field_id, value) VALUES (${sql(messageId)}, ${sql(
+          FLD_EMMSG_FROM,
+        )}, ${sql("test_p_loser_bbbbbbbbbbbbbbbbb")});`,
+      ].join("\n"),
+    );
+
+    await mergeDuplicatePeople();
+
+    expect(await readPersonField(messageId, FLD_EMMSG_FROM)).toBe(
+      "test_p_canon_aaaaaaaaaaaaaaaaa",
+    );
+  });
+});

--- a/apps/web/lib/people-merge.ts
+++ b/apps/web/lib/people-merge.ts
@@ -1,0 +1,532 @@
+/**
+ * Auto-merge duplicate `people` entries by normalized email or phone key.
+ *
+ * Why this exists:
+ *
+ *   The Gmail/Calendar sync paths already dedupe in-memory via a
+ *   `normalizeEmailKey -> entry_id` map preloaded from DuckDB
+ *   (see `gmail-sync.ts#buildCacheFromDb` and `ensurePerson`). That works
+ *   while a single sync run is in flight, but if the DB *already* contains
+ *   duplicate rows — from an interrupted backfill, a process crash, a
+ *   future manual import, or an Apollo enrichment pass — the cache
+ *   silently picks one entry_id per key and orphans the others. The
+ *   orphans then keep showing up in the People list and the Team tab on
+ *   the Company profile (the Kubeace duplicate-`dileep@kubeace.com` bug).
+ *
+ * What this does:
+ *
+ *   1. `findDuplicateGroups()` scans every `people` entry, computes a
+ *      normalized key per row (`email:<...>` and/or `phone:<...>`), and
+ *      uses union-find to collapse rows that share *any* key into a
+ *      single connected component. So if A↔B by email and B↔C by phone,
+ *      all three end up in the same group.
+ *
+ *   2. `mergeDuplicatePeople()` picks a canonical winner per group
+ *      (oldest `entries.created_at`, tie-break by id), copies the loser's
+ *      missing scalar fields onto the canonical, rewrites every
+ *      `relation` reference to the loser across all 7 known
+ *      people-relation fields (`email_thread.Participants`,
+ *      `email_message.From|To|Cc`, `calendar_event.Organizer|Attendees`,
+ *      `interaction.Person`), and finally hard-deletes the loser entry +
+ *      its `entry_fields` rows.
+ *
+ * Field-combine rule:
+ *
+ *   For each loser scalar field, copy to canonical *only if the canonical
+ *   doesn't already have a value for that field*. Existing canonical
+ *   values win. We don't trust the loser to be more correct because the
+ *   canonical is the older row and has accumulated more user signals.
+ *
+ *   Strength Score will be re-aggregated by the sync-runner's call to
+ *   `recomputeAllScores()` immediately after merging, so the canonical's
+ *   stale score is replaced with one computed from the union of
+ *   interactions across canonical + (now-remapped) losers.
+ */
+
+import {
+  duckdbExecOnFileAsync,
+  duckdbPathAsync,
+  duckdbQueryAsync,
+  parseRelationValue,
+} from "./workspace";
+import {
+  ONBOARDING_OBJECT_IDS,
+} from "./workspace-schema-migrations";
+import { loadCrmFieldMaps } from "./crm-queries";
+import { normalizeEmailKey } from "./email-domain";
+import { normalizePhoneKey } from "./phone-normalize";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type DuplicateGroup = {
+  /** First key encountered for this group, used for logging only. */
+  representativeKey: string;
+  /** All normalized keys associated with this group (email:* and/or phone:*). */
+  keys: string[];
+  /** Canonical winner — kept after merge. */
+  canonicalId: string;
+  /** Losers — fields copied onto canonical, then deleted. */
+  loserIds: string[];
+};
+
+export type PersonMergeReport = {
+  /** Number of duplicate groups (>1 entries sharing keys). */
+  groupsFound: number;
+  /** Total loser entries deleted across all groups. */
+  rowsMerged: number;
+  /** entry_fields rows copied from a loser onto its canonical. */
+  fieldsCopied: number;
+  /** entry_fields relation rows remapped from loser → canonical. */
+  relationsRemapped: number;
+  /** Wall-clock duration in milliseconds. */
+  durationMs: number;
+};
+
+// ---------------------------------------------------------------------------
+// SQL helpers
+// ---------------------------------------------------------------------------
+
+function sqlString(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+// ---------------------------------------------------------------------------
+// Union-find for transitive grouping
+// ---------------------------------------------------------------------------
+
+class UnionFind {
+  private parent = new Map<string, string>();
+
+  find(x: string): string {
+    let cur = x;
+    while (this.parent.has(cur)) {
+      const p = this.parent.get(cur);
+      if (!p || p === cur) {break;}
+      cur = p;
+    }
+    // Path compression — flatten so future lookups are O(1).
+    let walk = x;
+    while (this.parent.has(walk)) {
+      const p = this.parent.get(walk);
+      if (!p || p === walk) {break;}
+      this.parent.set(walk, cur);
+      walk = p;
+    }
+    return cur;
+  }
+
+  union(a: string, b: string): void {
+    const ra = this.find(a);
+    const rb = this.find(b);
+    if (ra === rb) {return;}
+    this.parent.set(rb, ra);
+  }
+
+  /** Ensure `x` is in the structure even if it has no peers. */
+  add(x: string): void {
+    if (!this.parent.has(x)) {
+      this.parent.set(x, x);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Group discovery
+// ---------------------------------------------------------------------------
+
+type PersonRow = {
+  entry_id: string;
+  created_at: string | null;
+  email: string | null;
+  phone: string | null;
+};
+
+/**
+ * Scan all `people` entries and compute their normalized email + phone keys.
+ * Group by union-find so transitive matches collapse to one component.
+ *
+ * Returns an empty array when there are no duplicates — the sync runner can
+ * skip the (slightly expensive) merge SQL entirely.
+ */
+export async function findDuplicateGroups(): Promise<DuplicateGroup[]> {
+  const fieldMaps = await loadCrmFieldMaps();
+  const emailFieldId = fieldMaps.people["Email Address"];
+  const phoneFieldId = fieldMaps.people["Phone Number"];
+
+  // If neither field is in the workspace yet (fresh / un-migrated DB),
+  // there's nothing to merge.
+  if (!emailFieldId && !phoneFieldId) {return [];}
+
+  const peopleObjectId = ONBOARDING_OBJECT_IDS.people;
+  const emailExpr = emailFieldId
+    ? `MAX(CASE WHEN ef.field_id = ${sqlString(emailFieldId)} THEN ef.value END)`
+    : `NULL`;
+  const phoneExpr = phoneFieldId
+    ? `MAX(CASE WHEN ef.field_id = ${sqlString(phoneFieldId)} THEN ef.value END)`
+    : `NULL`;
+
+  const sql = `
+    SELECT
+      e.id AS entry_id,
+      CAST(e.created_at AS VARCHAR) AS created_at,
+      ${emailExpr} AS email,
+      ${phoneExpr} AS phone
+    FROM entries e
+    LEFT JOIN entry_fields ef ON ef.entry_id = e.id
+    WHERE e.object_id = ${sqlString(peopleObjectId)}
+    GROUP BY e.id, e.created_at
+    ORDER BY e.created_at ASC, e.id ASC;
+  `;
+
+  const rows = await duckdbQueryAsync<PersonRow>(sql);
+  if (rows.length === 0) {return [];}
+
+  // Build (entry_id -> rowMeta) and (key -> [entry_ids]) maps.
+  const meta = new Map<string, { createdAt: string | null }>();
+  const keyToIds = new Map<string, string[]>();
+  for (const row of rows) {
+    meta.set(row.entry_id, { createdAt: row.created_at });
+    const keys: string[] = [];
+    const emailKey = normalizeEmailKey(row.email);
+    if (emailKey) {keys.push(`email:${emailKey}`);}
+    const phoneKey = normalizePhoneKey(row.phone);
+    if (phoneKey) {keys.push(`phone:${phoneKey}`);}
+    for (const key of keys) {
+      let bucket = keyToIds.get(key);
+      if (!bucket) {
+        bucket = [];
+        keyToIds.set(key, bucket);
+      }
+      bucket.push(row.entry_id);
+    }
+  }
+
+  // Union all entries that share any key.
+  const uf = new UnionFind();
+  const idToKeys = new Map<string, string[]>();
+  for (const [key, ids] of keyToIds) {
+    if (ids.length < 2) {continue;}
+    const root = ids[0];
+    uf.add(root);
+    for (const id of ids) {
+      uf.add(id);
+      uf.union(root, id);
+      let kbucket = idToKeys.get(id);
+      if (!kbucket) {
+        kbucket = [];
+        idToKeys.set(id, kbucket);
+      }
+      if (!kbucket.includes(key)) {kbucket.push(key);}
+    }
+  }
+
+  // Bucket entries by their union-find root.
+  const groupsByRoot = new Map<string, string[]>();
+  for (const id of idToKeys.keys()) {
+    const root = uf.find(id);
+    let bucket = groupsByRoot.get(root);
+    if (!bucket) {
+      bucket = [];
+      groupsByRoot.set(root, bucket);
+    }
+    bucket.push(id);
+  }
+
+  const groups: DuplicateGroup[] = [];
+  for (const ids of groupsByRoot.values()) {
+    if (ids.length < 2) {continue;}
+    // Pick canonical: earliest created_at, tie-break by id ascending.
+    const sorted = [...ids].sort((a, b) => {
+      const aMeta = meta.get(a);
+      const bMeta = meta.get(b);
+      const aTs = aMeta?.createdAt ?? "";
+      const bTs = bMeta?.createdAt ?? "";
+      if (aTs !== bTs) {return aTs < bTs ? -1 : 1;}
+      return a < b ? -1 : a > b ? 1 : 0;
+    });
+    const canonicalId = sorted[0];
+    const loserIds = sorted.slice(1);
+    const allKeys = new Set<string>();
+    for (const id of ids) {
+      for (const key of idToKeys.get(id) ?? []) {allKeys.add(key);}
+    }
+    groups.push({
+      representativeKey: idToKeys.get(canonicalId)?.[0] ?? Array.from(allKeys)[0] ?? "",
+      keys: Array.from(allKeys),
+      canonicalId,
+      loserIds,
+    });
+  }
+
+  return groups;
+}
+
+// ---------------------------------------------------------------------------
+// Relation-field metadata
+// ---------------------------------------------------------------------------
+
+type PeopleRelationField = {
+  /** field_id on the related object (e.g. email_message.From's field id). */
+  fieldId: string;
+  /** "many_to_one" stores a single id; "many_to_many" stores a JSON array. */
+  cardinality: "many_to_one" | "many_to_many";
+  /** Human-readable label, used for logging only. */
+  label: string;
+};
+
+/**
+ * Gather every field that holds a relation TO `people`. These are the rows
+ * we need to rewrite when a loser is deleted so dangling FKs don't appear.
+ *
+ * Looked up dynamically via `loadCrmFieldMaps` so a fresh workspace whose
+ * schema is mid-migration doesn't crash on a missing field.
+ */
+async function collectPeopleRelationFields(): Promise<PeopleRelationField[]> {
+  const fm = await loadCrmFieldMaps();
+  const out: PeopleRelationField[] = [];
+  const push = (
+    fieldId: string | undefined,
+    cardinality: PeopleRelationField["cardinality"],
+    label: string,
+  ): void => {
+    if (fieldId) {out.push({ fieldId, cardinality, label });}
+  };
+
+  push(fm.email_thread["Participants"], "many_to_many", "email_thread.Participants");
+  push(fm.email_message["From"], "many_to_one", "email_message.From");
+  push(fm.email_message["To"], "many_to_many", "email_message.To");
+  push(fm.email_message["Cc"], "many_to_many", "email_message.Cc");
+  push(fm.calendar_event["Organizer"], "many_to_one", "calendar_event.Organizer");
+  push(fm.calendar_event["Attendees"], "many_to_many", "calendar_event.Attendees");
+  push(fm.interaction["Person"], "many_to_one", "interaction.Person");
+
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Merge a single (canonical, loser) pair
+// ---------------------------------------------------------------------------
+
+type MergePairCounters = {
+  fieldsCopied: number;
+  relationsRemapped: number;
+};
+
+/**
+ * Build the SQL needed to merge one loser into its canonical winner.
+ * Returns the assembled statements plus counters that the caller folds
+ * into the per-run report. Does NOT execute anything — the caller batches
+ * many pairs and commits once per workspace DB.
+ *
+ * `canonicalFieldIds` is shared mutable state across all pairs in a group:
+ * the caller seeds it with the canonical's *current* field ids, and this
+ * function adds entries for every field it queues an INSERT for. Without
+ * that reservation, two losers in the same group that both supply a field
+ * the canonical lacks would each queue an INSERT, blowing the
+ * `UNIQUE(entry_id, field_id)` constraint when the batch executes.
+ */
+async function planMergePair(params: {
+  canonicalId: string;
+  loserId: string;
+  relationFields: PeopleRelationField[];
+  canonicalFieldIds: Set<string>;
+}): Promise<{ statements: string[]; counters: MergePairCounters }> {
+  const { canonicalId, loserId, relationFields, canonicalFieldIds } = params;
+  const statements: string[] = [];
+  const counters: MergePairCounters = { fieldsCopied: 0, relationsRemapped: 0 };
+
+  // ── 1. Copy loser's missing scalar fields onto the canonical ─────────
+  const loserFields = await duckdbQueryAsync<{ field_id: string; value: string | null }>(
+    `SELECT field_id, value FROM entry_fields WHERE entry_id = ${sqlString(loserId)};`,
+  );
+
+  for (const row of loserFields) {
+    if (canonicalFieldIds.has(row.field_id)) {continue;}
+    if (row.value === null) {continue;}
+    statements.push(
+      `INSERT INTO entry_fields (entry_id, field_id, value) VALUES (${sqlString(
+        canonicalId,
+      )}, ${sqlString(row.field_id)}, ${sqlString(row.value)});`,
+    );
+    counters.fieldsCopied += 1;
+    // Reserve so a later loser in the same group doesn't try to re-copy.
+    canonicalFieldIds.add(row.field_id);
+  }
+
+  // ── 2. Remap relation FKs ────────────────────────────────────────────
+  if (relationFields.length > 0) {
+    // many_to_one: a simple UPDATE per field.
+    const m2oFieldIds = relationFields
+      .filter((f) => f.cardinality === "many_to_one")
+      .map((f) => f.fieldId);
+    if (m2oFieldIds.length > 0) {
+      const inList = m2oFieldIds.map(sqlString).join(", ");
+      // Count first so the report is accurate; UPDATE returns affected
+      // rows but the duckdb CLI doesn't surface that in our exec helper.
+      const m2oCountRows = await duckdbQueryAsync<{ n: number }>(
+        `SELECT COUNT(*) AS n FROM entry_fields WHERE field_id IN (${inList}) AND value = ${sqlString(
+          loserId,
+        )};`,
+      );
+      const m2oCount = Number(m2oCountRows[0]?.n ?? 0);
+      if (m2oCount > 0) {
+        statements.push(
+          `UPDATE entry_fields SET value = ${sqlString(
+            canonicalId,
+          )} WHERE field_id IN (${inList}) AND value = ${sqlString(loserId)};`,
+        );
+        counters.relationsRemapped += m2oCount;
+      }
+    }
+
+    // many_to_many: parse JSON, replace loser with canonical, dedupe, write back.
+    // We do per-row UPDATEs because each row's array is unique. The LIKE
+    // predicate is good enough — the values are quoted UUIDs so no false
+    // positives in practice.
+    const m2mFieldIds = relationFields
+      .filter((f) => f.cardinality === "many_to_many")
+      .map((f) => f.fieldId);
+    if (m2mFieldIds.length > 0) {
+      const inList = m2mFieldIds.map(sqlString).join(", ");
+      const safeLoserForLike = loserId.replace(/'/g, "''");
+      const m2mRows = await duckdbQueryAsync<{
+        id: string;
+        value: string;
+      }>(
+        `SELECT id, value FROM entry_fields WHERE field_id IN (${inList}) AND value LIKE '%"${safeLoserForLike}"%';`,
+      );
+      for (const row of m2mRows) {
+        const ids = parseRelationValue(row.value);
+        const replaced = ids.map((id) => (id === loserId ? canonicalId : id));
+        // Dedupe while preserving order of first occurrence.
+        const seen = new Set<string>();
+        const compact: string[] = [];
+        for (const id of replaced) {
+          if (id && !seen.has(id)) {
+            seen.add(id);
+            compact.push(id);
+          }
+        }
+        const newValue = JSON.stringify(compact);
+        statements.push(
+          `UPDATE entry_fields SET value = ${sqlString(newValue)} WHERE id = ${sqlString(row.id)};`,
+        );
+        counters.relationsRemapped += 1;
+      }
+    }
+  }
+
+  // ── 3. Delete the loser ──────────────────────────────────────────────
+  // CHECKPOINT between the two DELETEs is required: DuckDB's foreign-key
+  // enforcement (entries.id ← entry_fields.entry_id) reads from a stale
+  // index when both deletes happen back-to-back in the same connection,
+  // so the second DELETE bails with "still referenced by a foreign key in
+  // a different table" even though the first DELETE just emptied the
+  // referencing rows. CHECKPOINT flushes the index. We deliberately do
+  // *not* wrap the merge in BEGIN TRANSACTION / COMMIT — DuckDB rejects
+  // CHECKPOINT inside a transaction ("transaction has transaction local
+  // changes") and its FK check appears even more permissive at the
+  // batch level than per-statement, so the auto-commit-per-statement
+  // mode is the path that actually works. Each statement is individually
+  // idempotent (and a re-run of `mergeDuplicatePeople` recovers any
+  // partial mid-batch failure), so we don't lose much by skipping the
+  // explicit transaction.
+  statements.push(`DELETE FROM entry_fields WHERE entry_id = ${sqlString(loserId)};`);
+  statements.push(`CHECKPOINT;`);
+  statements.push(`DELETE FROM entries WHERE id = ${sqlString(loserId)};`);
+
+  return { statements, counters };
+}
+
+// ---------------------------------------------------------------------------
+// Public: run the full merge pass
+// ---------------------------------------------------------------------------
+
+/**
+ * Find and merge every duplicate-people group in the active workspace's
+ * DuckDB. Idempotent: running twice in a row reports `rowsMerged: 0` on
+ * the second run because the first run consolidated everything.
+ *
+ * Designed to be cheap when there's nothing to do: a single GROUP BY
+ * scan of `entries × entry_fields` for the people object. Only runs the
+ * (more expensive) per-pair merge SQL when actual duplicates exist.
+ */
+export async function mergeDuplicatePeople(): Promise<PersonMergeReport> {
+  const startedAt = Date.now();
+  const empty: PersonMergeReport = {
+    groupsFound: 0,
+    rowsMerged: 0,
+    fieldsCopied: 0,
+    relationsRemapped: 0,
+    durationMs: 0,
+  };
+
+  const dbPath = await duckdbPathAsync();
+  if (!dbPath) {
+    return { ...empty, durationMs: Date.now() - startedAt };
+  }
+
+  const groups = await findDuplicateGroups();
+  if (groups.length === 0) {
+    return { ...empty, durationMs: Date.now() - startedAt };
+  }
+
+  const relationFields = await collectPeopleRelationFields();
+
+  let totalFieldsCopied = 0;
+  let totalRelationsRemapped = 0;
+  let totalRowsMerged = 0;
+
+  for (const group of groups) {
+    // Read the canonical's current field ids ONCE per group, then thread
+    // the same Set through every per-loser plan. This prevents two losers
+    // that each supply the same field (e.g. both have a Phone Number the
+    // canonical lacks) from both queuing INSERTs and tripping
+    // `UNIQUE(entry_id, field_id)` when the batch executes.
+    const canonicalFieldIdsRows = await duckdbQueryAsync<{ field_id: string }>(
+      `SELECT field_id FROM entry_fields WHERE entry_id = ${sqlString(group.canonicalId)};`,
+    );
+    const canonicalFieldIds = new Set(canonicalFieldIdsRows.map((r) => r.field_id));
+
+    // Run all statements for the group in one stdin pipe so DuckDB
+    // executes them sequentially in a single CLI process. We don't wrap
+    // in BEGIN/COMMIT (see `planMergePair` for why DuckDB's FK check
+    // forces us into auto-commit). Each statement is individually
+    // idempotent — a partial mid-batch failure is recovered by the next
+    // call to `mergeDuplicatePeople`.
+    const groupStatements: string[] = [];
+    for (const loserId of group.loserIds) {
+      const { statements, counters } = await planMergePair({
+        canonicalId: group.canonicalId,
+        loserId,
+        relationFields,
+        canonicalFieldIds,
+      });
+      groupStatements.push(...statements);
+      totalFieldsCopied += counters.fieldsCopied;
+      totalRelationsRemapped += counters.relationsRemapped;
+    }
+
+    const ok = await duckdbExecOnFileAsync(dbPath, groupStatements.join("\n"));
+    if (!ok) {
+      // Don't throw — keep going so one bad group doesn't block the rest
+      // of a sync run from completing. Surface to stderr for triage.
+      console.error(
+        `[people-merge] failed to merge group with canonical=${group.canonicalId}, ` +
+          `losers=[${group.loserIds.join(",")}], keys=[${group.keys.join(",")}]`,
+      );
+      continue;
+    }
+    totalRowsMerged += group.loserIds.length;
+  }
+
+  return {
+    groupsFound: groups.length,
+    rowsMerged: totalRowsMerged,
+    fieldsCopied: totalFieldsCopied,
+    relationsRemapped: totalRelationsRemapped,
+    durationMs: Date.now() - startedAt,
+  };
+}

--- a/apps/web/lib/phone-normalize.test.ts
+++ b/apps/web/lib/phone-normalize.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { normalizePhoneKey } from "./phone-normalize";
+
+describe("normalizePhoneKey", () => {
+  it("strips formatting characters", () => {
+    expect(normalizePhoneKey("(555) 234-5678")).toBe("5552345678");
+    expect(normalizePhoneKey("555.234.5678")).toBe("5552345678");
+    expect(normalizePhoneKey("555 234 5678")).toBe("5552345678");
+    expect(normalizePhoneKey("555-234-5678")).toBe("5552345678");
+  });
+
+  it("collapses leading 1 on 11-digit US numbers so country-code variants merge", () => {
+    expect(normalizePhoneKey("+1 (555) 234-5678")).toBe("5552345678");
+    expect(normalizePhoneKey("15552345678")).toBe("5552345678");
+    expect(normalizePhoneKey("1-555-234-5678")).toBe("5552345678");
+    expect(normalizePhoneKey("(555) 234-5678")).toBe("5552345678");
+  });
+
+  it("preserves country code on non-11-digit international numbers", () => {
+    expect(normalizePhoneKey("+44 20 7946 0958")).toBe("442079460958");
+    expect(normalizePhoneKey("+91 98765 43210")).toBe("919876543210");
+    expect(normalizePhoneKey("+33 1 23 45 67 89")).toBe("33123456789");
+  });
+
+  it("accepts short but plausible phone numbers (>= 7 digits)", () => {
+    expect(normalizePhoneKey("555-1234")).toBe("5551234");
+    expect(normalizePhoneKey("555 12 34")).toBe("5551234");
+  });
+
+  it("rejects too-short input as junk", () => {
+    expect(normalizePhoneKey("x1234")).toBeNull();
+    expect(normalizePhoneKey("123")).toBeNull();
+    expect(normalizePhoneKey("12345")).toBeNull();
+  });
+
+  it("rejects empty / null / non-string input", () => {
+    expect(normalizePhoneKey("")).toBeNull();
+    expect(normalizePhoneKey("   ")).toBeNull();
+    expect(normalizePhoneKey(null)).toBeNull();
+    expect(normalizePhoneKey(undefined)).toBeNull();
+    // @ts-expect-error - exercising runtime safety
+    expect(normalizePhoneKey(12345)).toBeNull();
+  });
+
+  it("rejects non-numeric junk", () => {
+    expect(normalizePhoneKey("not a phone")).toBeNull();
+    expect(normalizePhoneKey("hello world")).toBeNull();
+  });
+
+  it("is idempotent: feeding the result back returns the same key", () => {
+    const key = normalizePhoneKey("+1 (555) 234-5678");
+    expect(key).not.toBeNull();
+    expect(normalizePhoneKey(key)).toBe(key);
+  });
+});

--- a/apps/web/lib/phone-normalize.ts
+++ b/apps/web/lib/phone-normalize.ts
@@ -1,0 +1,53 @@
+/**
+ * Phone-number normalization for dedup matching.
+ *
+ * The CRM stores phone numbers as free-form strings on the `people.Phone Number`
+ * field. Two records that look identical to a human (`+1 (555) 234-5678` vs
+ * `15552345678` vs `(555) 234-5678`) need to collapse to the same key so the
+ * people-merge engine can recognize them as duplicates.
+ *
+ * Strategy: strip everything that isn't a digit, then chop a leading `1` if
+ * the result is 11 digits long (common North-American "country code or no?"
+ * ambiguity). Anything shorter than 7 digits is rejected — too short to be a
+ * real phone number, almost certainly junk in a phone field.
+ *
+ * For display/href formatting (e.g. `tel:` links) see `normalizePhone` in
+ * `workspace-cell-format.ts`. That helper preserves the leading `+` and is
+ * intentionally less aggressive — display values shouldn't pretend to know
+ * the country code.
+ */
+
+const MIN_DEDUP_DIGITS = 7;
+
+/**
+ * Normalize a phone-number string to a stable dedup key. Returns `null` for
+ * input that doesn't have enough digits to be a real number.
+ *
+ * Examples:
+ *   "+1 (555) 234-5678"  -> "5552345678"
+ *   "15552345678"        -> "5552345678"
+ *   "(555) 234-5678"     -> "5552345678"
+ *   "+44 20 7946 0958"   -> "442079460958"
+ *   "555-1234"           -> "5551234"
+ *   "x1234"              -> null   (only 4 digits)
+ *   ""                   -> null
+ *   null / undefined     -> null
+ */
+export function normalizePhoneKey(input: string | null | undefined): string | null {
+  if (typeof input !== "string") {return null;}
+  const trimmed = input.trim();
+  if (!trimmed) {return null;}
+
+  const digits = trimmed.replace(/\D/g, "");
+  if (digits.length < MIN_DEDUP_DIGITS) {return null;}
+
+  // North-American "1" prefix: 11 digits starting with 1 collapses to 10.
+  // We deliberately don't try to be clever about other country codes; the
+  // 1-prefix case is the one users hit constantly because Gmail / Apollo /
+  // manual entry all flip-flop on whether to include it.
+  if (digits.length === 11 && digits.startsWith("1")) {
+    return digits.slice(1);
+  }
+
+  return digits;
+}


### PR DESCRIPTION
Adds `phone-normalize`, `people-merge`, and `object-display-name` utilities with tests. Downstream PRs wire these into sync, APIs, and UI.

Verification: `pnpm web:build`, `pnpm build`, `pnpm test`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new DuckDB-backed people dedup/merge engine that rewrites relations and deletes rows, which is data-destructive if invoked incorrectly. Changes are currently isolated to new helper modules with extensive tests, but correctness depends on schema/field mapping and SQL behavior.
> 
> **Overview**
> Adds new CRM helper libraries for the web app.
> 
> Introduces `object-display-name` to turn machine identifiers into human-friendly singular/plural labels (tokenizing snake/kebab/camel case, uppercasing known acronyms, and applying last-token pluralization/irregular forms).
> 
> Adds `phone-normalize` and a new `people-merge` module that detects duplicate `people` entries by normalized email/phone (including transitive matches), then merges groups by copying missing fields, remapping known people relations (many-to-one and many-to-many JSON arrays), and deleting loser rows; includes integration tests that run real DuckDB SQL against the seed schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa066d84f9a653753af903956b1c40776a13ea2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->