### PR TITLE
feat(web): CRM API routes and shared crm-queries

### DIFF
--- a/apps/web/app/api/crm/calendar/[id]/route.ts
+++ b/apps/web/app/api/crm/calendar/[id]/route.ts
@@ -1,0 +1,151 @@
+import {
+  ONBOARDING_OBJECT_IDS,
+} from "@/lib/workspace-schema-migrations";
+import {
+  buildEntryProjection,
+  hydratePeopleByIds,
+  loadCrmFieldMaps,
+  safeQuery,
+  sqlString,
+} from "@/lib/crm-queries";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * GET /api/crm/calendar/:id
+ *
+ * Returns the full detail for a single calendar_event entry, hydrating
+ * the relation columns (organizer, attendees, companies) so the UI can
+ * render names + avatars without N extra round-trips.
+ *
+ * Shape mirrors the row shape in `apps/web/app/api/crm/calendar/route.ts`
+ * but adds organizer + company hydration that the list call doesn't
+ * bother with.
+ */
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+  const eventId = id?.trim();
+  if (!eventId) {
+    return Response.json({ error: "Missing event id." }, { status: 400 });
+  }
+
+  const fieldMaps = await loadCrmFieldMaps();
+
+  // ─── 1. Event row ─────────────────────────────────────────────────────
+  const projection = buildEntryProjection({
+    objectId: ONBOARDING_OBJECT_IDS.calendar_event,
+    fieldMap: fieldMaps.calendar_event,
+    aliasedFields: [
+      { name: "Title", alias: "title" },
+      { name: "Start At", alias: "start_at" },
+      { name: "End At", alias: "end_at" },
+      { name: "Organizer", alias: "organizer_id" },
+      { name: "Attendees", alias: "attendees_json" },
+      { name: "Companies", alias: "companies_json" },
+      { name: "Meeting Type", alias: "meeting_type" },
+      { name: "Google Event ID", alias: "google_event_id" },
+    ],
+    whereSql: `e.id = ${sqlString(eventId)}`,
+  });
+  const rows = await safeQuery<Record<string, string | null>>(projection);
+  if (rows.length === 0) {
+    return Response.json({ error: "Event not found." }, { status: 404 });
+  }
+  const row = rows[0];
+
+  // ─── 2. Hydrate organizer + attendees in one round-trip ───────────────
+  const attendeeIds = parseRelationIds(row.attendees_json);
+  const organizerId = row.organizer_id?.trim() ? row.organizer_id.trim() : null;
+  const peopleIds = new Set<string>(attendeeIds);
+  if (organizerId) {peopleIds.add(organizerId);}
+
+  const personMap = await hydratePeopleByIds(
+    Array.from(peopleIds),
+    fieldMaps.people,
+  );
+
+  const organizer = organizerId ? personMap.get(organizerId) ?? null : null;
+  const attendees = attendeeIds
+    .map((personId) => personMap.get(personId))
+    .filter((p): p is NonNullable<typeof p> => Boolean(p));
+
+  // ─── 3. Hydrate companies ─────────────────────────────────────────────
+  const companyIds = parseRelationIds(row.companies_json);
+  const companies = await hydrateCompanies(companyIds, fieldMaps.company);
+
+  return Response.json({
+    event: {
+      id: String(row.entry_id),
+      title: row.title,
+      start_at: row.start_at,
+      end_at: row.end_at,
+      meeting_type: row.meeting_type,
+      google_event_id: row.google_event_id,
+    },
+    organizer,
+    attendees,
+    companies,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseRelationIds(value: string | null): string[] {
+  if (!value) {return [];}
+  const trimmed = value.trim();
+  if (!trimmed) {return [];}
+  if (trimmed.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {return parsed.map(String).filter(Boolean);}
+    } catch {
+      return [trimmed];
+    }
+  }
+  return [trimmed];
+}
+
+type CompanyRow = {
+  id: string;
+  name: string | null;
+  domain: string | null;
+};
+
+async function hydrateCompanies(
+  ids: ReadonlyArray<string>,
+  companyFieldMap: Record<string, string>,
+): Promise<CompanyRow[]> {
+  if (ids.length === 0) {return [];}
+  const nameFieldId = companyFieldMap["Company Name"];
+  const domainFieldId = companyFieldMap["Domain"];
+  if (!nameFieldId && !domainFieldId) {return [];}
+
+  const inList = ids.map((id) => `'${id.replace(/'/g, "''")}'`).join(", ");
+  const sql = `
+    SELECT
+      e.id AS company_id,
+      ${nameFieldId ? `MAX(CASE WHEN ef.field_id = '${nameFieldId}' THEN ef.value END)` : "NULL"} AS name,
+      ${domainFieldId ? `MAX(CASE WHEN ef.field_id = '${domainFieldId}' THEN ef.value END)` : "NULL"} AS domain
+    FROM entries e
+    LEFT JOIN entry_fields ef ON ef.entry_id = e.id
+    WHERE e.object_id = '${ONBOARDING_OBJECT_IDS.company}'
+      AND e.id IN (${inList})
+    GROUP BY e.id;
+  `;
+  const rows = await safeQuery<{
+    company_id: string;
+    name: string | null;
+    domain: string | null;
+  }>(sql);
+  return rows.map((row) => ({
+    id: row.company_id,
+    name: row.name,
+    domain: row.domain,
+  }));
+}

--- a/apps/web/app/api/crm/companies/[id]/route.ts
+++ b/apps/web/app/api/crm/companies/[id]/route.ts
@@ -3,6 +3,8 @@ import {
 } from "@/lib/workspace-schema-migrations";
 import {
   buildEntryProjection,
+  buildLatestMessagePerThreadCte,
+  hydratePeopleByIds,
   loadCrmFieldMaps,
   safeQuery,
   sqlString,
@@ -93,12 +95,24 @@ export async function GET(
         { name: "Avatar URL", alias: "avatar_url" },
       ],
     });
+    // Defense-in-depth dedupe: even with `mergeDuplicatePeople` running on
+    // every sync, brand-new duplicates could appear briefly between an
+    // incremental Gmail/Calendar write and the next merge tick. Picking
+    // DISTINCT ON the lowercased email keeps the Team tab clean. Rows
+    // without an email get their own bucket via COALESCE(entry_id) so we
+    // don't accidentally collapse two anonymous people into one.
     const sql = `
-      SELECT * FROM (${peopleProjection}) sub
-      WHERE LOWER(SUBSTR(sub.email, INSTR(sub.email, '@') + 1)) = '${safeDomain}'
-         OR LOWER(SUBSTR(sub.email, INSTR(sub.email, '@') + 1)) LIKE '%.${safeDomain}'
-      ORDER BY TRY_CAST(sub.strength_score AS DOUBLE) DESC NULLS LAST,
-               sub.last_interaction_at DESC NULLS LAST
+      SELECT * FROM (
+        SELECT DISTINCT ON (COALESCE(LOWER(TRIM(sub.email)), sub.entry_id)) sub.*
+        FROM (${peopleProjection}) sub
+        WHERE LOWER(SUBSTR(sub.email, INSTR(sub.email, '@') + 1)) = '${safeDomain}'
+           OR LOWER(SUBSTR(sub.email, INSTR(sub.email, '@') + 1)) LIKE '%.${safeDomain}'
+        ORDER BY COALESCE(LOWER(TRIM(sub.email)), sub.entry_id),
+                 TRY_CAST(sub.strength_score AS DOUBLE) DESC NULLS LAST,
+                 sub.last_interaction_at DESC NULLS LAST
+      ) deduped
+      ORDER BY TRY_CAST(deduped.strength_score AS DOUBLE) DESC NULLS LAST,
+               deduped.last_interaction_at DESC NULLS LAST
       LIMIT 100;
     `;
     const peopleRows = await safeQuery<PersonRow>(sql);
@@ -120,6 +134,8 @@ export async function GET(
   }
 
   // ─── 3. Email threads where Company is in Companies relation ─────────
+  // Returns the same enriched Thread shape as Person profile + Inbox, so
+  // ProfileThreadList can render the inline conversation reader.
   const threadCompaniesFieldId = fieldMaps.email_thread["Companies"];
   let threads: Array<{
     id: string;
@@ -127,6 +143,12 @@ export async function GET(
     last_message_at: string | null;
     message_count: number | null;
     gmail_thread_id: string | null;
+    snippet: string | null;
+    primary_sender_type: string | null;
+    primary_sender_id: string | null;
+    primary_sender_name: string | null;
+    primary_sender_email: string | null;
+    primary_sender_avatar_url: string | null;
   }> = [];
   if (threadCompaniesFieldId) {
     const threadProjection = buildEntryProjection({
@@ -139,26 +161,68 @@ export async function GET(
         { name: "Gmail Thread ID", alias: "gmail_thread_id" },
       ],
     });
-    const safeId = company.id.replace(/"/g, '""').replace(/'/g, "''");
+    const safeCompanyForLike = company.id
+      .replace(/"/g, '""')
+      .replace(/'/g, "''");
+    const safeCompaniesFieldId = threadCompaniesFieldId.replace(/'/g, "''");
+    const candidateThreadsCte = `candidate_threads`;
+    const latestMsg = buildLatestMessagePerThreadCte({
+      emailMessageFieldMap: fieldMaps.email_message,
+      candidateThreadIdsCte: candidateThreadsCte,
+    });
     const sql = `
-      SELECT * FROM (${threadProjection}) sub
-      WHERE EXISTS (
-        SELECT 1 FROM entry_fields c
-        WHERE c.entry_id = sub.entry_id
-          AND c.field_id = '${threadCompaniesFieldId.replace(/'/g, "''")}'
-          AND c.value LIKE '%"${safeId}"%'
-      )
-      ORDER BY last_message_at DESC NULLS LAST
-      LIMIT 50;
+      WITH base AS (${threadProjection}),
+      ${candidateThreadsCte} AS (
+        SELECT entry_id FROM base
+        WHERE EXISTS (
+          SELECT 1 FROM entry_fields c
+          WHERE c.entry_id = base.entry_id
+            AND c.field_id = '${safeCompaniesFieldId}'
+            AND c.value LIKE '%"${safeCompanyForLike}"%'
+        )
+        ORDER BY last_message_at DESC NULLS LAST
+        LIMIT 50
+      )${latestMsg ? `, ${latestMsg.cte}` : ""}
+      SELECT
+        base.*${latestMsg ? `,
+        latest_msg.sender_type AS sender_type,
+        latest_msg.snippet AS snippet,
+        latest_msg.from_person_id AS from_person_id` : `,
+        NULL AS sender_type, NULL AS snippet, NULL AS from_person_id`}
+      FROM base
+      ${latestMsg ? latestMsg.joinClause : ""}
+      WHERE base.entry_id IN (SELECT entry_id FROM ${candidateThreadsCte})
+      ORDER BY base.last_message_at DESC NULLS LAST;
     `;
     const rows = await safeQuery<Record<string, string | null>>(sql);
-    threads = rows.map((row) => ({
-      id: String(row.entry_id),
-      subject: row.subject,
-      last_message_at: row.last_message_at,
-      message_count: row.message_count ? Number(row.message_count) : null,
-      gmail_thread_id: row.gmail_thread_id,
-    }));
+
+    // Hydrate the From-of-latest-message senders for the row chrome.
+    const senderIds = new Set<string>();
+    for (const row of rows) {
+      if (row.from_person_id) {senderIds.add(row.from_person_id);}
+    }
+    const senderMap = await hydratePeopleByIds(
+      Array.from(senderIds),
+      fieldMaps.people,
+    );
+
+    threads = rows.map((row) => {
+      const senderId = row.from_person_id ?? null;
+      const sender = senderId ? senderMap.get(senderId) ?? null : null;
+      return {
+        id: String(row.entry_id),
+        subject: row.subject,
+        last_message_at: row.last_message_at,
+        message_count: row.message_count ? Number(row.message_count) : null,
+        gmail_thread_id: row.gmail_thread_id,
+        snippet: row.snippet,
+        primary_sender_type: row.sender_type,
+        primary_sender_id: senderId,
+        primary_sender_name: sender?.name ?? null,
+        primary_sender_email: sender?.email ?? null,
+        primary_sender_avatar_url: sender?.avatar_url ?? null,
+      };
+    });
   }
 
   // ─── 4. Calendar events where Company is in Companies relation ───────

--- a/apps/web/app/api/crm/people/[id]/activity/route.ts
+++ b/apps/web/app/api/crm/people/[id]/activity/route.ts
@@ -1,0 +1,363 @@
+import {
+  ONBOARDING_OBJECT_IDS,
+} from "@/lib/workspace-schema-migrations";
+import {
+  hydratePeopleByIds,
+  loadCrmFieldMaps,
+  safeQuery,
+  sqlString,
+} from "@/lib/crm-queries";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 200;
+
+/**
+ * GET /api/crm/people/:id/activity?limit=100&offset=0
+ *
+ * Returns the timeline of `interaction` rows for this person, hydrated
+ * with the parent email_message + calendar_event context that the
+ * Activity tab renders. Newest first.
+ *
+ * Each interaction is one atomic event (per-message-per-counterparty
+ * or per-meeting-per-attendee — see strength-score docs); filtering by
+ * `interaction.Person = :id` collapses the per-message-per-recipient
+ * fan-out to "one row per message I exchanged with this person + one
+ * per meeting we both attended", which is the right unit for a
+ * per-person feed.
+ */
+export async function GET(
+  req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+  const personId = id?.trim();
+  if (!personId) {
+    return Response.json({ error: "Missing person id." }, { status: 400 });
+  }
+
+  const url = new URL(req.url);
+  const limit = clampInt(url.searchParams.get("limit"), DEFAULT_LIMIT, MAX_LIMIT);
+  const offset = Math.max(0, parseInt(url.searchParams.get("offset") ?? "0", 10) || 0);
+
+  const fieldMaps = await loadCrmFieldMaps();
+
+  const personRelFieldId = fieldMaps.interaction["Person"];
+  const typeFieldId = fieldMaps.interaction["Type"];
+  const occurredFieldId = fieldMaps.interaction["Occurred At"];
+  const directionFieldId = fieldMaps.interaction["Direction"];
+  const emailRelFieldId = fieldMaps.interaction["Email"];
+  const eventRelFieldId = fieldMaps.interaction["Event"];
+
+  if (!personRelFieldId || !typeFieldId || !occurredFieldId) {
+    return Response.json({
+      activities: [],
+      total: 0,
+      has_more: false,
+    });
+  }
+
+  const safePerson = personId.replace(/'/g, "''");
+
+  // Total count up-front — cheap; lets the client decide whether to
+  // render a "Show more" button without fetching the next page.
+  const countSql = `
+    SELECT COUNT(*) AS total
+    FROM entries e
+    JOIN entry_fields person_rel ON person_rel.entry_id = e.id
+      AND person_rel.field_id = '${personRelFieldId.replace(/'/g, "''")}'
+      AND person_rel.value = '${safePerson}'
+    WHERE e.object_id = '${ONBOARDING_OBJECT_IDS.interaction}';
+  `;
+  const countRows = await safeQuery<{ total: number | string | null }>(countSql);
+  const total = countRows[0]?.total ? Number(countRows[0].total) : 0;
+
+  if (total === 0) {
+    return Response.json({ activities: [], total: 0, has_more: false });
+  }
+
+  // Pivot the requested page of interactions for this person.
+  const pivotSelectParts: string[] = [
+    `e.id AS interaction_id`,
+    `MAX(CASE WHEN ef.field_id = '${typeFieldId.replace(/'/g, "''")}' THEN ef.value END) AS type`,
+    `MAX(CASE WHEN ef.field_id = '${occurredFieldId.replace(/'/g, "''")}' THEN ef.value END) AS occurred_at`,
+  ];
+  if (directionFieldId) {
+    pivotSelectParts.push(
+      `MAX(CASE WHEN ef.field_id = '${directionFieldId.replace(/'/g, "''")}' THEN ef.value END) AS direction`,
+    );
+  } else {
+    pivotSelectParts.push(`NULL AS direction`);
+  }
+  if (emailRelFieldId) {
+    pivotSelectParts.push(
+      `MAX(CASE WHEN ef.field_id = '${emailRelFieldId.replace(/'/g, "''")}' THEN ef.value END) AS email_id`,
+    );
+  } else {
+    pivotSelectParts.push(`NULL AS email_id`);
+  }
+  if (eventRelFieldId) {
+    pivotSelectParts.push(
+      `MAX(CASE WHEN ef.field_id = '${eventRelFieldId.replace(/'/g, "''")}' THEN ef.value END) AS event_id`,
+    );
+  } else {
+    pivotSelectParts.push(`NULL AS event_id`);
+  }
+
+  const interactionsSql = `
+    SELECT * FROM (
+      SELECT
+        ${pivotSelectParts.join(",\n        ")}
+      FROM entries e
+      JOIN entry_fields person_rel ON person_rel.entry_id = e.id
+        AND person_rel.field_id = '${personRelFieldId.replace(/'/g, "''")}'
+        AND person_rel.value = '${safePerson}'
+      LEFT JOIN entry_fields ef ON ef.entry_id = e.id
+      WHERE e.object_id = '${ONBOARDING_OBJECT_IDS.interaction}'
+      GROUP BY e.id
+    ) sub
+    ORDER BY occurred_at DESC NULLS LAST
+    LIMIT ${limit} OFFSET ${offset};
+  `;
+  const interactionRows = await safeQuery<{
+    interaction_id: string;
+    type: string | null;
+    occurred_at: string | null;
+    direction: string | null;
+    email_id: string | null;
+    event_id: string | null;
+  }>(interactionsSql);
+
+  if (interactionRows.length === 0) {
+    return Response.json({
+      activities: [],
+      total,
+      has_more: offset < total,
+    });
+  }
+
+  // Collect referenced email/event/person ids for batched hydration.
+  const emailIds = new Set<string>();
+  const eventIds = new Set<string>();
+  for (const row of interactionRows) {
+    if (row.email_id) {emailIds.add(row.email_id);}
+    if (row.event_id) {eventIds.add(row.event_id);}
+  }
+
+  const [emailMap, eventMap] = await Promise.all([
+    hydrateEmailMessages(emailIds, fieldMaps.email_message),
+    hydrateCalendarEvents(eventIds, fieldMaps.calendar_event),
+  ]);
+
+  // Hydrate "from" people for the email rows in one batched call.
+  const fromPersonIds = new Set<string>();
+  for (const row of emailMap.values()) {
+    if (row.from_id) {fromPersonIds.add(row.from_id);}
+  }
+  const fromPersonMap = await hydratePeopleByIds(
+    Array.from(fromPersonIds),
+    fieldMaps.people,
+  );
+
+  type Activity = {
+    id: string;
+    type: "Email" | "Meeting";
+    direction: "Sent" | "Received" | "Internal" | null;
+    occurred_at: string | null;
+    email: {
+      id: string;
+      thread_id: string | null;
+      subject: string | null;
+      snippet: string | null;
+      from: {
+        id: string;
+        name: string | null;
+        email: string | null;
+        avatar_url: string | null;
+      } | null;
+    } | null;
+    event: {
+      id: string;
+      title: string | null;
+      start_at: string | null;
+      end_at: string | null;
+      meeting_type: string | null;
+    } | null;
+  };
+
+  const activities: Activity[] = interactionRows.map((row) => {
+    const direction = normalizeDirection(row.direction);
+    const type = row.type === "Meeting" ? "Meeting" : "Email";
+
+    let email: Activity["email"] = null;
+    if (type === "Email" && row.email_id) {
+      const msg = emailMap.get(row.email_id);
+      if (msg) {
+        const from = msg.from_id ? fromPersonMap.get(msg.from_id) ?? null : null;
+        email = {
+          id: msg.id,
+          thread_id: msg.thread_id,
+          subject: msg.subject,
+          snippet: msg.preview,
+          from,
+        };
+      }
+    }
+
+    let event: Activity["event"] = null;
+    if (type === "Meeting" && row.event_id) {
+      const ev = eventMap.get(row.event_id);
+      if (ev) {
+        event = {
+          id: ev.id,
+          title: ev.title,
+          start_at: ev.start_at,
+          end_at: ev.end_at,
+          meeting_type: ev.meeting_type,
+        };
+      }
+    }
+
+    return {
+      id: row.interaction_id,
+      type,
+      direction,
+      occurred_at: row.occurred_at,
+      email,
+      event,
+    };
+  });
+
+  return Response.json({
+    activities,
+    total,
+    has_more: offset + activities.length < total,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function clampInt(raw: string | null, fallback: number, max: number): number {
+  const parsed = raw ? parseInt(raw, 10) : NaN;
+  if (!Number.isFinite(parsed) || parsed <= 0) {return fallback;}
+  return Math.min(parsed, max);
+}
+
+function normalizeDirection(value: string | null): "Sent" | "Received" | "Internal" | null {
+  if (value === "Sent" || value === "Received" || value === "Internal") {return value;}
+  return null;
+}
+
+type EmailMessageRow = {
+  id: string;
+  subject: string | null;
+  preview: string | null;
+  from_id: string | null;
+  thread_id: string | null;
+};
+
+async function hydrateEmailMessages(
+  ids: ReadonlySet<string>,
+  fieldMap: Record<string, string>,
+): Promise<Map<string, EmailMessageRow>> {
+  const out = new Map<string, EmailMessageRow>();
+  if (ids.size === 0) {return out;}
+  const subjectFieldId = fieldMap["Subject"];
+  const previewFieldId = fieldMap["Body Preview"];
+  const fromFieldId = fieldMap["From"];
+  const threadFieldId = fieldMap["Thread"];
+  if (!subjectFieldId && !previewFieldId && !fromFieldId && !threadFieldId) {
+    return out;
+  }
+
+  const inList = Array.from(ids).map((eid) => sqlString(eid)).join(", ");
+  const sql = `
+    SELECT
+      e.id AS msg_id,
+      ${subjectFieldId ? `MAX(CASE WHEN ef.field_id = '${subjectFieldId.replace(/'/g, "''")}' THEN ef.value END)` : "NULL"} AS subject,
+      ${previewFieldId ? `MAX(CASE WHEN ef.field_id = '${previewFieldId.replace(/'/g, "''")}' THEN ef.value END)` : "NULL"} AS preview,
+      ${fromFieldId ? `MAX(CASE WHEN ef.field_id = '${fromFieldId.replace(/'/g, "''")}' THEN ef.value END)` : "NULL"} AS from_id,
+      ${threadFieldId ? `MAX(CASE WHEN ef.field_id = '${threadFieldId.replace(/'/g, "''")}' THEN ef.value END)` : "NULL"} AS thread_id
+    FROM entries e
+    LEFT JOIN entry_fields ef ON ef.entry_id = e.id
+    WHERE e.object_id = '${ONBOARDING_OBJECT_IDS.email_message}'
+      AND e.id IN (${inList})
+    GROUP BY e.id;
+  `;
+  const rows = await safeQuery<{
+    msg_id: string;
+    subject: string | null;
+    preview: string | null;
+    from_id: string | null;
+    thread_id: string | null;
+  }>(sql);
+  for (const row of rows) {
+    out.set(row.msg_id, {
+      id: row.msg_id,
+      subject: row.subject,
+      preview: row.preview,
+      from_id: row.from_id ?? null,
+      thread_id: row.thread_id ?? null,
+    });
+  }
+  return out;
+}
+
+type CalendarEventRow = {
+  id: string;
+  title: string | null;
+  start_at: string | null;
+  end_at: string | null;
+  meeting_type: string | null;
+};
+
+async function hydrateCalendarEvents(
+  ids: ReadonlySet<string>,
+  fieldMap: Record<string, string>,
+): Promise<Map<string, CalendarEventRow>> {
+  const out = new Map<string, CalendarEventRow>();
+  if (ids.size === 0) {return out;}
+  const titleFieldId = fieldMap["Title"];
+  const startFieldId = fieldMap["Start At"];
+  const endFieldId = fieldMap["End At"];
+  const meetingTypeFieldId = fieldMap["Meeting Type"];
+  if (!titleFieldId && !startFieldId && !endFieldId && !meetingTypeFieldId) {
+    return out;
+  }
+
+  const inList = Array.from(ids).map((eid) => sqlString(eid)).join(", ");
+  const sql = `
+    SELECT
+      e.id AS evt_id,
+      ${titleFieldId ? `MAX(CASE WHEN ef.field_id = '${titleFieldId.replace(/'/g, "''")}' THEN ef.value END)` : "NULL"} AS title,
+      ${startFieldId ? `MAX(CASE WHEN ef.field_id = '${startFieldId.replace(/'/g, "''")}' THEN ef.value END)` : "NULL"} AS start_at,
+      ${endFieldId ? `MAX(CASE WHEN ef.field_id = '${endFieldId.replace(/'/g, "''")}' THEN ef.value END)` : "NULL"} AS end_at,
+      ${meetingTypeFieldId ? `MAX(CASE WHEN ef.field_id = '${meetingTypeFieldId.replace(/'/g, "''")}' THEN ef.value END)` : "NULL"} AS meeting_type
+    FROM entries e
+    LEFT JOIN entry_fields ef ON ef.entry_id = e.id
+    WHERE e.object_id = '${ONBOARDING_OBJECT_IDS.calendar_event}'
+      AND e.id IN (${inList})
+    GROUP BY e.id;
+  `;
+  const rows = await safeQuery<{
+    evt_id: string;
+    title: string | null;
+    start_at: string | null;
+    end_at: string | null;
+    meeting_type: string | null;
+  }>(sql);
+  for (const row of rows) {
+    out.set(row.evt_id, {
+      id: row.evt_id,
+      title: row.title,
+      start_at: row.start_at,
+      end_at: row.end_at,
+      meeting_type: row.meeting_type,
+    });
+  }
+  return out;
+}

--- a/apps/web/app/api/crm/people/[id]/route.ts
+++ b/apps/web/app/api/crm/people/[id]/route.ts
@@ -3,6 +3,8 @@ import {
 } from "@/lib/workspace-schema-migrations";
 import {
   buildEntryProjection,
+  buildLatestMessagePerThreadCte,
+  hydratePeopleByIds,
   jsonArrayContains,
   loadCrmFieldMaps,
   safeQuery,
@@ -52,6 +54,15 @@ type ThreadSummary = {
   last_message_at: string | null;
   message_count: number | null;
   gmail_thread_id: string | null;
+  /** Snippet from the latest message — powers the row's preview text. */
+  snippet: string | null;
+  /** Sender Type of the latest message; null/Person → no chip in the UI. */
+  primary_sender_type: string | null;
+  /** Headline sender of the latest message — name + email + avatar. */
+  primary_sender_id: string | null;
+  primary_sender_name: string | null;
+  primary_sender_email: string | null;
+  primary_sender_avatar_url: string | null;
 };
 
 type EventSummary = {
@@ -157,6 +168,7 @@ export async function GET(
       `MAX(CASE WHEN ef.field_id = '${participantsFieldId.replace(/'/g, "''")}' THEN ef.value END)`,
       person.id,
     );
+    void containsExpr;
     const threadProjection = buildEntryProjection({
       objectId: ONBOARDING_OBJECT_IDS.email_thread,
       fieldMap: fieldMaps.email_thread,
@@ -167,26 +179,70 @@ export async function GET(
         { name: "Gmail Thread ID", alias: "gmail_thread_id" },
       ],
     });
+    const safePersonForLike = person.id.replace(/"/g, '""').replace(/'/g, "''");
+    const safeParticipantsFieldId = participantsFieldId.replace(/'/g, "''");
+    // Pre-filter the latest-message aggregate to threads this person
+    // participates in — same windowed-aggregate trick as Inbox so the
+    // join only scans messages we actually care about.
+    const candidateThreadsCte = `candidate_threads`;
+    const latestMsg = buildLatestMessagePerThreadCte({
+      emailMessageFieldMap: fieldMaps.email_message,
+      candidateThreadIdsCte: candidateThreadsCte,
+    });
     const threadSql = `
-      SELECT * FROM (${threadProjection}) sub
-      WHERE EXISTS (
-        SELECT 1 FROM entry_fields p
-        WHERE p.entry_id = sub.entry_id
-          AND p.field_id = '${participantsFieldId.replace(/'/g, "''")}'
-          AND p.value LIKE '%"${person.id.replace(/"/g, '""').replace(/'/g, "''")}"%'
-      )
-      ORDER BY last_message_at DESC NULLS LAST
-      LIMIT 50;
+      WITH base AS (${threadProjection}),
+      ${candidateThreadsCte} AS (
+        SELECT entry_id FROM base
+        WHERE EXISTS (
+          SELECT 1 FROM entry_fields p
+          WHERE p.entry_id = base.entry_id
+            AND p.field_id = '${safeParticipantsFieldId}'
+            AND p.value LIKE '%"${safePersonForLike}"%'
+        )
+        ORDER BY last_message_at DESC NULLS LAST
+        LIMIT 50
+      )${latestMsg ? `, ${latestMsg.cte}` : ""}
+      SELECT
+        base.*${latestMsg ? `,
+        latest_msg.sender_type AS sender_type,
+        latest_msg.snippet AS snippet,
+        latest_msg.from_person_id AS from_person_id` : `,
+        NULL AS sender_type, NULL AS snippet, NULL AS from_person_id`}
+      FROM base
+      ${latestMsg ? latestMsg.joinClause : ""}
+      WHERE base.entry_id IN (SELECT entry_id FROM ${candidateThreadsCte})
+      ORDER BY base.last_message_at DESC NULLS LAST;
     `;
-    void containsExpr;
     const threadRows = await safeQuery<Record<string, string | null>>(threadSql);
-    threads = threadRows.map((row) => ({
-      id: String(row.entry_id),
-      subject: row.subject,
-      last_message_at: row.last_message_at,
-      message_count: row.message_count ? Number(row.message_count) : null,
-      gmail_thread_id: row.gmail_thread_id,
-    }));
+
+    // Hydrate the From-of-latest-message senders so each row can show
+    // "Sarah Chen" + avatar without a per-row fetch.
+    const senderIds = new Set<string>();
+    for (const row of threadRows) {
+      if (row.from_person_id) {senderIds.add(row.from_person_id);}
+    }
+    const senderMap = await hydratePeopleByIds(
+      Array.from(senderIds),
+      fieldMaps.people,
+    );
+
+    threads = threadRows.map((row) => {
+      const senderId = row.from_person_id ?? null;
+      const sender = senderId ? senderMap.get(senderId) ?? null : null;
+      return {
+        id: String(row.entry_id),
+        subject: row.subject,
+        last_message_at: row.last_message_at,
+        message_count: row.message_count ? Number(row.message_count) : null,
+        gmail_thread_id: row.gmail_thread_id,
+        snippet: row.snippet,
+        primary_sender_type: row.sender_type,
+        primary_sender_id: senderId,
+        primary_sender_name: sender?.name ?? null,
+        primary_sender_email: sender?.email ?? null,
+        primary_sender_avatar_url: sender?.avatar_url ?? null,
+      };
+    });
   }
 
   // ─── 4. Calendar events where person is in Attendees ──────────────────

--- a/apps/web/app/api/crm/people/route.ts
+++ b/apps/web/app/api/crm/people/route.ts
@@ -157,9 +157,23 @@ export async function GET(req: Request) {
   // list + total into one round trip cuts the warm-path latency in half.
   // `COUNT(*) OVER ()` computes the full filtered total on every row;
   // LIMIT applies after the window so pagination still works correctly.
+  //
+  // The DISTINCT ON deduper sits between `base` (the raw EAV pivot) and
+  // the WHERE/ORDER apply: even with `mergeDuplicatePeople` running on
+  // every sync, brand-new duplicates can appear briefly between an
+  // incremental write and the next merge tick. Rows without an email get
+  // their own bucket via COALESCE(entry_id) so anonymous people don't
+  // accidentally collapse into one.
   const sql = `
-    WITH base AS (${projection})
-    SELECT *, COUNT(*) OVER () AS _total FROM base
+    WITH base AS (${projection}),
+    deduped AS (
+      SELECT DISTINCT ON (COALESCE(LOWER(TRIM(email)), entry_id)) *
+      FROM base
+      ORDER BY COALESCE(LOWER(TRIM(email)), entry_id),
+               TRY_CAST(strength_score AS DOUBLE) DESC NULLS LAST,
+               last_interaction_at DESC NULLS LAST
+    )
+    SELECT *, COUNT(*) OVER () AS _total FROM deduped
     WHERE ${where}
     ORDER BY ${order}
     LIMIT ${pagination.pageSize} OFFSET ${offset};

--- a/apps/web/lib/crm-queries.ts
+++ b/apps/web/lib/crm-queries.ts
@@ -158,3 +158,140 @@ export async function safeQuery<T = Record<string, unknown>>(
     return fallback;
   }
 }
+
+// ---------------------------------------------------------------------------
+// Latest-message-per-thread aggregate
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the SQL fragment that produces a `latest_msg` CTE row per
+ * thread, projecting:
+ *   - thread_id          → email_thread.entry_id this latest msg belongs to
+ *   - sender_type        → Sender Type of the message with max sent_at
+ *   - snippet            → Body Preview of the same message
+ *   - from_person_id     → email_message.From relation entry_id
+ *
+ * Returns `null` when the email_message field map is missing the
+ * critical Thread / Sent At fields (i.e. fresh / un-migrated workspace),
+ * so the caller can branch and emit a no-aggregate fallback.
+ *
+ * If `candidateThreadIdsCte` is provided, the message scan is restricted
+ * to threads whose id is in that CTE — dramatically cheaper when only a
+ * small windowed set of threads is needed (the Inbox uses this; Person /
+ * Company profile pages use it too).
+ */
+export function buildLatestMessagePerThreadCte(params: {
+  emailMessageFieldMap: Record<string, string>;
+  /** Name of an upstream CTE that yields a single column `entry_id`. */
+  candidateThreadIdsCte?: string;
+}): { cte: string; joinClause: string } | null {
+  const fm = params.emailMessageFieldMap;
+  const threadFieldId = fm["Thread"];
+  const sentFieldId = fm["Sent At"];
+  if (!threadFieldId || !sentFieldId) {return null;}
+
+  const senderTypeFieldId = fm["Sender Type"];
+  const previewFieldId = fm["Body Preview"];
+  const fromFieldId = fm["From"];
+
+  const fieldIdsInJoin = [threadFieldId, sentFieldId];
+  if (senderTypeFieldId) {fieldIdsInJoin.push(senderTypeFieldId);}
+  if (previewFieldId) {fieldIdsInJoin.push(previewFieldId);}
+  if (fromFieldId) {fieldIdsInJoin.push(fromFieldId);}
+  const inList = fieldIdsInJoin.map((id) => `'${id.replace(/'/g, "''")}'`).join(", ");
+
+  const candidateFilter = params.candidateThreadIdsCte
+    ? `WHERE m.thread_value IN (SELECT entry_id FROM ${params.candidateThreadIdsCte})`
+    : `WHERE m.thread_value IS NOT NULL`;
+
+  const cte = `
+    latest_msg AS (
+      SELECT
+        thread_value AS thread_id,
+        ${senderTypeFieldId ? "ARG_MAX(sender_type_value, sent_at_value)" : "NULL"} AS sender_type,
+        ${previewFieldId ? "ARG_MAX(preview_value, sent_at_value)" : "NULL"} AS snippet,
+        ${fromFieldId ? "ARG_MAX(from_value, sent_at_value)" : "NULL"} AS from_person_id
+      FROM (
+        SELECT
+          e.id AS msg_id,
+          MAX(CASE WHEN ef.field_id = '${threadFieldId}' THEN ef.value END) AS thread_value,
+          MAX(CASE WHEN ef.field_id = '${sentFieldId}' THEN ef.value END) AS sent_at_value,
+          ${senderTypeFieldId ? `MAX(CASE WHEN ef.field_id = '${senderTypeFieldId}' THEN ef.value END)` : "NULL"} AS sender_type_value,
+          ${previewFieldId ? `MAX(CASE WHEN ef.field_id = '${previewFieldId}' THEN ef.value END)` : "NULL"} AS preview_value,
+          ${fromFieldId ? `MAX(CASE WHEN ef.field_id = '${fromFieldId}' THEN ef.value END)` : "NULL"} AS from_value
+        FROM entries e
+        JOIN entry_fields ef
+          ON ef.entry_id = e.id
+         AND ef.field_id IN (${inList})
+        WHERE e.object_id = '${ONBOARDING_OBJECT_IDS.email_message}'
+        GROUP BY e.id
+      ) m
+      ${candidateFilter}
+      GROUP BY thread_value
+    )
+  `;
+
+  return {
+    cte,
+    joinClause: "LEFT JOIN latest_msg ON latest_msg.thread_id = base.entry_id",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// People hydration by id
+// ---------------------------------------------------------------------------
+
+export type ParticipantRow = {
+  id: string;
+  name: string | null;
+  email: string | null;
+  avatar_url: string | null;
+};
+
+/**
+ * Bulk-hydrate a set of People entries by id. Returns a Map keyed by
+ * person entry_id. Quietly tolerates missing field-map entries (returns
+ * an empty map instead of throwing) so a partially-migrated workspace
+ * never breaks the caller's UX.
+ */
+export async function hydratePeopleByIds(
+  peopleIds: ReadonlyArray<string>,
+  peopleFieldMap: Record<string, string>,
+): Promise<Map<string, ParticipantRow>> {
+  const map = new Map<string, ParticipantRow>();
+  if (peopleIds.length === 0) {return map;}
+
+  const nameFieldId = peopleFieldMap["Full Name"];
+  const emailFieldId = peopleFieldMap["Email Address"];
+  const avatarFieldId = peopleFieldMap["Avatar URL"];
+  if (!nameFieldId && !emailFieldId) {return map;}
+
+  const inList = peopleIds.map((id) => `'${id.replace(/'/g, "''")}'`).join(", ");
+  const sql = `
+    SELECT
+      e.id AS person_id,
+      ${nameFieldId ? `MAX(CASE WHEN ef.field_id = '${nameFieldId}' THEN ef.value END)` : "NULL"} AS name,
+      ${emailFieldId ? `MAX(CASE WHEN ef.field_id = '${emailFieldId}' THEN ef.value END)` : "NULL"} AS email,
+      ${avatarFieldId ? `MAX(CASE WHEN ef.field_id = '${avatarFieldId}' THEN ef.value END)` : "NULL"} AS avatar_url
+    FROM entries e
+    LEFT JOIN entry_fields ef ON ef.entry_id = e.id
+    WHERE e.object_id = '${ONBOARDING_OBJECT_IDS.people}'
+      AND e.id IN (${inList})
+    GROUP BY e.id;
+  `;
+  const rows = await safeQuery<{
+    person_id: string;
+    name: string | null;
+    email: string | null;
+    avatar_url: string | null;
+  }>(sql);
+  for (const row of rows) {
+    map.set(row.person_id, {
+      id: row.person_id,
+      name: row.name,
+      email: row.email,
+      avatar_url: row.avatar_url,
+    });
+  }
+  return map;
+}


### PR DESCRIPTION
Backend support for richer CRM profiles: expanded `crm-queries`, company/people routes, calendar detail, and people activity API.

Verification: `pnpm web:build`, `pnpm build`, `pnpm test`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds several new CRM API endpoints and expands SQL generation/hydration logic, which may affect performance and correctness of CRM profile data (threads/people deduping, activity pagination). Changes are backend-only but touch multiple query paths and rely on dynamic SQL against DuckDB/EAV tables.
> 
> **Overview**
> **Expands the CRM backend API to support richer profile views.** Adds `GET /api/crm/calendar/:id` to return a single calendar event with hydrated organizer/attendees/companies, and adds `GET /api/crm/people/:id/activity` to return a paginated interaction timeline hydrated with related email-message and calendar-event context.
> 
> **Improves profile/list query results and reuse.** Company and person profile thread queries now include latest-message `snippet` and primary sender info (via a shared `buildLatestMessagePerThreadCte` + batched `hydratePeopleByIds`), and the People list + company “team” query add `DISTINCT ON` deduping by normalized email to reduce transient duplicate people entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de1565eea5c1cf9c522db57f33416e6bada78c8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->