### PR TITLE
fix(web): sync pipeline, Gmail hydration, inbox body re-fetch

### DIFF
--- a/apps/web/app/api/crm/inbox/[threadId]/route.ts
+++ b/apps/web/app/api/crm/inbox/[threadId]/route.ts
@@ -7,7 +7,15 @@ import {
   safeQuery,
   sqlString,
 } from "@/lib/crm-queries";
-import { hydrateMessageBodies, type MessageNeedingHydration } from "@/lib/gmail-body-hydrate";
+import {
+  bodyLooksLikeHtml,
+  hydrateMessageBodies,
+  type MessageNeedingHydration,
+} from "@/lib/gmail-body-hydrate";
+import {
+  markEmailBodyHydrationAttempted,
+  readEmailBodyHydrationAttempted,
+} from "@/lib/denchclaw-state";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -109,23 +117,59 @@ export async function GET(
     }
   }
 
-  // ─── Lazy-hydrate full bodies from Composio for messages that only
-  // have a preview. The sync stores just the snippet (Composio's verbose
-  // page mode exceeds the gateway 413 cap at 50-message pages), so the
-  // first time a thread is opened we fetch the full bodies in parallel,
-  // persist them back to DuckDB, and merge into the response. Subsequent
-  // opens skip the fetch entirely because `row.body` is now populated.
+  // ─── Lazy-hydrate full bodies from Composio.
+  //
+  // Two cases trigger a fetch:
+  //
+  //   1. Body is empty — the sync stores only the snippet (Composio's
+  //      verbose page mode exceeds the gateway 413 cap at 50-message
+  //      pages), so the first time a thread is opened we fetch the
+  //      full bodies in parallel and persist them back to DuckDB.
+  //
+  //   2. Body is non-empty but doesn't look like HTML — predates the
+  //      extractFullBody bug fix, where Composio's plain-text
+  //      `messageText` was preferred over the actual text/html part.
+  //      We re-fetch once per entry to get the rich HTML body.
+  //
+  // To keep case (2) from re-hitting Composio every single thread open
+  // for genuinely plain-text emails, we persist a marker file of entry
+  // IDs we've already attempted. Once an entry is in the set we skip
+  // it forever (delete the file to force a workspace-wide retry).
+  const attemptedHtmlRehydrate = readEmailBodyHydrationAttempted();
   const toHydrate: MessageNeedingHydration[] = [];
+  const newlyAttempted: string[] = [];
   for (const row of rows) {
-    if ((row.body ?? "").trim() === "" && row.gmail_message_id) {
+    if (!row.gmail_message_id) continue;
+    const entryId = String(row.entry_id);
+    const stored = (row.body ?? "").trim();
+    const bodyEmpty = stored === "";
+    const bodyIsPlainText =
+      !bodyEmpty && !bodyLooksLikeHtml(stored) && !attemptedHtmlRehydrate.has(entryId);
+    if (bodyEmpty || bodyIsPlainText) {
       toHydrate.push({
-        entryId: String(row.entry_id),
+        entryId,
         gmailMessageId: row.gmail_message_id,
       });
+      if (bodyIsPlainText) {
+        newlyAttempted.push(entryId);
+      }
     }
   }
 
   const hydrated = await hydrateMessageBodies(toHydrate);
+
+  // Persist the "attempted" set even when a re-fetch returned the same
+  // plain text (genuine plain-text email) — that's the whole point of
+  // the marker, so we don't keep fetching the same Gmail message every
+  // time the thread is opened.
+  if (newlyAttempted.length > 0 && !hydrated.skipped) {
+    try {
+      markEmailBodyHydrationAttempted(newlyAttempted);
+    } catch {
+      // Marker writes are best-effort; failure just means we may
+      // re-attempt one more time on the next request.
+    }
+  }
 
   const messages: Message[] = rows.map((row) => {
     const entryId = String(row.entry_id);
@@ -154,6 +198,7 @@ export async function GET(
       fetched: hydrated.bodies.size,
       failed: hydrated.failed,
       skipped: hydrated.skipped,
+      rehydrated_plain_text: newlyAttempted.length,
     },
   });
 }

--- a/apps/web/app/components/onboarding/sync-step.tsx
+++ b/apps/web/app/components/onboarding/sync-step.tsx
@@ -10,6 +10,7 @@ type ProgressEvent = {
     | "gmail"
     | "calendar"
     | "scoring"
+    | "merging"
     | "complete"
     | "error";
   message: string;
@@ -127,6 +128,8 @@ export function SyncStep({
         return "Loading email";
       case "calendar":
         return "Loading calendar";
+      case "merging":
+        return "Merging duplicates";
       case "scoring":
         return "Ranking relationships";
       case "complete":

--- a/apps/web/lib/denchclaw-state.ts
+++ b/apps/web/lib/denchclaw-state.ts
@@ -29,6 +29,7 @@ const ONBOARDING_FILENAME = "onboarding.json";
 const CONNECTIONS_FILENAME = "connections.json";
 const SYNC_CURSORS_FILENAME = "sync-cursors.json";
 const PERSONAL_DOMAINS_FILENAME = "personal-domains.json";
+const EMAIL_BODY_HYDRATION_FILENAME = "email-body-hydration-attempted.json";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -426,5 +427,77 @@ export function writePersonalDomainsOverrides(
     updatedAt: nowIso(),
   };
   writeJsonFileAtomic(denchClawFilePath(PERSONAL_DOMAINS_FILENAME, workspaceName), next);
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// Email body HTML re-hydration tracking
+//
+// The Composio Gmail sync used to store plain-text bodies for every
+// message because `extractFullBody` short-circuited on the normalized
+// `messageText` field before walking the MIME tree for HTML. After that
+// bug was fixed, the inbox detail route re-hydrates any stored body
+// that doesn't *look* like HTML so existing data flips to the rich
+// rendering on next open.
+//
+// To keep that re-hydration from hitting Composio every single time a
+// thread is opened on a genuinely plain-text email (e.g. a coworker's
+// reply), we persist the set of email_message entry IDs we've already
+// attempted. Once an entry is in the set we never try again, regardless
+// of whether the attempt successfully produced HTML.
+//
+// Manual recovery: delete this file to force a one-time retry across
+// every plain-text message in the workspace.
+// ---------------------------------------------------------------------------
+
+export type EmailBodyHydrationAttemptedFile = {
+  version: 1;
+  /** Sorted list of email_message entry IDs we've already attempted. */
+  attempted: string[];
+  updatedAt: string;
+};
+
+function defaultEmailBodyHydrationAttempted(): EmailBodyHydrationAttemptedFile {
+  return { version: 1, attempted: [], updatedAt: nowIso() };
+}
+
+export function readEmailBodyHydrationAttempted(
+  workspaceName?: string | null,
+): Set<string> {
+  const raw = readJsonFile<unknown>(
+    denchClawFilePath(EMAIL_BODY_HYDRATION_FILENAME, workspaceName),
+    null,
+  );
+  if (!raw || typeof raw !== "object") {
+    return new Set();
+  }
+  const list = (raw as Record<string, unknown>).attempted;
+  if (!Array.isArray(list)) {
+    return new Set();
+  }
+  return new Set(list.filter((v): v is string => typeof v === "string" && Boolean(v)));
+}
+
+/**
+ * Mark a batch of email_message entry IDs as "we've already attempted
+ * to hydrate their HTML body". Idempotent: re-marking is a no-op for
+ * the on-disk set, but always bumps `updatedAt` for observability.
+ */
+export function markEmailBodyHydrationAttempted(
+  entryIds: ReadonlyArray<string>,
+  workspaceName?: string | null,
+): EmailBodyHydrationAttemptedFile {
+  const current = readEmailBodyHydrationAttempted(workspaceName);
+  for (const id of entryIds) {
+    if (typeof id === "string" && id) {
+      current.add(id);
+    }
+  }
+  const next: EmailBodyHydrationAttemptedFile = {
+    version: 1,
+    attempted: Array.from(current).sort(),
+    updatedAt: nowIso(),
+  };
+  writeJsonFileAtomic(denchClawFilePath(EMAIL_BODY_HYDRATION_FILENAME, workspaceName), next);
   return next;
 }

--- a/apps/web/lib/gmail-body-hydrate.ts
+++ b/apps/web/lib/gmail-body-hydrate.ts
@@ -62,20 +62,23 @@ function decodeBase64Url(value: string): string {
 /**
  * Pull the best body string out of a full Gmail message payload.
  *
- * Preference order:
- *   1. top-level `messageText` (Composio's convenience field)
- *   2. first text/html part found walking the MIME tree (richest render)
- *   3. first text/plain part (fallback)
+ * Preference order — HTML wins so the sandboxed iframe in
+ * `message-body.tsx` can render a real marketing email with images,
+ * links, layout and typography:
+ *
+ *   1. first text/html part found walking the MIME tree (richest render)
+ *   2. first text/plain part walked from the MIME tree
+ *   3. top-level `messageText` (Composio's normalized plain-text body —
+ *      always plain text, never HTML, so it's a fallback only)
  *   4. preview / snippet (very last resort)
  *
- * Returning HTML when available lets the existing sandboxed iframe in
- * `message-body.tsx` render a real email — the prior behavior of keeping
- * only the stripped text would lose images + links inside the body.
+ * IMPORTANT: do not short-circuit on `messageText` before walking the
+ * MIME tree. Composio populates `messageText` with the decoded plain
+ * text body alongside the full payload. Returning it early was the
+ * cause of every newsletter rendering as plain text — the HTML part
+ * was right there in `payload`, we just never looked at it.
  */
 export function extractFullBody(message: ComposioGmailMessage): string {
-  const direct = (message.messageText ?? "").trim();
-  if (direct) return direct;
-
   let htmlBody = "";
   let textBody = "";
 
@@ -100,8 +103,28 @@ export function extractFullBody(message: ComposioGmailMessage): string {
   if (htmlBody) return htmlBody;
   if (textBody) return textBody;
 
+  const direct = (message.messageText ?? "").trim();
+  if (direct) return direct;
+
   const fallback = (message.preview?.body ?? message.snippet ?? "").trim();
   return fallback;
+}
+
+// ---------------------------------------------------------------------------
+// HTML detection — kept in sync with `looksLikeHtml` in
+// `apps/web/app/components/crm/inbox/message-body.tsx`. The client uses
+// the same regex to decide between iframe rendering and the
+// preformatted plain-text fallback; the server uses it to decide
+// whether a stored body is "real" rich content or a stale plain-text
+// body that predates the extractFullBody fix and should be re-hydrated.
+// ---------------------------------------------------------------------------
+
+const HTML_SHAPE_RE =
+  /<!doctype|<html|<body|<head|<table|<div|<p\b|<a\s|<br\s*\/?>|<img\s|<\/[a-z]/i;
+
+export function bodyLooksLikeHtml(input: string | null | undefined): boolean {
+  if (!input) return false;
+  return HTML_SHAPE_RE.test(input);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/lib/gmail-sync.ts
+++ b/apps/web/lib/gmail-sync.ts
@@ -424,47 +424,57 @@ function decodeBase64Url(value: string): string {
 }
 
 function extractBodyPreview(message: ComposioGmailMessage): { preview: string; body: string } {
-  // Body content sources in priority order:
-  //   1. `messageText` — full decoded body, only present when the page was
-  //      fetched with `verbose: true`.
-  //   2. `preview.body` — Composio's HTML-decoded snippet, present in
+  // Body content sources in priority order — HTML wins so that the
+  // sandboxed iframe in the inbox renders a real email instead of a
+  // plain-text mirror image:
+  //   1. text/html part walked from `payload` (richest render).
+  //   2. text/plain part walked from `payload`.
+  //   3. `messageText` — Composio's normalized plain-text body (only
+  //      present when the page was fetched with `verbose: true`; always
+  //      plain text, never HTML).
+  //   4. `preview.body` — Composio's HTML-decoded snippet, present in
   //      both verbose and metadata-only modes.
-  //   3. `snippet` — raw Gmail snippet, only there in raw-API responses.
-  //   4. `payload.parts[]` walk — last-resort decode of base64 part bodies.
-  // We always store *some* preview so the UI doesn't render an empty cell
-  // for "Body Preview"; full body is only persisted when we actually have it.
-  const direct = (message.messageText ?? "").trim();
-  if (direct) {
-    const preview = (message.snippet ?? message.preview?.body ?? direct)
-      .replace(/\s+/g, " ")
-      .slice(0, 500);
-    return { preview, body: direct };
-  }
-
-  const previewBody = (message.preview?.body ?? message.snippet ?? "").trim();
-  if (previewBody) {
-    const preview = previewBody.replace(/\s+/g, " ").slice(0, 500);
-    return { preview, body: "" };
-  }
-
-  const payload = message.payload;
-  const candidates: string[] = [];
+  //   5. `snippet` — raw Gmail snippet, only there in raw-API responses.
+  //
+  // We always store *some* preview so the UI doesn't render an empty
+  // cell for "Body Preview"; the full body is only persisted when we
+  // actually have it (HTML preferred, plain text accepted).
+  let htmlBody = "";
+  let textBody = "";
 
   function walk(part: ComposioGmailMessage["payload"] | undefined): void {
     if (!part) {return;}
     const mime = (part.mimeType ?? "").toLowerCase();
     const data = part.body?.data;
-    if (typeof data === "string" && data && (mime.startsWith("text/") || !mime)) {
-      candidates.push(decodeBase64Url(data));
+    if (typeof data === "string" && data) {
+      const decoded = decodeBase64Url(data);
+      if (decoded) {
+        if (mime.startsWith("text/html") && !htmlBody) {
+          htmlBody = decoded;
+        } else if ((mime.startsWith("text/plain") || !mime) && !textBody) {
+          textBody = decoded;
+        }
+      }
     }
     for (const child of part.parts ?? []) {
       walk(child);
     }
   }
-  walk(payload);
+  walk(message.payload);
 
-  const body = candidates.find((c) => c.trim().length > 0)?.trim() ?? "";
-  const preview = body.replace(/\s+/g, " ").slice(0, 500);
+  const direct = (message.messageText ?? "").trim();
+  const body = htmlBody || textBody || direct || "";
+
+  // Preview should always be plain text — it's shown inline in lists,
+  // not rendered as HTML. Prefer the actual snippets over stripped HTML.
+  const previewSource =
+    (message.snippet ?? "").trim() ||
+    (message.preview?.body ?? "").trim() ||
+    direct ||
+    textBody ||
+    htmlBody;
+  const preview = previewSource.replace(/\s+/g, " ").slice(0, 500);
+
   return { preview, body };
 }
 

--- a/apps/web/lib/sync-runner.ts
+++ b/apps/web/lib/sync-runner.ts
@@ -31,6 +31,7 @@ import { recomputeAllScores } from "./strength-score";
 import { ComposioToolNoConnectionError } from "./composio-execute";
 import { ensureLatestSchema } from "./workspace-schema-migrations";
 import { ensureOnboardingObjectDirs, installDefaultViews } from "./onboarding-views";
+import { mergeDuplicatePeople } from "./people-merge";
 
 // ---------------------------------------------------------------------------
 // Public progress event
@@ -42,6 +43,7 @@ export type SyncProgressEvent = {
     | "gmail"
     | "calendar"
     | "scoring"
+    | "merging"
     | "complete"
     | "error"
     | "polling";
@@ -269,6 +271,34 @@ async function runBackfillInner(options: StartBackfillOptions): Promise<void> {
       }
     }
 
+    // ----- Auto-merge duplicate people (by normalized email/phone) -----
+    // Runs *before* scoring so the score recompute reflects the
+    // consolidated people rows (interactions on losers are remapped onto
+    // the canonical winner before we sum up Strength Score).
+    emit({
+      phase: "merging",
+      message: "Merging duplicate contacts…",
+      messagesProcessed: totalMessages,
+      peopleProcessed: totalPeople,
+      companiesProcessed: totalCompanies,
+      threadsProcessed: totalThreads,
+      eventsProcessed: totalEvents,
+    });
+    try {
+      const mergeReport = await mergeDuplicatePeople();
+      if (mergeReport.rowsMerged > 0) {
+        // The People count we surfaced earlier counted post-sync rows
+        // *before* dedupe; subtract the merged-away losers so the
+        // onboarding "X people" headline reflects what the user will
+        // actually see in the workspace.
+        totalPeople = Math.max(0, totalPeople - mergeReport.rowsMerged);
+      }
+    } catch (err) {
+      console.error("[sync-runner] people merge failed:", err);
+      // Non-fatal: a failed merge leaves duplicates in place but the
+      // rest of the workspace is fine. Next poll tick will retry.
+    }
+
     // ----- Score recompute -----
     emit({
       phase: "scoring",
@@ -415,6 +445,15 @@ async function tickPoller(): Promise<void> {
     }
 
     if (didWork) {
+      // Auto-merge any duplicate people that the incremental sync may
+      // have introduced (e.g. an attendee surfaced via Calendar that the
+      // Gmail-side cache hadn't yet seen). Order matters: merge first so
+      // the rescore aggregates over the canonical-only set of people.
+      try {
+        await mergeDuplicatePeople();
+      } catch (err) {
+        console.error("[sync-runner] people merge failed during poll:", err);
+      }
       // Lightweight rescore — runs in foreground so the next render has it.
       try {
         await recomputeAllScores();


### PR DESCRIPTION
See commit message. Depends on merged helper libs for people merge.

Verification: `pnpm web:build`, `pnpm build`, `pnpm test`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync and inbox hydration paths, including mutating persisted DuckDB data (people merges and message bodies) and adding a new on-disk state file; mistakes could cause incorrect contact consolidation or unnecessary refetching.
> 
> **Overview**
> **Improves email body fidelity and backfills rich HTML bodies.** Gmail body extraction now prefers `text/html` MIME parts over Composio’s plain-text `messageText`, and the inbox thread API will re-fetch bodies not only when empty but also when the stored body doesn’t look like HTML (to fix pre-existing plain-text-only rows).
> 
> **Adds persistence to avoid repeated re-fetches.** A new `.denchclaw` JSON file tracks which message entry IDs have already attempted HTML rehydration, and the thread API reports `rehydrated_plain_text` in its hydration stats.
> 
> **Adds a dedupe phase to the sync pipeline.** The sync runner introduces a `merging` phase that runs `mergeDuplicatePeople()` before scoring (and again after incremental poll work), updating onboarding progress labels and adjusting the reported People count after merges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc7e195f14b0efb3e9aae197ae604d682bfdcc8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->