### PR TITLE
feat(web): CRM UI — profiles, inbox, calendar, activity

### DIFF
--- a/apps/web/app/components/crm/activity-timeline.test.ts
+++ b/apps/web/app/components/crm/activity-timeline.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { bucketByDate, bucketLabel } from "./activity-timeline";
+
+// Fixed "now" — Thursday, April 16, 2026, 12:00 local.
+// ISO week of that date starts Monday April 13, 2026.
+const NOW = new Date(2026, 3, 16, 12, 0, 0);
+
+function dt(year: number, month1Indexed: number, day: number, hour = 12): Date {
+  return new Date(year, month1Indexed - 1, day, hour, 0, 0);
+}
+
+describe("bucketByDate", () => {
+  it("returns 'today' for the same calendar day", () => {
+    expect(bucketByDate(dt(2026, 4, 16, 8), NOW)).toBe("today");
+    expect(bucketByDate(dt(2026, 4, 16, 23), NOW)).toBe("today");
+  });
+
+  it("returns 'yesterday' for the previous calendar day", () => {
+    expect(bucketByDate(dt(2026, 4, 15, 9), NOW)).toBe("yesterday");
+  });
+
+  it("returns 'this_week' for an earlier day in the current ISO week (Mon-Sun)", () => {
+    // Monday Apr 13 (start of the week) and Tuesday Apr 14 — both in this week,
+    // neither today nor yesterday.
+    expect(bucketByDate(dt(2026, 4, 13, 9), NOW)).toBe("this_week");
+    expect(bucketByDate(dt(2026, 4, 14, 9), NOW)).toBe("this_week");
+  });
+
+  it("returns 'last_week' for the prior Mon-Sun window", () => {
+    // Apr 6 (Mon) and Apr 12 (Sun) bracket last week.
+    expect(bucketByDate(dt(2026, 4, 6, 9), NOW)).toBe("last_week");
+    expect(bucketByDate(dt(2026, 4, 12, 23), NOW)).toBe("last_week");
+  });
+
+  it("returns 'this_month' for earlier days in the same month that aren't this/last week", () => {
+    // Apr 1-5 are in April but before last week's Mon (Apr 6).
+    expect(bucketByDate(dt(2026, 4, 1, 9), NOW)).toBe("this_month");
+    expect(bucketByDate(dt(2026, 4, 5, 9), NOW)).toBe("this_month");
+  });
+
+  it("returns 'older:YYYY-MM' for prior months", () => {
+    expect(bucketByDate(dt(2026, 3, 28, 9), NOW)).toBe("older:2026-03");
+    expect(bucketByDate(dt(2026, 1, 5, 9), NOW)).toBe("older:2026-01");
+    expect(bucketByDate(dt(2025, 12, 31, 9), NOW)).toBe("older:2025-12");
+  });
+
+  it("zero-pads single-digit months in the older bucket key", () => {
+    // February 2026 → "older:2026-02" (not "older:2026-2").
+    expect(bucketByDate(dt(2026, 2, 14, 9), NOW)).toBe("older:2026-02");
+  });
+
+  it("returns 'unknown' for null / undefined / invalid input", () => {
+    expect(bucketByDate(null, NOW)).toBe("unknown");
+    expect(bucketByDate(undefined, NOW)).toBe("unknown");
+    expect(bucketByDate("not-a-date", NOW)).toBe("unknown");
+    expect(bucketByDate(NaN, NOW)).toBe("unknown");
+  });
+
+  it("accepts ISO strings, Date objects, and millisecond timestamps", () => {
+    expect(bucketByDate("2026-04-16T08:00:00", NOW)).toBe("today");
+    expect(bucketByDate(dt(2026, 4, 15, 9), NOW)).toBe("yesterday");
+    expect(bucketByDate(dt(2026, 4, 14, 9).getTime(), NOW)).toBe("this_week");
+  });
+
+  it("handles week boundaries when 'now' is on Monday (today consumes the week's only weekday)", () => {
+    const monday = new Date(2026, 3, 13, 12, 0, 0); // Mon Apr 13
+    // Apr 12 (Sun) of the previous ISO week — should land in last_week, not yesterday.
+    expect(bucketByDate(dt(2026, 4, 12, 9), monday)).toBe("yesterday");
+    // Apr 11 (Sat) — also in last week.
+    expect(bucketByDate(dt(2026, 4, 11, 9), monday)).toBe("last_week");
+  });
+});
+
+describe("bucketLabel", () => {
+  it("renders stable labels for the fixed buckets", () => {
+    expect(bucketLabel("today")).toBe("Today");
+    expect(bucketLabel("yesterday")).toBe("Yesterday");
+    expect(bucketLabel("this_week")).toBe("Earlier this week");
+    expect(bucketLabel("last_week")).toBe("Last week");
+    expect(bucketLabel("this_month")).toBe("Earlier this month");
+    expect(bucketLabel("unknown")).toBe("Unknown date");
+  });
+
+  it("renders 'Month YYYY' for older:YYYY-MM keys", () => {
+    expect(bucketLabel("older:2026-03")).toMatch(/March 2026/);
+    expect(bucketLabel("older:2025-12")).toMatch(/December 2025/);
+    expect(bucketLabel("older:2026-01")).toMatch(/January 2026/);
+  });
+
+  it("returns the raw key for unrecognized formats (defensive fallback)", () => {
+    expect(bucketLabel("garbage")).toBe("garbage");
+  });
+});

--- a/apps/web/app/components/crm/activity-timeline.tsx
+++ b/apps/web/app/components/crm/activity-timeline.tsx
@@ -1,0 +1,655 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Button } from "../ui/button";
+import { CrmEmptyState, CrmLoadingState } from "./crm-list-shell";
+import { formatAbsoluteDate, formatRelativeDate } from "./format-relative-date";
+import { EventDetailBody } from "./event-list-item";
+import { ThreadMessages } from "./inbox/thread-messages";
+
+// ---------------------------------------------------------------------------
+// Public types — mirrors GET /api/crm/people/[id]/activity
+// ---------------------------------------------------------------------------
+
+export type ActivityDirection = "Sent" | "Received" | "Internal" | null;
+
+export type ActivityRow = {
+  id: string;
+  type: "Email" | "Meeting";
+  direction: ActivityDirection;
+  occurred_at: string | null;
+  email: {
+    id: string;
+    thread_id: string | null;
+    subject: string | null;
+    snippet: string | null;
+    from: {
+      id: string;
+      name: string | null;
+      email: string | null;
+      avatar_url: string | null;
+    } | null;
+  } | null;
+  event: {
+    id: string;
+    title: string | null;
+    start_at: string | null;
+    end_at: string | null;
+    meeting_type: string | null;
+  } | null;
+};
+
+type ActivityResponse = {
+  activities: ActivityRow[];
+  total: number;
+  has_more: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Date bucketing
+// ---------------------------------------------------------------------------
+
+/**
+ * Bucket an ISO date into one of the timeline's date sections, relative
+ * to `now`. Pure function — pulled out so we can unit-test the edge
+ * cases (week boundaries, month rollover, missing dates) without
+ * mounting the component.
+ *
+ * Buckets, in display order:
+ *   - "today"
+ *   - "yesterday"
+ *   - "this_week"      (Mon-Sun of the current calendar week, minus today / yesterday)
+ *   - "last_week"      (Mon-Sun of the prior calendar week)
+ *   - "this_month"     (current calendar month, minus everything above)
+ *   - "older:YYYY-MM"  (one bucket per earlier month, e.g. "older:2026-02")
+ *   - "unknown"        (date is null / unparseable)
+ */
+export function bucketByDate(
+  isoOrTs: string | number | Date | null | undefined,
+  now: Date,
+): string {
+  if (isoOrTs === null || isoOrTs === undefined) {return "unknown";}
+  const ts =
+    typeof isoOrTs === "string"
+      ? Date.parse(isoOrTs)
+      : isoOrTs instanceof Date
+        ? isoOrTs.getTime()
+        : isoOrTs;
+  if (!Number.isFinite(ts)) {return "unknown";}
+  const date = new Date(ts);
+
+  if (sameDay(date, now)) {return "today";}
+  const yesterday = new Date(now);
+  yesterday.setDate(now.getDate() - 1);
+  if (sameDay(date, yesterday)) {return "yesterday";}
+
+  // ISO-week boundaries (Mon = start). We compare against the START of
+  // the current and previous weeks, so "this_week" stays well-defined
+  // even when "today"/"yesterday" already consumed those days.
+  const weekStart = startOfIsoWeek(now);
+  const lastWeekStart = new Date(weekStart);
+  lastWeekStart.setDate(weekStart.getDate() - 7);
+  const lastWeekEnd = new Date(weekStart); // exclusive
+
+  if (date >= weekStart && date <= now) {return "this_week";}
+  if (date >= lastWeekStart && date < lastWeekEnd) {return "last_week";}
+
+  // Earlier this month — e.g. it's Apr 18 and the message is Apr 2.
+  if (date.getFullYear() === now.getFullYear() && date.getMonth() === now.getMonth()) {
+    return "this_month";
+  }
+
+  // Older — group by year-month so the headers read "April 2026".
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  return `older:${yyyy}-${mm}`;
+}
+
+/**
+ * Human label for a bucket key. Stable strings for the in-set buckets,
+ * derived "Month YYYY" for the dynamic `older:YYYY-MM` keys.
+ */
+export function bucketLabel(key: string): string {
+  switch (key) {
+    case "today":
+      return "Today";
+    case "yesterday":
+      return "Yesterday";
+    case "this_week":
+      return "Earlier this week";
+    case "last_week":
+      return "Last week";
+    case "this_month":
+      return "Earlier this month";
+    case "unknown":
+      return "Unknown date";
+    default: {
+      const m = /^older:(\d{4})-(\d{2})$/.exec(key);
+      if (!m) {return key;}
+      const year = Number(m[1]);
+      const month = Number(m[2]) - 1;
+      return new Intl.DateTimeFormat(undefined, {
+        month: "long",
+        year: "numeric",
+      }).format(new Date(year, month, 1));
+    }
+  }
+}
+
+const FIXED_BUCKET_ORDER = [
+  "today",
+  "yesterday",
+  "this_week",
+  "last_week",
+  "this_month",
+] as const;
+
+/**
+ * Stable sort comparator for bucket keys: fixed buckets first in their
+ * canonical order, then "older:YYYY-MM" buckets in reverse-chronological
+ * order, and finally "unknown" at the bottom.
+ */
+function compareBuckets(a: string, b: string): number {
+  const ai = FIXED_BUCKET_ORDER.indexOf(a as (typeof FIXED_BUCKET_ORDER)[number]);
+  const bi = FIXED_BUCKET_ORDER.indexOf(b as (typeof FIXED_BUCKET_ORDER)[number]);
+  if (ai !== -1 && bi !== -1) {return ai - bi;}
+  if (ai !== -1) {return -1;}
+  if (bi !== -1) {return 1;}
+  if (a === "unknown") {return 1;}
+  if (b === "unknown") {return -1;}
+  // Both are "older:YYYY-MM" → string compare DESC pushes newer dates up.
+  return a < b ? 1 : a > b ? -1 : 0;
+}
+
+function sameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+function startOfIsoWeek(d: Date): Date {
+  const out = new Date(d);
+  const day = out.getDay();
+  const diff = (day + 6) % 7; // Monday = 0
+  out.setDate(out.getDate() - diff);
+  out.setHours(0, 0, 0, 0);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+const PAGE_SIZE = 100;
+
+/**
+ * Per-person activity timeline. Renders the most recent interactions in
+ * date-bucketed sections (Today / Yesterday / This week / Last week /
+ * Earlier this month / by-month older), with each row expandable inline
+ * to the full email thread (for Email rows) or the meeting detail panel
+ * (for Meeting rows).
+ *
+ * Pagination is "Show more" rather than infinite scroll so the sticky
+ * bucket headers remain stable.
+ */
+export function ActivityTimeline({
+  personId,
+  onOpenPerson,
+  onOpenCompany,
+}: {
+  personId: string;
+  onOpenPerson?: (id: string) => void;
+  onOpenCompany?: (id: string) => void;
+}) {
+  const [items, setItems] = useState<ActivityRow[]>([]);
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const loadPage = useCallback(
+    async (pageOffset: number, signal?: AbortSignal): Promise<ActivityResponse | null> => {
+      const res = await fetch(
+        `/api/crm/people/${encodeURIComponent(personId)}/activity?limit=${PAGE_SIZE}&offset=${pageOffset}`,
+        { cache: "no-store", signal },
+      );
+      if (!res.ok) {throw new Error(`HTTP ${res.status}`);}
+      return (await res.json()) as ActivityResponse;
+    },
+    [personId],
+  );
+
+  // Initial load (and reload when person changes).
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    setItems([]);
+    setOffset(0);
+    setHasMore(false);
+    setExpandedId(null);
+    void (async () => {
+      try {
+        const body = await loadPage(0, controller.signal);
+        if (!body) {return;}
+        setItems(body.activities);
+        setTotal(body.total);
+        setHasMore(body.has_more);
+        setOffset(body.activities.length);
+      } catch (err) {
+        if ((err as Error).name === "AbortError") {return;}
+        setError(err instanceof Error ? err.message : "Failed to load activity.");
+      } finally {
+        setLoading(false);
+      }
+    })();
+    return () => controller.abort();
+  }, [loadPage]);
+
+  const loadMore = useCallback(async () => {
+    if (loadingMore || !hasMore) {return;}
+    setLoadingMore(true);
+    try {
+      const body = await loadPage(offset);
+      if (!body) {return;}
+      setItems((prev) => [...prev, ...body.activities]);
+      setHasMore(body.has_more);
+      setOffset((prev) => prev + body.activities.length);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load more activity.");
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [hasMore, loadPage, loadingMore, offset]);
+
+  const grouped = useMemo(() => {
+    const now = new Date();
+    const buckets = new Map<string, ActivityRow[]>();
+    for (const item of items) {
+      const key = bucketByDate(item.occurred_at, now);
+      if (!buckets.has(key)) {buckets.set(key, []);}
+      buckets.get(key)!.push(item);
+    }
+    return Array.from(buckets.entries())
+      .sort(([a], [b]) => compareBuckets(a, b));
+  }, [items]);
+
+  if (loading && items.length === 0) {
+    return <CrmLoadingState label="Loading activity…" />;
+  }
+  if (error && items.length === 0) {
+    return (
+      <CrmEmptyState
+        title="Couldn't load activity"
+        description={error}
+      />
+    );
+  }
+  if (items.length === 0) {
+    return (
+      <CrmEmptyState
+        title="No activity yet"
+        description="Emails and meetings appear here once they're synced."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {grouped.map(([key, rows]) => (
+        <section key={key}>
+          <h3
+            className="sticky top-0 z-[1] mb-2 px-1 py-1 text-[11px] font-semibold uppercase tracking-[0.16em]"
+            style={{
+              color: "var(--color-text-muted)",
+              background: "var(--color-background)",
+            }}
+          >
+            {bucketLabel(key)}
+          </h3>
+          <ul className="space-y-2">
+            {rows.map((item) => (
+              <ActivityRowItem
+                key={item.id}
+                row={item}
+                expanded={expandedId === item.id}
+                onToggle={() =>
+                  setExpandedId((prev) => (prev === item.id ? null : item.id))
+                }
+                onOpenPerson={onOpenPerson}
+                onOpenCompany={onOpenCompany}
+              />
+            ))}
+          </ul>
+        </section>
+      ))}
+
+      {hasMore && (
+        <div className="flex justify-center pt-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={loadMore}
+            disabled={loadingMore}
+          >
+            {loadingMore
+              ? "Loading…"
+              : `Show more (${(total - items.length).toLocaleString()} remaining)`}
+          </Button>
+        </div>
+      )}
+      {error && items.length > 0 && (
+        <p className="text-center text-[12px]" style={{ color: "var(--color-text-muted)" }}>
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Row
+// ---------------------------------------------------------------------------
+
+const DIRECTION_STYLE: Record<
+  Exclude<ActivityDirection, null>,
+  { label: string; color: string }
+> = {
+  Sent: { label: "You", color: "#22c55e" },
+  Received: { label: "Them", color: "#3b82f6" },
+  Internal: { label: "Internal", color: "#94a3b8" },
+};
+
+function ActivityRowItem({
+  row,
+  expanded,
+  onToggle,
+  onOpenPerson,
+  onOpenCompany,
+}: {
+  row: ActivityRow;
+  expanded: boolean;
+  onToggle: () => void;
+  onOpenPerson?: (id: string) => void;
+  onOpenCompany?: (id: string) => void;
+}) {
+  const dirStyle = row.direction ? DIRECTION_STYLE[row.direction] : null;
+  const tintBg = dirStyle ? `${dirStyle.color}1a` : "var(--color-surface-hover)";
+  const tintFg = dirStyle ? dirStyle.color : "var(--color-text-muted)";
+
+  const title =
+    row.type === "Email"
+      ? row.email?.subject?.trim() || "(no subject)"
+      : row.event?.title?.trim() || "(no title)";
+
+  return (
+    <li
+      className="rounded-xl border overflow-hidden"
+      style={{
+        borderColor: expanded ? "var(--color-accent)" : "var(--color-border)",
+        background: "var(--color-surface)",
+        transition: "border-color 120ms ease",
+      }}
+    >
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded}
+        onClick={onToggle}
+        onKeyDown={(e) => {
+          if (e.target !== e.currentTarget) {return;}
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onToggle();
+          }
+        }}
+        className="grid w-full items-start gap-3 px-4 py-3 text-left cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] transition-colors"
+        style={{ gridTemplateColumns: "auto minmax(0, 1fr) auto" }}
+        onMouseEnter={(e) => {
+          if (expanded) {return;}
+          (e.currentTarget as HTMLElement).style.background =
+            "var(--color-surface-hover)";
+        }}
+        onMouseLeave={(e) => {
+          if (expanded) {return;}
+          (e.currentTarget as HTMLElement).style.background = "transparent";
+        }}
+      >
+        {/* Type icon — direction-tinted circle */}
+        <span
+          className="inline-flex h-7 w-7 items-center justify-center rounded-full shrink-0"
+          style={{
+            background: tintBg,
+            color: tintFg,
+          }}
+          aria-hidden
+        >
+          {row.type === "Email" ? <EnvelopeIcon /> : <CalendarIcon />}
+        </span>
+
+        {/* Body */}
+        <div className="min-w-0">
+          <div className="flex items-baseline gap-2 flex-wrap">
+            <span
+              className="font-instrument truncate"
+              style={{
+                color: "var(--color-text)",
+                fontSize: 14,
+                fontWeight: 600,
+              }}
+            >
+              {title}
+            </span>
+            {dirStyle && (
+              <span
+                className="shrink-0 inline-flex items-center gap-1 rounded-full px-1.5 py-0 text-[10px] uppercase tracking-[0.06em]"
+                style={{
+                  background: `${dirStyle.color}1f`,
+                  color: dirStyle.color,
+                  fontWeight: 600,
+                }}
+              >
+                {dirStyle.label}
+              </span>
+            )}
+          </div>
+          <ContextLine row={row} />
+        </div>
+
+        {/* Time */}
+        <span
+          className="text-right text-[11px] tabular-nums shrink-0"
+          style={{ color: "var(--color-text-muted)" }}
+          title={row.occurred_at ? formatAbsoluteDate(row.occurred_at) : undefined}
+        >
+          {row.occurred_at && formatRelativeDate(row.occurred_at)}
+        </span>
+      </div>
+
+      {/* Inline expansion */}
+      <div
+        className="grid transition-[grid-template-rows] duration-[220ms] ease-out motion-reduce:transition-none"
+        style={{ gridTemplateRows: expanded ? "1fr" : "0fr" }}
+      >
+        <div className="overflow-hidden">
+          {expanded && (
+            <ExpandedBody
+              row={row}
+              onOpenPerson={onOpenPerson}
+              onOpenCompany={onOpenCompany}
+            />
+          )}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function ContextLine({ row }: { row: ActivityRow }) {
+  if (row.type === "Email" && row.email) {
+    const senderName =
+      row.email.from?.name?.trim() || row.email.from?.email || null;
+    const snippet = row.email.snippet?.trim();
+    if (!senderName && !snippet) {return null;}
+    return (
+      <p
+        className="mt-0.5 truncate text-[13px]"
+        style={{
+          color: "var(--color-text-muted)",
+          fontFamily: '"Bookerly", Georgia, "Times New Roman", serif',
+        }}
+      >
+        {senderName && (
+          <span style={{ color: "var(--color-text)" }}>{senderName}</span>
+        )}
+        {senderName && snippet && <span> — {snippet}</span>}
+        {!senderName && snippet}
+      </p>
+    );
+  }
+  if (row.type === "Meeting" && row.event) {
+    const range = formatTimeRange(row.event.start_at, row.event.end_at);
+    const type = row.event.meeting_type;
+    if (!range && !type) {return null;}
+    return (
+      <p
+        className="mt-0.5 text-[12px]"
+        style={{ color: "var(--color-text-muted)" }}
+      >
+        {range}
+        {range && type && " · "}
+        {type}
+      </p>
+    );
+  }
+  return null;
+}
+
+function ExpandedBody({
+  row,
+  onOpenPerson,
+  onOpenCompany,
+}: {
+  row: ActivityRow;
+  onOpenPerson?: (id: string) => void;
+  onOpenCompany?: (id: string) => void;
+}) {
+  if (row.type === "Email") {
+    if (!row.email?.thread_id) {
+      return (
+        <div
+          className="border-t px-4 py-4 text-[12px]"
+          style={{
+            borderColor: "var(--color-border)",
+            background: "var(--color-background)",
+            color: "var(--color-text-muted)",
+          }}
+        >
+          The thread for this message is no longer available.
+        </div>
+      );
+    }
+    return (
+      <div
+        className="border-t px-4 py-4"
+        style={{
+          borderColor: "var(--color-border)",
+          background: "var(--color-background)",
+        }}
+      >
+        <ThreadMessages
+          threadId={row.email.thread_id}
+          recipientName={row.email.from?.name ?? row.email.from?.email ?? null}
+          onOpenPerson={onOpenPerson}
+          autoScrollOnLoad={false}
+          showReply={false}
+        />
+      </div>
+    );
+  }
+  if (row.type === "Meeting" && row.event) {
+    return (
+      <EventDetailBody
+        eventId={row.event.id}
+        fallbackEvent={{
+          id: row.event.id,
+          title: row.event.title,
+          start_at: row.event.start_at,
+          end_at: row.event.end_at,
+          meeting_type: row.event.meeting_type,
+        }}
+        onOpenPerson={onOpenPerson}
+        onOpenCompany={onOpenCompany}
+      />
+    );
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Building blocks
+// ---------------------------------------------------------------------------
+
+function EnvelopeIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <rect x="3" y="5" width="18" height="14" rx="2" />
+      <path d="m3 7 9 6 9-6" />
+    </svg>
+  );
+}
+
+function CalendarIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <rect x="3" y="4" width="18" height="17" rx="2" />
+      <path d="M3 10h18" />
+      <path d="M8 2v4" />
+      <path d="M16 2v4" />
+    </svg>
+  );
+}
+
+function formatTimeRange(startIso: string | null, endIso: string | null): string | null {
+  if (!startIso) {return null;}
+  const start = new Date(startIso);
+  if (Number.isNaN(start.getTime())) {return null;}
+  const startStr = new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(start);
+  if (!endIso) {return startStr;}
+  const end = new Date(endIso);
+  if (Number.isNaN(end.getTime())) {return startStr;}
+  const endStr = new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(end);
+  return `${startStr} – ${endStr}`;
+}

--- a/apps/web/app/components/crm/calendar-view.tsx
+++ b/apps/web/app/components/crm/calendar-view.tsx
@@ -2,15 +2,8 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { CrmListShell, CrmEmptyState, CrmLoadingState } from "./crm-list-shell";
-import { PersonAvatar } from "./person-avatar";
-import { formatDayLabel, formatRelativeDate } from "./format-relative-date";
-
-type Attendee = {
-  id: string;
-  name: string | null;
-  email: string | null;
-  avatar_url: string | null;
-};
+import { formatDayLabel } from "./format-relative-date";
+import { EventListItem, type EventDetailPerson } from "./event-list-item";
 
 type EventRow = {
   id: string;
@@ -20,7 +13,7 @@ type EventRow = {
   organizer: string | null;
   meeting_type: string | null;
   google_event_id: string | null;
-  attendees: Attendee[];
+  attendees: EventDetailPerson[];
 };
 
 type Range = "upcoming" | "this_week" | "past";
@@ -33,14 +26,17 @@ const RANGES: ReadonlyArray<{ id: Range; label: string }> = [
 
 export function CalendarView({
   onOpenPerson,
+  onOpenCompany,
 }: {
   onOpenPerson?: (id: string) => void;
+  onOpenCompany?: (id: string) => void;
 }) {
   const [range, setRange] = useState<Range>("upcoming");
   const [events, setEvents] = useState<EventRow[]>([]);
   const [total, setTotal] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
 
   const load = useCallback(
     async (signal: AbortSignal) => {
@@ -155,7 +151,16 @@ export function CalendarView({
               </h3>
               <ul className="space-y-2">
                 {dayEvents.map((event) => (
-                  <EventRow key={event.id} event={event} onOpenPerson={onOpenPerson} />
+                  <EventListItem
+                    key={event.id}
+                    event={event}
+                    expanded={expandedId === event.id}
+                    onToggle={() =>
+                      setExpandedId((prev) => (prev === event.id ? null : event.id))
+                    }
+                    onOpenPerson={onOpenPerson}
+                    onOpenCompany={onOpenCompany}
+                  />
                 ))}
               </ul>
             </section>
@@ -164,90 +169,6 @@ export function CalendarView({
       )}
     </CrmListShell>
   );
-}
-
-function EventRow({
-  event,
-  onOpenPerson,
-}: {
-  event: EventRow;
-  onOpenPerson?: (id: string) => void;
-}) {
-  const startDate = event.start_at ? new Date(event.start_at) : null;
-  const endDate = event.end_at ? new Date(event.end_at) : null;
-  const timeRange = startDate
-    ? endDate
-      ? `${formatTime(startDate)} – ${formatTime(endDate)}`
-      : formatTime(startDate)
-    : "";
-
-  const visibleAttendees = event.attendees.slice(0, 5);
-  const overflow = event.attendees.length - visibleAttendees.length;
-
-  return (
-    <li
-      className="rounded-xl border px-4 py-3"
-      style={{ borderColor: "var(--color-border)", background: "var(--color-surface)" }}
-    >
-      <div className="flex items-baseline justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <p className="truncate text-[14px] font-medium" style={{ color: "var(--color-text)" }}>
-            {event.title?.trim() || "(no title)"}
-          </p>
-          <p className="mt-0.5 text-[12px]" style={{ color: "var(--color-text-muted)" }}>
-            {timeRange}
-            {event.start_at && (
-              <>
-                {timeRange && " · "}
-                {formatRelativeDate(event.start_at)}
-              </>
-            )}
-          </p>
-        </div>
-        {event.meeting_type && (
-          <span
-            className="rounded-full px-2 py-0.5 text-[11px] shrink-0"
-            style={{
-              background: "var(--color-surface-hover)",
-              color: "var(--color-text-muted)",
-            }}
-          >
-            {event.meeting_type}
-          </span>
-        )}
-      </div>
-      {visibleAttendees.length > 0 && (
-        <div className="mt-2.5 flex items-center gap-1">
-          {visibleAttendees.map((person) => (
-            <button
-              key={person.id}
-              type="button"
-              onClick={() => onOpenPerson?.(person.id)}
-              disabled={!onOpenPerson}
-              title={person.name ?? person.email ?? undefined}
-              className="disabled:cursor-default"
-            >
-              <PersonAvatar
-                src={person.avatar_url}
-                name={person.name}
-                seed={person.email ?? person.id}
-                size="sm"
-              />
-            </button>
-          ))}
-          {overflow > 0 && (
-            <span className="text-[11px] ml-1" style={{ color: "var(--color-text-muted)" }}>
-              +{overflow}
-            </span>
-          )}
-        </div>
-      )}
-    </li>
-  );
-}
-
-function formatTime(d: Date): string {
-  return new Intl.DateTimeFormat(undefined, { hour: "numeric", minute: "2-digit" }).format(d);
 }
 
 function startOfWeek(d: Date): Date {

--- a/apps/web/app/components/crm/company-profile.tsx
+++ b/apps/web/app/components/crm/company-profile.tsx
@@ -6,8 +6,10 @@ import { CompanyFavicon } from "./company-favicon";
 import { PersonAvatar } from "./person-avatar";
 import { ConnectionStrengthChip } from "./connection-strength-chip";
 import { CrmEmptyState, CrmLoadingState } from "./crm-list-shell";
-import { formatAbsoluteDate, formatDayLabel, formatRelativeDate } from "./format-relative-date";
+import { formatDayLabel, formatRelativeDate } from "./format-relative-date";
 import { EnrichButton } from "./enrich-button";
+import { ProfileThreadList } from "./inbox/profile-thread-list";
+import { EventListItem } from "./event-list-item";
 
 // ---------------------------------------------------------------------------
 // API response shape (mirrors apps/web/app/api/crm/companies/[id]/route.ts)
@@ -47,6 +49,12 @@ type CompanyResponse = {
     last_message_at: string | null;
     message_count: number | null;
     gmail_thread_id: string | null;
+    snippet: string | null;
+    primary_sender_type: string | null;
+    primary_sender_id: string | null;
+    primary_sender_name: string | null;
+    primary_sender_email: string | null;
+    primary_sender_avatar_url: string | null;
   }>;
   events: Array<{
     id: string;
@@ -154,8 +162,8 @@ export function CompanyProfile({
         <div className="mx-auto w-full max-w-4xl px-6 py-6">
           {tab === "overview" && <OverviewTab data={data} />}
           {tab === "team" && <TeamTab data={data} onOpenPerson={onOpenPerson} />}
-          {tab === "emails" && <EmailsTab data={data} />}
-          {tab === "meetings" && <MeetingsTab data={data} />}
+          {tab === "emails" && <EmailsTab data={data} onOpenPerson={onOpenPerson} />}
+          {tab === "meetings" && <MeetingsTab data={data} onOpenPerson={onOpenPerson} />}
         </div>
       </div>
     </div>
@@ -350,53 +358,30 @@ function TeamTab({
   );
 }
 
-function EmailsTab({ data }: { data: CompanyResponse }) {
+function EmailsTab({
+  data,
+  onOpenPerson,
+}: {
+  data: CompanyResponse;
+  onOpenPerson?: (id: string) => void;
+}) {
   if (data.threads.length === 0) {
     return <CrmEmptyState title="No threads yet" />;
   }
-  return (
-    <ul className="divide-y" style={{ borderTop: "1px solid var(--color-border)", borderBottom: "1px solid var(--color-border)" }}>
-      {data.threads.map((thread) => {
-        const linkHref = thread.gmail_thread_id
-          ? `https://mail.google.com/mail/u/0/#all/${thread.gmail_thread_id}`
-          : undefined;
-        const Inner = (
-          <div className="flex items-start gap-4 px-4 py-3 hover:bg-[var(--color-surface-hover)]">
-            <div className="min-w-0 flex-1">
-              <p className="truncate text-[14px] font-medium" style={{ color: "var(--color-text)" }}>
-                {thread.subject?.trim() || "(no subject)"}
-              </p>
-              <p className="mt-0.5 text-[12px]" style={{ color: "var(--color-text-muted)" }}>
-                {thread.message_count ?? 0}{" "}
-                {(thread.message_count ?? 0) === 1 ? "message" : "messages"}
-              </p>
-            </div>
-            <span className="text-right text-[12px] shrink-0" style={{ color: "var(--color-text-muted)" }}>
-              {thread.last_message_at && (
-                <span title={formatAbsoluteDate(thread.last_message_at)}>
-                  {formatRelativeDate(thread.last_message_at)}
-                </span>
-              )}
-            </span>
-          </div>
-        );
-        return (
-          <li key={thread.id}>
-            {linkHref ? (
-              <a href={linkHref} target="_blank" rel="noreferrer" className="block">
-                {Inner}
-              </a>
-            ) : (
-              Inner
-            )}
-          </li>
-        );
-      })}
-    </ul>
-  );
+  // Same Inbox-style thread list + inline conversation reader as the
+  // Person profile uses.
+  return <ProfileThreadList threads={data.threads} onOpenPerson={onOpenPerson} />;
 }
 
-function MeetingsTab({ data }: { data: CompanyResponse }) {
+function MeetingsTab({
+  data,
+  onOpenPerson,
+}: {
+  data: CompanyResponse;
+  onOpenPerson?: (id: string) => void;
+}) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
   if (data.events.length === 0) {
     return <CrmEmptyState title="No meetings with this company yet" />;
   }
@@ -418,28 +403,15 @@ function MeetingsTab({ data }: { data: CompanyResponse }) {
           </h3>
           <ul className="space-y-2">
             {events.map((event) => (
-              <li
+              <EventListItem
                 key={event.id}
-                className="rounded-xl border px-4 py-3"
-                style={{ borderColor: "var(--color-border)", background: "var(--color-surface)" }}
-              >
-                <div className="flex items-baseline justify-between gap-3">
-                  <p className="text-[14px] font-medium truncate" style={{ color: "var(--color-text)" }}>
-                    {event.title?.trim() || "(no title)"}
-                  </p>
-                  {event.meeting_type && (
-                    <span
-                      className="text-[11px] rounded-full px-2 py-0.5"
-                      style={{ background: "var(--color-surface-hover)", color: "var(--color-text-muted)" }}
-                    >
-                      {event.meeting_type}
-                    </span>
-                  )}
-                </div>
-                <p className="mt-0.5 text-[12px]" style={{ color: "var(--color-text-muted)" }}>
-                  {event.start_at && formatAbsoluteDate(event.start_at)}
-                </p>
-              </li>
+                event={event}
+                expanded={expandedId === event.id}
+                onToggle={() =>
+                  setExpandedId((prev) => (prev === event.id ? null : event.id))
+                }
+                onOpenPerson={onOpenPerson}
+              />
             ))}
           </ul>
         </section>

--- a/apps/web/app/components/crm/event-list-item.tsx
+++ b/apps/web/app/components/crm/event-list-item.tsx
@@ -1,0 +1,565 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { PersonAvatar } from "./person-avatar";
+import { CompanyFavicon } from "./company-favicon";
+import { formatRelativeDate } from "./format-relative-date";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * The minimum-viable shape that all three meeting list contexts (Person
+ * profile, Company profile, main Calendar view) can satisfy from their
+ * existing list payloads. The richer detail (organizer, attendees with
+ * avatars, companies) is fetched lazily on first expand.
+ */
+export type EventListItemSummary = {
+  id: string;
+  title: string | null;
+  start_at: string | null;
+  end_at: string | null;
+  meeting_type: string | null;
+  /** Optional — used to render a small avatar stack in the collapsed row when known. */
+  attendees?: ReadonlyArray<EventDetailPerson>;
+  /** Optional — Calendar list provides this; profile views don't bother. */
+  google_event_id?: string | null;
+};
+
+export type EventDetailPerson = {
+  id: string;
+  name: string | null;
+  email: string | null;
+  avatar_url: string | null;
+};
+
+export type EventDetailCompany = {
+  id: string;
+  name: string | null;
+  domain: string | null;
+};
+
+type EventDetailResponse = {
+  event: {
+    id: string;
+    title: string | null;
+    start_at: string | null;
+    end_at: string | null;
+    meeting_type: string | null;
+    google_event_id: string | null;
+  };
+  organizer: EventDetailPerson | null;
+  attendees: EventDetailPerson[];
+  companies: EventDetailCompany[];
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * Expandable row for a calendar_event. Collapsed state matches the
+ * existing card UI (title + meeting-type chip + time). Click anywhere on
+ * the row to expand inline — the detail panel fetches organizer +
+ * attendee + company hydration from `/api/crm/calendar/:id` on first
+ * open and caches it for subsequent toggles.
+ *
+ * Same expand/collapse animation pattern as `ProfileThreadList` (grid-rows
+ * trick) so visual rhythm matches the Email tab.
+ */
+export function EventListItem({
+  event,
+  expanded,
+  onToggle,
+  onOpenPerson,
+  onOpenCompany,
+}: {
+  event: EventListItemSummary;
+  expanded: boolean;
+  onToggle: () => void;
+  onOpenPerson?: (id: string) => void;
+  onOpenCompany?: (id: string) => void;
+}) {
+  const startDate = event.start_at ? new Date(event.start_at) : null;
+  const endDate = event.end_at ? new Date(event.end_at) : null;
+  const timeRange = startDate
+    ? endDate
+      ? `${formatTime(startDate)} – ${formatTime(endDate)}`
+      : formatTime(startDate)
+    : "";
+
+  const collapsedAttendees = (event.attendees ?? []).slice(0, 5);
+  const overflow = (event.attendees?.length ?? 0) - collapsedAttendees.length;
+
+  return (
+    <li
+      className="rounded-xl border overflow-hidden"
+      style={{
+        borderColor: expanded ? "var(--color-accent)" : "var(--color-border)",
+        background: "var(--color-surface)",
+        transition: "border-color 120ms ease",
+      }}
+    >
+      {/* Row trigger — div+role="button" so we can nest interactive
+          children (attendee avatar buttons, external links) without
+          generating invalid HTML. Same approach as ProfileThreadListItem. */}
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded}
+        onClick={onToggle}
+        onKeyDown={(e) => {
+          if (e.target !== e.currentTarget) {return;}
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onToggle();
+          }
+        }}
+        className="w-full px-4 py-3 text-left cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] transition-colors"
+        onMouseEnter={(e) => {
+          if (expanded) {return;}
+          (e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)";
+        }}
+        onMouseLeave={(e) => {
+          if (expanded) {return;}
+          (e.currentTarget as HTMLElement).style.background = "transparent";
+        }}
+      >
+        <div className="flex items-baseline justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <p
+              className="truncate text-[14px] font-medium"
+              style={{ color: "var(--color-text)" }}
+            >
+              {event.title?.trim() || "(no title)"}
+            </p>
+            <p
+              className="mt-0.5 text-[12px]"
+              style={{ color: "var(--color-text-muted)" }}
+            >
+              {timeRange}
+              {event.start_at && (
+                <>
+                  {timeRange && " · "}
+                  {formatRelativeDate(event.start_at)}
+                </>
+              )}
+            </p>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            {event.meeting_type && (
+              <span
+                className="rounded-full px-2 py-0.5 text-[11px]"
+                style={{
+                  background: "var(--color-surface-hover)",
+                  color: "var(--color-text-muted)",
+                }}
+              >
+                {event.meeting_type}
+              </span>
+            )}
+            <Chevron expanded={expanded} />
+          </div>
+        </div>
+        {collapsedAttendees.length > 0 && (
+          <div className="mt-2.5 flex items-center gap-1">
+            {collapsedAttendees.map((person) => (
+              <button
+                key={person.id}
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onOpenPerson?.(person.id);
+                }}
+                disabled={!onOpenPerson}
+                title={person.name ?? person.email ?? undefined}
+                className="disabled:cursor-default"
+              >
+                <PersonAvatar
+                  src={person.avatar_url}
+                  name={person.name}
+                  seed={person.email ?? person.id}
+                  size="sm"
+                />
+              </button>
+            ))}
+            {overflow > 0 && (
+              <span
+                className="ml-1 text-[11px]"
+                style={{ color: "var(--color-text-muted)" }}
+              >
+                +{overflow}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Inline detail — animates open via the grid-rows trick. */}
+      <div
+        className="grid transition-[grid-template-rows] duration-[220ms] ease-out motion-reduce:transition-none"
+        style={{ gridTemplateRows: expanded ? "1fr" : "0fr" }}
+      >
+        <div className="overflow-hidden">
+          {expanded && (
+            <EventDetailBody
+              eventId={event.id}
+              fallbackEvent={event}
+              onOpenPerson={onOpenPerson}
+              onOpenCompany={onOpenCompany}
+            />
+          )}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Detail panel (lazy-loaded)
+// ---------------------------------------------------------------------------
+
+/**
+ * The body that fills the inline-expand area of an `EventListItem` —
+ * exported so the per-person Activity timeline can mount the same
+ * detail UI when a meeting row is expanded there. The caller is
+ * expected to provide a `fallbackEvent` summary so the panel can paint
+ * (with date/time at least) before the detail fetch resolves.
+ */
+export function EventDetailBody({
+  eventId,
+  fallbackEvent,
+  onOpenPerson,
+  onOpenCompany,
+}: {
+  eventId: string;
+  fallbackEvent: EventListItemSummary;
+  onOpenPerson?: (id: string) => void;
+  onOpenCompany?: (id: string) => void;
+}) {
+  const [detail, setDetail] = useState<EventDetailResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(`/api/crm/calendar/${encodeURIComponent(eventId)}`, { cache: "no-store" })
+      .then((r) => {
+        if (!r.ok) {throw new Error(`HTTP ${r.status}`);}
+        return r.json() as Promise<EventDetailResponse>;
+      })
+      .then((body) => {
+        if (cancelled) {return;}
+        setDetail(body);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) {return;}
+        setError(err instanceof Error ? err.message : "Failed to load meeting details.");
+      })
+      .finally(() => {
+        if (cancelled) {return;}
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [eventId]);
+
+  const startDate = (detail?.event.start_at ?? fallbackEvent.start_at)
+    ? new Date(detail?.event.start_at ?? fallbackEvent.start_at!)
+    : null;
+  const endDate = (detail?.event.end_at ?? fallbackEvent.end_at)
+    ? new Date(detail?.event.end_at ?? fallbackEvent.end_at!)
+    : null;
+  const dayLabel = startDate ? formatLongDay(startDate) : null;
+  const timeRange = startDate
+    ? endDate
+      ? `${formatTime(startDate)} – ${formatTime(endDate)}`
+      : formatTime(startDate)
+    : null;
+  const duration = startDate && endDate ? formatDuration(startDate, endDate) : null;
+
+  const organizer = detail?.organizer ?? null;
+  const attendees = detail?.attendees ?? fallbackEvent.attendees ?? [];
+  const companies = detail?.companies ?? [];
+
+  return (
+    <div
+      className="border-t px-4 py-4"
+      style={{
+        borderColor: "var(--color-border)",
+        background: "var(--color-background)",
+      }}
+    >
+      {/* When -> a single row of date/time/duration */}
+      {(dayLabel || timeRange || duration) && (
+        <DetailSection label="When">
+          <div
+            className="text-[13px]"
+            style={{ color: "var(--color-text)" }}
+          >
+            {dayLabel && <div className="font-medium">{dayLabel}</div>}
+            {(timeRange || duration) && (
+              <div className="mt-0.5" style={{ color: "var(--color-text-muted)" }}>
+                {timeRange}
+                {timeRange && duration && " · "}
+                {duration}
+              </div>
+            )}
+          </div>
+        </DetailSection>
+      )}
+
+      {/* Organizer */}
+      {organizer && (
+        <DetailSection label="Organizer">
+          <PersonChip person={organizer} onOpenPerson={onOpenPerson} />
+        </DetailSection>
+      )}
+
+      {/* Attendees */}
+      {attendees.length > 0 && (
+        <DetailSection label={`Attendees · ${attendees.length}`}>
+          <div className="flex flex-col gap-1.5">
+            {attendees.map((person) => (
+              <PersonChip
+                key={person.id}
+                person={person}
+                onOpenPerson={onOpenPerson}
+              />
+            ))}
+          </div>
+        </DetailSection>
+      )}
+
+      {/* Companies */}
+      {companies.length > 0 && (
+        <DetailSection label={companies.length === 1 ? "Company" : "Companies"}>
+          <div className="flex flex-col gap-1.5">
+            {companies.map((company) => (
+              <CompanyChip
+                key={company.id}
+                company={company}
+                onOpenCompany={onOpenCompany}
+              />
+            ))}
+          </div>
+        </DetailSection>
+      )}
+
+      {/* Loading / error feedback */}
+      {loading && !detail && (
+        <p
+          className="text-[12px]"
+          style={{ color: "var(--color-text-muted)" }}
+        >
+          Loading meeting details…
+        </p>
+      )}
+      {error && (
+        <p
+          className="text-[12px]"
+          style={{ color: "var(--color-text-muted)" }}
+        >
+          Couldn&rsquo;t load meeting details ({error}). Showing what we have.
+        </p>
+      )}
+
+      {/* If we have absolutely nothing to show, give a friendly fallback. */}
+      {!loading && !error && detail && attendees.length === 0 && !organizer && companies.length === 0 && (
+        <p
+          className="text-[12px]"
+          style={{ color: "var(--color-text-muted)" }}
+        >
+          No additional details for this meeting.
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Building blocks
+// ---------------------------------------------------------------------------
+
+function DetailSection({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="mb-4 last:mb-0">
+      <h4
+        className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.16em]"
+        style={{ color: "var(--color-text-muted)" }}
+      >
+        {label}
+      </h4>
+      {children}
+    </div>
+  );
+}
+
+function PersonChip({
+  person,
+  onOpenPerson,
+}: {
+  person: EventDetailPerson;
+  onOpenPerson?: (id: string) => void;
+}) {
+  const displayName = person.name?.trim() || person.email || "Unknown";
+  const subtitle = person.name?.trim() && person.email ? person.email : null;
+  return (
+    <button
+      type="button"
+      onClick={() => onOpenPerson?.(person.id)}
+      disabled={!onOpenPerson}
+      className="flex items-center gap-2.5 rounded-lg px-2 py-1.5 text-left transition-colors disabled:cursor-default"
+      style={{ color: "var(--color-text)" }}
+      onMouseEnter={(e) => {
+        if (!onOpenPerson) {return;}
+        (e.currentTarget as HTMLElement).style.background =
+          "var(--color-surface-hover)";
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLElement).style.background = "transparent";
+      }}
+    >
+      <PersonAvatar
+        src={person.avatar_url}
+        name={displayName}
+        seed={person.email ?? person.id}
+        size="sm"
+      />
+      <div className="min-w-0">
+        <p
+          className="truncate text-[13px] font-medium"
+          style={{ color: "var(--color-text)" }}
+        >
+          {displayName}
+        </p>
+        {subtitle && (
+          <p
+            className="truncate text-[11px]"
+            style={{ color: "var(--color-text-muted)" }}
+          >
+            {subtitle}
+          </p>
+        )}
+      </div>
+    </button>
+  );
+}
+
+function CompanyChip({
+  company,
+  onOpenCompany,
+}: {
+  company: EventDetailCompany;
+  onOpenCompany?: (id: string) => void;
+}) {
+  const displayName = company.name?.trim() || company.domain || "Unknown company";
+  return (
+    <button
+      type="button"
+      onClick={() => onOpenCompany?.(company.id)}
+      disabled={!onOpenCompany}
+      className="flex items-center gap-2.5 rounded-lg px-2 py-1.5 text-left transition-colors disabled:cursor-default"
+      onMouseEnter={(e) => {
+        if (!onOpenCompany) {return;}
+        (e.currentTarget as HTMLElement).style.background =
+          "var(--color-surface-hover)";
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLElement).style.background = "transparent";
+      }}
+    >
+      <CompanyFavicon domain={company.domain} name={company.name} size="sm" />
+      <div className="min-w-0">
+        <p
+          className="truncate text-[13px] font-medium"
+          style={{ color: "var(--color-text)" }}
+        >
+          {displayName}
+        </p>
+        {company.domain && company.name && (
+          <p
+            className="truncate text-[11px]"
+            style={{ color: "var(--color-text-muted)" }}
+          >
+            {company.domain}
+          </p>
+        )}
+      </div>
+    </button>
+  );
+}
+
+function Chevron({ expanded }: { expanded: boolean }) {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      className="motion-reduce:transition-none"
+      style={{
+        color: "var(--color-text-muted)",
+        transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
+        transition: "transform 180ms ease",
+      }}
+    >
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Date/time helpers (kept local — same shape as CalendarView's helpers)
+// ---------------------------------------------------------------------------
+
+function formatTime(d: Date): string {
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(d);
+}
+
+/** Long-form day label, e.g. "Friday, April 16, 2027". */
+function formatLongDay(d: Date): string {
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }).format(d);
+}
+
+/**
+ * "55 min", "1h 30m", "2h", "all-day". Accepts dates in either order so
+ * a malformed feed doesn't crash the row.
+ */
+function formatDuration(start: Date, end: Date): string {
+  let diffMs = end.getTime() - start.getTime();
+  if (diffMs <= 0) {return "";}
+  const totalMinutes = Math.round(diffMs / (60 * 1000));
+  if (totalMinutes >= 60 * 24) {
+    const days = Math.round(totalMinutes / (60 * 24));
+    return `${days} day${days === 1 ? "" : "s"}`;
+  }
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours === 0) {return `${minutes} min`;}
+  if (minutes === 0) {return `${hours}h`;}
+  return `${hours}h ${minutes}m`;
+}

--- a/apps/web/app/components/crm/inbox/conversation-header.tsx
+++ b/apps/web/app/components/crm/inbox/conversation-header.tsx
@@ -14,8 +14,6 @@ export function ConversationHeader({
   starred,
   onToggleStar,
   onOpenPerson,
-  onToggleFocus,
-  focusMode,
   onClose,
 }: {
   subject: string | null;
@@ -25,8 +23,6 @@ export function ConversationHeader({
   starred: boolean;
   onToggleStar: () => void;
   onOpenPerson?: (id: string) => void;
-  onToggleFocus?: () => void;
-  focusMode?: boolean;
   /** Single-pane drilldown: back-to-list affordance. */
   onClose?: () => void;
 }) {
@@ -105,15 +101,6 @@ export function ConversationHeader({
           >
             <CopyIcon />
           </IconButton>
-          {onToggleFocus && (
-            <IconButton
-              title={focusMode ? "Exit focus mode" : "Focus mode"}
-              onClick={onToggleFocus}
-              active={!!focusMode}
-            >
-              {focusMode ? <ExitFocusIcon /> : <EnterFocusIcon />}
-            </IconButton>
-          )}
         </div>
       </div>
     </header>
@@ -218,24 +205,3 @@ function CopyIcon() {
   );
 }
 
-function EnterFocusIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-      <polyline points="9 21 3 21 3 15" />
-      <polyline points="15 3 21 3 21 9" />
-      <line x1="3" y1="21" x2="10" y2="14" />
-      <line x1="14" y1="10" x2="21" y2="3" />
-    </svg>
-  );
-}
-
-function ExitFocusIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-      <polyline points="4 14 10 14 10 20" />
-      <polyline points="20 10 14 10 14 4" />
-      <line x1="14" y1="10" x2="21" y2="3" />
-      <line x1="3" y1="21" x2="10" y2="14" />
-    </svg>
-  );
-}

--- a/apps/web/app/components/crm/inbox/conversation-pane.tsx
+++ b/apps/web/app/components/crm/inbox/conversation-pane.tsx
@@ -6,7 +6,7 @@ import { ThreadMessages } from "./thread-messages";
 import type { Thread } from "./types";
 
 /**
- * Right pane (or full-pane on mobile / focus-mode) of the Inbox.
+ * Right pane (or full-pane on mobile) of the Inbox.
  *
  * This is now a thin shell: sticky `ConversationHeader` on top, the
  * reusable `ThreadMessages` block in the scroller below. The actual
@@ -24,8 +24,6 @@ export function ConversationPane({
   onToggleStar,
   onOpenPerson,
   onClose,
-  onToggleFocus,
-  focusMode,
 }: {
   selectedThread: Thread | null;
   starred: boolean;
@@ -33,8 +31,6 @@ export function ConversationPane({
   onOpenPerson?: (id: string) => void;
   /** Single-pane drilldown back-to-list. */
   onClose?: () => void;
-  onToggleFocus?: () => void;
-  focusMode?: boolean;
 }) {
   const handleClose = useCallback(() => {
     onClose?.();
@@ -93,8 +89,6 @@ export function ConversationPane({
         starred={starred}
         onToggleStar={onToggleStar}
         onOpenPerson={onOpenPerson}
-        onToggleFocus={onToggleFocus}
-        focusMode={focusMode}
         onClose={handleClose}
       />
       <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">

--- a/apps/web/app/components/crm/inbox/inbox-layout.tsx
+++ b/apps/web/app/components/crm/inbox/inbox-layout.tsx
@@ -12,11 +12,9 @@ const COLLAPSE_BREAKPOINT = 900;
  * Responsive shell for the inbox.
  *
  * Modes:
- *   - desktop (>= 900px) + no focus mode
+ *   - desktop (>= 900px)
  *       → two-pane split, resizable drag handle between list + reader.
  *         Width is persisted to localStorage so it's stable across visits.
- *   - desktop + focus mode
- *       → conversation full-width; list hidden.
  *   - narrow (<  900px)
  *       → single-pane drilldown. Show list when no thread is selected,
  *         otherwise show conversation pane (with back-to-list affordance
@@ -26,12 +24,10 @@ export function InboxLayout({
   list,
   conversation,
   hasSelection,
-  focusMode,
 }: {
   list: ReactNode;
   conversation: ReactNode;
   hasSelection: boolean;
-  focusMode: boolean;
 }) {
   const [width, setWidth] = useState<number>(DEFAULT_WIDTH);
   const [isNarrow, setIsNarrow] = useState<boolean>(false);
@@ -99,17 +95,8 @@ export function InboxLayout({
   // ─── Single-pane (narrow) ─────────────────────────────────────────────
   if (isNarrow) {
     return (
-      <div ref={containerRef} className="flex h-full min-h-0 w-full">
+      <div ref={containerRef} className="h-full min-h-0 w-full">
         {hasSelection ? conversation : list}
-      </div>
-    );
-  }
-
-  // ─── Focus mode (full-width conversation) ─────────────────────────────
-  if (focusMode && hasSelection) {
-    return (
-      <div ref={containerRef} className="flex h-full min-h-0 w-full">
-        {conversation}
       </div>
     );
   }

--- a/apps/web/app/components/crm/inbox/inbox-toolbar.tsx
+++ b/apps/web/app/components/crm/inbox/inbox-toolbar.tsx
@@ -2,17 +2,10 @@
 
 import { type ChangeEvent, type RefObject, forwardRef } from "react";
 import { Input } from "../../ui/input";
-import type { SenderFilter } from "./types";
-
-const FILTERS: ReadonlyArray<{ id: SenderFilter; label: string; hint: string }> = [
-  { id: "person", label: "People", hint: "Real human-from-human mail" },
-  { id: "automated", label: "Automated", hint: "Newsletters, receipts, notifications" },
-  { id: "all", label: "All", hint: "Everything in your inbox" },
-];
 
 /**
- * Top-of-pane toolbar above the thread list. Search, sender filter
- * pills, and the bulk-select strip when one or more rows are checked.
+ * Top-of-pane toolbar above the thread list. Search and the
+ * bulk-select strip when one or more rows are checked.
  *
  * The bulk actions (Mark read / Star / Archive) are intentionally
  * mocked — they fire a toast pointing at the two-way Gmail sync
@@ -24,8 +17,6 @@ export const InboxToolbar = forwardRef<
   {
     search: string;
     onSearchChange: (value: string) => void;
-    senderFilter: SenderFilter;
-    onSenderFilterChange: (value: SenderFilter) => void;
     selectedCount: number;
     onClearSelection: () => void;
     onBulkAction: (action: "read" | "star" | "archive") => void;
@@ -35,8 +26,6 @@ export const InboxToolbar = forwardRef<
   {
     search,
     onSearchChange,
-    senderFilter,
-    onSenderFilterChange,
     selectedCount,
     onClearSelection,
     onBulkAction,
@@ -67,29 +56,6 @@ export const InboxToolbar = forwardRef<
         >
           <KbdIcon />
         </button>
-      </div>
-
-      {/* Filter pills */}
-      <div className="flex flex-wrap items-center gap-1 px-4 pb-2">
-        {FILTERS.map((f) => {
-          const active = senderFilter === f.id;
-          return (
-            <button
-              key={f.id}
-              type="button"
-              onClick={() => onSenderFilterChange(f.id)}
-              title={f.hint}
-              className="rounded-full px-3 py-1 text-[12px] font-medium transition-colors"
-              style={{
-                background: active ? "var(--color-text)" : "transparent",
-                color: active ? "var(--color-bg)" : "var(--color-text-muted)",
-                border: active ? "1px solid var(--color-text)" : "1px solid var(--color-border)",
-              }}
-            >
-              {f.label}
-            </button>
-          );
-        })}
       </div>
 
       {/* Bulk action strip — only when one or more rows are checked */}

--- a/apps/web/app/components/crm/inbox/inbox-view.tsx
+++ b/apps/web/app/components/crm/inbox/inbox-view.tsx
@@ -29,7 +29,6 @@ const DEFAULT_LIMIT = 100;
  *   - Server fetch (debounced on search)
  *   - Selection/star/read state via the localStorage hooks
  *   - Keyboard navigation (j/k/o/Enter/Esc/x/s/e/?/“/”)
- *   - Focus mode toggle (hides list pane)
  */
 export function InboxView({
   onOpenPerson,
@@ -49,10 +48,9 @@ export function InboxView({
       : "person";
 
   const [search, setSearch] = useState(initialSearch);
-  const [senderFilter, setSenderFilter] = useState<SenderFilter>(initialSender);
+  const [senderFilter] = useState<SenderFilter>(initialSender);
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(initialThread);
   const [focusedIndex, setFocusedIndex] = useState<number>(0);
-  const [focusMode, setFocusMode] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
 
   const [threads, setThreads] = useState<Thread[]>([]);
@@ -204,10 +202,6 @@ export function InboxView({
           setHelpOpen(false);
           return;
         }
-        if (focusMode) {
-          setFocusMode(false);
-          return;
-        }
         setSelectedThreadId(null);
       },
       focusSearch: () => {
@@ -243,7 +237,6 @@ export function InboxView({
     <>
       <InboxLayout
         hasSelection={!!selectedThread}
-        focusMode={focusMode}
         list={
           <div
             className="flex h-full min-h-0 flex-col"
@@ -253,8 +246,6 @@ export function InboxView({
               ref={searchInputRef}
               search={search}
               onSearchChange={setSearch}
-              senderFilter={senderFilter}
-              onSenderFilterChange={setSenderFilter}
               selectedCount={selection.set.size}
               onClearSelection={selection.clear}
               onBulkAction={handleBulkAction}
@@ -300,8 +291,6 @@ export function InboxView({
             }}
             onOpenPerson={onOpenPerson}
             onClose={handleClose}
-            onToggleFocus={() => setFocusMode((v) => !v)}
-            focusMode={focusMode}
           />
         }
       />

--- a/apps/web/app/components/crm/inbox/profile-thread-list.tsx
+++ b/apps/web/app/components/crm/inbox/profile-thread-list.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useState } from "react";
+import { PersonAvatar } from "../person-avatar";
+import { formatAbsoluteDate, formatRelativeDate } from "../format-relative-date";
+import { ThreadMessages } from "./thread-messages";
+
+const SENDER_TYPE_COLOR: Record<string, string> = {
+  Marketing: "#ef4444",
+  Transactional: "#3b82f6",
+  Notification: "#f59e0b",
+  "Mailing List": "#8b5cf6",
+  Automated: "#94a3b8",
+};
+
+/**
+ * Minimal thread shape consumed by ProfileThreadList. Mirrors a subset
+ * of the Inbox API's Thread type — kept narrow so PersonProfile /
+ * CompanyProfile APIs don't have to project the full participants array
+ * or primary-sender fields up-front (those load lazily inside
+ * ThreadMessages on row expand).
+ */
+export type ProfileThread = {
+  id: string;
+  subject: string | null;
+  snippet?: string | null;
+  last_message_at: string | null;
+  message_count: number | null;
+  gmail_thread_id: string | null;
+  /** Optional Sender Type chip. Person-typed threads render with no chip. */
+  primary_sender_type?: string | null;
+  /** Optional headline sender (avatar / name). */
+  primary_sender_name?: string | null;
+  primary_sender_email?: string | null;
+  primary_sender_avatar_url?: string | null;
+};
+
+/**
+ * Reusable thread list for PersonProfile / CompanyProfile email tabs.
+ *
+ * Rows match the Inbox visual language (avatar + Instrument Serif subject
+ * + Bookerly snippet + relative time + sender-type chip), without the
+ * Inbox-specific affordances (checkbox / star / bulk-select / unread dot
+ * — none of which apply in a single-record context).
+ *
+ * Click anywhere on a row to expand the conversation reader inline. The
+ * conversation reader is the SAME `ThreadMessages` component that powers
+ * the Inbox's right pane, so message cards / iframe rendering / quick
+ * reply behave identically across the app.
+ */
+export function ProfileThreadList({
+  threads,
+  onOpenPerson,
+}: {
+  threads: ReadonlyArray<ProfileThread>;
+  onOpenPerson?: (id: string) => void;
+}) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  return (
+    <ul
+      className="divide-y"
+      style={{
+        borderTop: "1px solid var(--color-border)",
+        borderBottom: "1px solid var(--color-border)",
+      }}
+    >
+      {threads.map((thread) => (
+        <ProfileThreadListItem
+          key={thread.id}
+          thread={thread}
+          expanded={expandedId === thread.id}
+          onToggle={() =>
+            setExpandedId((prev) => (prev === thread.id ? null : thread.id))
+          }
+          onOpenPerson={onOpenPerson}
+        />
+      ))}
+    </ul>
+  );
+}
+
+function ProfileThreadListItem({
+  thread,
+  expanded,
+  onToggle,
+  onOpenPerson,
+}: {
+  thread: ProfileThread;
+  expanded: boolean;
+  onToggle: () => void;
+  onOpenPerson?: (id: string) => void;
+}) {
+  const senderName =
+    thread.primary_sender_name ??
+    thread.primary_sender_email ??
+    null;
+  const senderEmail = thread.primary_sender_email ?? null;
+  const senderTypeColor =
+    thread.primary_sender_type && thread.primary_sender_type !== "Person"
+      ? SENDER_TYPE_COLOR[thread.primary_sender_type] ?? "#94a3b8"
+      : null;
+
+  const gmailHref = thread.gmail_thread_id
+    ? `https://mail.google.com/mail/u/0/#all/${thread.gmail_thread_id}`
+    : null;
+
+  return (
+    <li>
+      {/* Row affordance is a div+role="button" instead of a real <button>
+         because the row contains an <a> (the Gmail "open externally"
+         link). Interactive content (a, button, etc.) inside a <button>
+         is invalid HTML and trips React 19 / Next 15's nesting validator
+         ("<button> cannot contain a nested <button>" — same family of
+         error). Same approach we use for MessageCard's header. We keep
+         keyboard parity with a native button via tabIndex + Enter/Space
+         handling and focus-visible ring. */}
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={onToggle}
+        onKeyDown={(e) => {
+          // Only react to keyboard activation on the row itself; the
+          // Gmail link inside has its own keyboard semantics.
+          if (e.target !== e.currentTarget) {return;}
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onToggle();
+          }
+        }}
+        aria-expanded={expanded}
+        className="group grid w-full items-center gap-3 px-4 py-3 text-left transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+        style={{
+          gridTemplateColumns: "auto minmax(0, 1fr) auto",
+          background: expanded ? "var(--color-accent-light)" : "transparent",
+          borderLeft: expanded
+            ? "2px solid var(--color-accent)"
+            : "2px solid transparent",
+        }}
+        onMouseEnter={(e) => {
+          if (expanded) {return;}
+          (e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)";
+        }}
+        onMouseLeave={(e) => {
+          if (expanded) {return;}
+          (e.currentTarget as HTMLElement).style.background = "transparent";
+        }}
+      >
+        <PersonAvatar
+          src={thread.primary_sender_avatar_url}
+          name={senderName ?? thread.subject ?? "Email"}
+          seed={senderEmail ?? thread.id}
+          size="sm"
+        />
+        <div className="min-w-0">
+          <div className="flex items-baseline gap-2 flex-wrap">
+            <span
+              className="font-instrument truncate"
+              style={{
+                color: "var(--color-text)",
+                fontSize: 14,
+                fontWeight: 600,
+                fontStyle: senderTypeColor ? "italic" : "normal",
+              }}
+            >
+              {thread.subject?.trim() || "(no subject)"}
+            </span>
+            {senderTypeColor && (
+              <span
+                className="shrink-0 inline-flex items-center gap-1 rounded-full px-1.5 py-0 text-[10px] uppercase tracking-[0.06em]"
+                style={{
+                  background: `${senderTypeColor}1f`,
+                  color: senderTypeColor,
+                  fontWeight: 600,
+                }}
+              >
+                <span
+                  aria-hidden
+                  style={{
+                    width: 5,
+                    height: 5,
+                    borderRadius: 99,
+                    background: senderTypeColor,
+                  }}
+                />
+                {thread.primary_sender_type}
+              </span>
+            )}
+            <span
+              className="text-[11px] tabular-nums"
+              style={{ color: "var(--color-text-muted)", fontWeight: 400 }}
+            >
+              {thread.message_count ?? 0}{" "}
+              {(thread.message_count ?? 0) === 1 ? "msg" : "msgs"}
+            </span>
+          </div>
+          {(thread.snippet?.trim() || senderName) && (
+            <p
+              className="mt-0.5 truncate text-[13px]"
+              style={{
+                color: "var(--color-text-muted)",
+                fontFamily: '"Bookerly", Georgia, "Times New Roman", serif',
+              }}
+            >
+              {senderName && (
+                <span style={{ color: "var(--color-text)" }}>{senderName}</span>
+              )}
+              {senderName && thread.snippet?.trim() && (
+                <span> — {thread.snippet.trim()}</span>
+              )}
+              {!senderName && thread.snippet?.trim() && thread.snippet.trim()}
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          {gmailHref && (
+            <a
+              href={gmailHref}
+              target="_blank"
+              rel="noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              title="Open in Gmail"
+              className="inline-flex h-7 w-7 items-center justify-center rounded transition-colors opacity-0 group-hover:opacity-100"
+              style={{ color: "var(--color-text-muted)" }}
+              onMouseEnter={(e) => {
+                (e.currentTarget as HTMLElement).style.background =
+                  "var(--color-surface)";
+                (e.currentTarget as HTMLElement).style.color =
+                  "var(--color-text)";
+              }}
+              onMouseLeave={(e) => {
+                (e.currentTarget as HTMLElement).style.background = "transparent";
+                (e.currentTarget as HTMLElement).style.color =
+                  "var(--color-text-muted)";
+              }}
+            >
+              <svg
+                width="13"
+                height="13"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden
+              >
+                <path d="M15 3h6v6" />
+                <path d="M10 14 21 3" />
+                <path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5" />
+              </svg>
+            </a>
+          )}
+          <span
+            className="text-right text-[11px] tabular-nums"
+            style={{ color: "var(--color-text-muted)" }}
+            title={
+              thread.last_message_at
+                ? formatAbsoluteDate(thread.last_message_at)
+                : undefined
+            }
+          >
+            {thread.last_message_at && formatRelativeDate(thread.last_message_at)}
+          </span>
+        </div>
+      </div>
+
+      {/* Inline conversation reader — animates open via grid-rows trick. */}
+      <div
+        className="grid transition-[grid-template-rows] duration-[220ms] ease-out motion-reduce:transition-none"
+        style={{ gridTemplateRows: expanded ? "1fr" : "0fr" }}
+      >
+        <div className="overflow-hidden">
+          {expanded && (
+            <div
+              className="px-4 py-4"
+              style={{ background: "var(--color-main-bg)" }}
+            >
+              <ThreadMessages
+                threadId={thread.id}
+                recipientName={senderName}
+                onOpenPerson={onOpenPerson}
+                autoScrollOnLoad={false}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/apps/web/app/components/crm/person-profile.tsx
+++ b/apps/web/app/components/crm/person-profile.tsx
@@ -6,8 +6,11 @@ import { PersonAvatar } from "./person-avatar";
 import { CompanyFavicon } from "./company-favicon";
 import { ConnectionStrengthChip } from "./connection-strength-chip";
 import { CrmEmptyState, CrmLoadingState } from "./crm-list-shell";
-import { formatAbsoluteDate, formatDayLabel, formatRelativeDate } from "./format-relative-date";
+import { formatDayLabel, formatRelativeDate } from "./format-relative-date";
 import { EnrichButton } from "./enrich-button";
+import { ProfileThreadList } from "./inbox/profile-thread-list";
+import { EventListItem } from "./event-list-item";
+import { ActivityTimeline } from "./activity-timeline";
 
 // ---------------------------------------------------------------------------
 // API response shape (mirrors apps/web/app/api/crm/people/[id]/route.ts)
@@ -50,6 +53,12 @@ type PersonResponse = {
     last_message_at: string | null;
     message_count: number | null;
     gmail_thread_id: string | null;
+    snippet: string | null;
+    primary_sender_type: string | null;
+    primary_sender_id: string | null;
+    primary_sender_name: string | null;
+    primary_sender_email: string | null;
+    primary_sender_avatar_url: string | null;
   }>;
   events: Array<{
     id: string;
@@ -173,9 +182,21 @@ export function PersonProfile({
           {tab === "overview" && (
             <OverviewTab data={data} onOpenCompany={onOpenCompany} />
           )}
-          {tab === "emails" && <EmailsTab data={data} />}
-          {tab === "calendar" && <CalendarTab data={data} onOpenPerson={onOpenPerson} />}
-          {tab === "activity" && <ActivityTab data={data} />}
+          {tab === "emails" && <EmailsTab data={data} onOpenPerson={onOpenPerson} />}
+          {tab === "calendar" && (
+            <CalendarTab
+              data={data}
+              onOpenPerson={onOpenPerson}
+              onOpenCompany={onOpenCompany}
+            />
+          )}
+          {tab === "activity" && (
+            <ActivityTab
+              data={data}
+              onOpenPerson={onOpenPerson}
+              onOpenCompany={onOpenCompany}
+            />
+          )}
           {tab === "notes" && <NotesTab data={data} />}
         </div>
       </div>
@@ -461,7 +482,13 @@ function OverviewTab({
   );
 }
 
-function EmailsTab({ data }: { data: PersonResponse }) {
+function EmailsTab({
+  data,
+  onOpenPerson,
+}: {
+  data: PersonResponse;
+  onOpenPerson?: (id: string) => void;
+}) {
   if (data.threads.length === 0) {
     return (
       <CrmEmptyState
@@ -470,56 +497,24 @@ function EmailsTab({ data }: { data: PersonResponse }) {
       />
     );
   }
-  return (
-    <ul className="divide-y" style={{ borderTop: "1px solid var(--color-border)", borderBottom: "1px solid var(--color-border)" }}>
-      {data.threads.map((thread) => {
-        const linkHref = thread.gmail_thread_id
-          ? `https://mail.google.com/mail/u/0/#all/${thread.gmail_thread_id}`
-          : undefined;
-        const Inner = (
-          <div className="flex items-start gap-4 px-4 py-3 hover:bg-[var(--color-surface-hover)]">
-            <div className="min-w-0 flex-1">
-              <p className="truncate text-[14px] font-medium" style={{ color: "var(--color-text)" }}>
-                {thread.subject?.trim() || "(no subject)"}
-              </p>
-              <p className="mt-0.5 text-[12px]" style={{ color: "var(--color-text-muted)" }}>
-                {thread.message_count ?? 0}{" "}
-                {(thread.message_count ?? 0) === 1 ? "message" : "messages"}
-              </p>
-            </div>
-            <div className="text-right text-[12px] shrink-0" style={{ color: "var(--color-text-muted)" }}>
-              {thread.last_message_at && (
-                <span title={formatAbsoluteDate(thread.last_message_at)}>
-                  {formatRelativeDate(thread.last_message_at)}
-                </span>
-              )}
-            </div>
-          </div>
-        );
-        return (
-          <li key={thread.id}>
-            {linkHref ? (
-              <a href={linkHref} target="_blank" rel="noreferrer" className="block">
-                {Inner}
-              </a>
-            ) : (
-              Inner
-            )}
-          </li>
-        );
-      })}
-    </ul>
-  );
+  // ProfileThreadList renders the same Inbox-style row treatment AND
+  // expands the conversation reader inline on click — same MessageCard /
+  // MessageBody / QuickReply chain the Inbox uses, no external Gmail
+  // round-trip required.
+  return <ProfileThreadList threads={data.threads} onOpenPerson={onOpenPerson} />;
 }
 
 function CalendarTab({
   data,
   onOpenPerson,
+  onOpenCompany,
 }: {
   data: PersonResponse;
   onOpenPerson?: (id: string) => void;
+  onOpenCompany?: (id: string) => void;
 }) {
-  void onOpenPerson;
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
   if (data.events.length === 0) {
     return (
       <CrmEmptyState
@@ -528,7 +523,8 @@ function CalendarTab({
       />
     );
   }
-  // Group by day
+  // Group by day — preserves the API's start_at DESC ordering inside
+  // each group, which is what the user expects (most recent on top).
   const groups = new Map<string, typeof data.events>();
   for (const event of data.events) {
     const day = event.start_at ? formatDayLabel(event.start_at) : "Unknown date";
@@ -547,31 +543,16 @@ function CalendarTab({
           </h3>
           <ul className="space-y-2">
             {events.map((event) => (
-              <li
+              <EventListItem
                 key={event.id}
-                className="rounded-xl border px-4 py-3"
-                style={{ borderColor: "var(--color-border)", background: "var(--color-surface)" }}
-              >
-                <div className="flex items-baseline justify-between gap-3">
-                  <p className="text-[14px] font-medium truncate" style={{ color: "var(--color-text)" }}>
-                    {event.title?.trim() || "(no title)"}
-                  </p>
-                  {event.meeting_type && (
-                    <span
-                      className="text-[11px] rounded-full px-2 py-0.5"
-                      style={{
-                        background: "var(--color-surface-hover)",
-                        color: "var(--color-text-muted)",
-                      }}
-                    >
-                      {event.meeting_type}
-                    </span>
-                  )}
-                </div>
-                <p className="mt-0.5 text-[12px]" style={{ color: "var(--color-text-muted)" }}>
-                  {event.start_at && formatAbsoluteDate(event.start_at)}
-                </p>
-              </li>
+                event={event}
+                expanded={expandedId === event.id}
+                onToggle={() =>
+                  setExpandedId((prev) => (prev === event.id ? null : event.id))
+                }
+                onOpenPerson={onOpenPerson}
+                onOpenCompany={onOpenCompany}
+              />
             ))}
           </ul>
         </section>
@@ -580,7 +561,15 @@ function CalendarTab({
   );
 }
 
-function ActivityTab({ data }: { data: PersonResponse }) {
+function ActivityTab({
+  data,
+  onOpenPerson,
+  onOpenCompany,
+}: {
+  data: PersonResponse;
+  onOpenPerson?: (id: string) => void;
+  onOpenCompany?: (id: string) => void;
+}) {
   const summary = data.interactions_summary;
   if (summary.total === 0) {
     return (
@@ -590,28 +579,54 @@ function ActivityTab({ data }: { data: PersonResponse }) {
       />
     );
   }
+  // The "Total" stat is the count of raw atomic interaction rows
+  // (one per message-per-counterparty + one per attendee-per-meeting),
+  // which is intentionally larger than the number of timeline rows
+  // shown below — those are de-duplicated to one row per
+  // message I exchanged with this person + one row per meeting we
+  // both attended. The label below makes that distinction explicit so
+  // users don't wonder why "500" doesn't match what they're scrolling.
   return (
-    <div className="space-y-4">
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        <Stat label="Total" value={summary.total.toLocaleString()} />
-        <Stat label="Emails" value={summary.email_count.toLocaleString()} />
-        <Stat label="Meetings" value={summary.meeting_count.toLocaleString()} />
-        <Stat
-          label="Last reply"
-          value={summary.last_inbound_at ? formatRelativeDate(summary.last_inbound_at) : "—"}
-        />
-      </div>
-      {summary.last_outbound_at && (
-        <div className="rounded-2xl border px-4 py-3 text-[13px]" style={{ borderColor: "var(--color-border)", background: "var(--color-surface)" }}>
-          <p style={{ color: "var(--color-text-muted)" }}>
-            You last reached out{" "}
-            <strong style={{ color: "var(--color-text)" }}>
-              {formatRelativeDate(summary.last_outbound_at)}
-            </strong>
-            .
-          </p>
+    <div className="space-y-6">
+      <section className="space-y-3">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Stat label="Interactions" value={summary.total.toLocaleString()} />
+          <Stat label="Emails" value={summary.email_count.toLocaleString()} />
+          <Stat label="Meetings" value={summary.meeting_count.toLocaleString()} />
+          <Stat
+            label="Last reply"
+            value={summary.last_inbound_at ? formatRelativeDate(summary.last_inbound_at) : "—"}
+          />
         </div>
-      )}
+        {summary.last_outbound_at && (
+          <div
+            className="rounded-2xl border px-4 py-3 text-[13px]"
+            style={{ borderColor: "var(--color-border)", background: "var(--color-surface)" }}
+          >
+            <p style={{ color: "var(--color-text-muted)" }}>
+              You last reached out{" "}
+              <strong style={{ color: "var(--color-text)" }}>
+                {formatRelativeDate(summary.last_outbound_at)}
+              </strong>
+              .
+            </p>
+          </div>
+        )}
+      </section>
+
+      <section>
+        <h3
+          className="mb-3 text-[11px] font-semibold uppercase tracking-[0.16em]"
+          style={{ color: "var(--color-text-muted)" }}
+        >
+          Timeline
+        </h3>
+        <ActivityTimeline
+          personId={data.person.id}
+          onOpenPerson={onOpenPerson}
+          onOpenCompany={onOpenCompany}
+        />
+      </section>
     </div>
   );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -11,6 +11,7 @@
 :root {
   /* Background / Surface */
   --color-bg: #f5f5f4;
+  --color-background: var(--color-bg); /* alias used widely in components */
   --color-surface: #ffffff;
   --color-sidebar-bg: #ebebea;
   --color-main-bg: #fafaf9;
@@ -101,6 +102,7 @@
 .dark {
   /* Background / Surface — warm neutral, layered for depth */
   --color-bg: #222222;
+  --color-background: var(--color-bg); /* alias used widely in components */
   --color-surface: #2e2e2e;
   --color-sidebar-bg: #1c1c1c;
   --color-main-bg: #282828;


### PR DESCRIPTION
Frontend for merged CRM APIs: profiles, inbox chrome, calendar, activity timeline.

Verification: `pnpm web:build`, `pnpm build`, `pnpm test`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to new client-side fetching/pagination and expanded inline detail views across multiple CRM screens, plus removal of inbox focus mode/filter UI that could change navigation behavior.
> 
> **Overview**
> Adds a new per-person `ActivityTimeline` view that fetches `/api/crm/people/:id/activity`, groups rows into date buckets (Today/Yesterday/This week/Last week/This month/Older), supports inline expansion (email thread reader or meeting detail panel), and paginates via “Show more”; date bucketing/labels are covered by new unit tests.
> 
> Refactors meeting lists in `CalendarView`, `PersonProfile`, and `CompanyProfile` to use a shared expandable `EventListItem` with lazy-loaded details from `/api/crm/calendar/:id` (organizer/attendees/companies), and refactors profile email tabs to use a shared `ProfileThreadList` that expands `ThreadMessages` inline (with updated thread summary fields).
> 
> Simplifies Inbox UI by removing focus mode plumbing and sender filter pills (leaving search + bulk actions), and adds a `--color-background` CSS alias used across new components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 324e463cf953ff302fca362367c5803646bd06da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->