### PR TITLE
feat(web): workspace shell UI (sidebar, content, object chrome)

### DIFF
--- a/apps/web/app/components/workspace/breadcrumbs.tsx
+++ b/apps/web/app/components/workspace/breadcrumbs.tsx
@@ -3,9 +3,13 @@
 type BreadcrumbsProps = {
   path: string;
   onNavigate: (path: string) => void;
+  /** Optional per-segment formatter (e.g. prettify CRM object names). Receives
+   *  the raw segment plus the partial path up to that segment. Falls back to
+   *  the raw segment text when omitted. */
+  formatSegment?: (segment: string, partialPath: string) => string;
 };
 
-export function Breadcrumbs({ path, onNavigate }: BreadcrumbsProps) {
+export function Breadcrumbs({ path, onNavigate, formatSegment }: BreadcrumbsProps) {
   const isAbsolute = path.startsWith("/");
   const segments = path.split("/").filter(Boolean);
 
@@ -33,6 +37,8 @@ export function Breadcrumbs({ path, onNavigate }: BreadcrumbsProps) {
       {segments.map((segment, idx) => {
         const partialPath = (isAbsolute ? "/" : "") + segments.slice(0, idx + 1).join("/");
         const isLast = idx === segments.length - 1;
+        const baseLabel = isLast ? segment.replace(/\.md$/, "") : segment;
+        const label = formatSegment ? formatSegment(baseLabel, partialPath) : baseLabel;
 
         return (
           <span key={partialPath} className="flex items-center gap-1">
@@ -55,7 +61,7 @@ export function Breadcrumbs({ path, onNavigate }: BreadcrumbsProps) {
                 className="px-1.5 py-0.5"
                 style={{ color: "var(--color-text)" }}
               >
-                {segment.replace(/\.md$/, "")}
+                {label}
               </span>
             ) : (
               <button
@@ -76,7 +82,7 @@ export function Breadcrumbs({ path, onNavigate }: BreadcrumbsProps) {
                     "transparent";
                 }}
               >
-                {segment}
+                {label}
               </button>
             )}
           </span>

--- a/apps/web/app/components/workspace/chat-sessions-sidebar.tsx
+++ b/apps/web/app/components/workspace/chat-sessions-sidebar.tsx
@@ -45,22 +45,6 @@ export type SidebarGatewaySession = {
 	};
 };
 
-export type SidebarChannelStatus = {
-	id: string;
-	configured: boolean;
-	running: boolean;
-	connected: boolean;
-	error?: string;
-};
-
-type SidebarTab = {
-	id: string;
-	label: string;
-	icon?: () => React.JSX.Element;
-	iconColor?: string;
-	count?: number;
-};
-
 type ChatSessionsSidebarProps = {
 	sessions: WebSession[];
 	activeSessionId: string | null;
@@ -82,11 +66,8 @@ type ChatSessionsSidebarProps = {
 	loading?: boolean;
 	embedded?: boolean;
 	gatewaySessions?: SidebarGatewaySession[];
-	channelStatuses?: SidebarChannelStatus[];
 	activeGatewaySessionKey?: string | null;
 	onSelectGatewaySession?: (sessionKey: string, sessionId: string) => void;
-	fileScopedSessions?: WebSession[];
-	heartbeatInfo?: { intervalMs: number; nextDueEstimateMs: number | null } | null;
 };
 
 function timeAgo(ts: number): string {
@@ -109,7 +90,7 @@ function timeAgo(ts: number): string {
 
 function PlusIcon() {
 	return (
-		<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+		<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
 			<path d="M5 12h14" /><path d="M12 5v14" />
 		</svg>
 	);
@@ -119,14 +100,6 @@ function SubagentIcon() {
 	return (
 		<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
 			<path d="M16 3h5v5" /><path d="m21 3-7 7" /><path d="M21 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h6" />
-		</svg>
-	);
-}
-
-function ChatBubbleIcon() {
-	return (
-		<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-			<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
 		</svg>
 	);
 }
@@ -195,30 +168,6 @@ function IMessageIcon() {
 	);
 }
 
-function CronIcon() {
-	return (
-		<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-			<circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" />
-		</svg>
-	);
-}
-
-function HeartbeatIcon() {
-	return (
-		<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-			<path d="M22 12h-4l-3 9L9 3l-3 9H2" />
-		</svg>
-	);
-}
-
-function FileIcon() {
-	return (
-		<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-			<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" /><path d="M14 2v4a2 2 0 0 0 2 2h4" />
-		</svg>
-	);
-}
-
 function GoogleChatIcon() {
 	return (
 		<svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
@@ -244,41 +193,31 @@ const CHANNEL_META: Record<string, { label: string; icon: () => React.JSX.Elemen
 	imessage: { label: "iMessage", icon: IMessageIcon, color: "#34C759" },
 	googlechat: { label: "Google Chat", icon: GoogleChatIcon, color: "#00AC47" },
 	nostr: { label: "Nostr", icon: NostrIcon, color: "#8B5CF6" },
-	cron: { label: "Crons", icon: CronIcon, color: "var(--color-text-muted)" },
 };
 
-function ChannelIcon({ channel, size = 12 }: { channel: string; size?: number }) {
+function ChannelMark({ channel }: { channel: string }) {
 	const meta = CHANNEL_META[channel];
-	if (!meta) return <ChatBubbleIcon />;
+	if (!meta) return null;
 	const Icon = meta.icon;
 	return (
-		<span style={{ color: meta.color, width: size, height: size, display: "inline-flex" }}>
+		<span
+			className="inline-flex shrink-0 items-center justify-center"
+			style={{ color: meta.color, width: 12, height: 12 }}
+			title={meta.label}
+			aria-label={meta.label}
+		>
 			<Icon />
 		</span>
 	);
 }
 
-function ConnectionDot({ status }: { status: "connected" | "running" | "configured" | "error" }) {
-	const color = status === "connected" ? "#22c55e"
-		: status === "running" ? "#eab308"
-		: status === "error" ? "#ef4444"
-		: "var(--color-text-muted)";
-	return (
-		<span
-			className="inline-block rounded-full shrink-0"
-			style={{ width: 6, height: 6, background: color }}
-			title={status}
-		/>
-	);
-}
+// ── Native (DenchClaw) row ──
 
-// ── Reusable session row for web sessions ──
-
-function WebSessionRow({
+function NativeRow({
 	session, isActive, isHovered, isStreaming, sessionSubagents,
 	activeSubagentKey, renamingId, renameValue,
 	onHover, onLeave, onSelect, onStartRename, onCommitRename, onCancelRename, onRenameChange,
-	onDelete, onStop, onSelectSubagent, onStopSubagent, showFilePath,
+	onDelete, onStop, onSelectSubagent, onStopSubagent,
 }: {
 	session: WebSession; isActive: boolean; isHovered: boolean; isStreaming: boolean;
 	sessionSubagents?: SidebarSubagentInfo[]; activeSubagentKey?: string | null;
@@ -290,7 +229,6 @@ function WebSessionRow({
 	onRenameChange?: (val: string) => void;
 	onDelete?: (id: string) => void; onStop?: (id: string) => void;
 	onSelectSubagent?: (key: string) => void; onStopSubagent?: (key: string) => void;
-	showFilePath?: boolean;
 }) {
 	const [ctxOpen, setCtxOpen] = useState(false);
 	const showMore = isHovered || isStreaming || ctxOpen;
@@ -303,7 +241,7 @@ function WebSessionRow({
 			onMouseLeave={() => { if (!ctxOpen) onLeave(); }}
 		>
 			<div
-				className="flex items-stretch w-full rounded-xl"
+				className="flex items-stretch w-full rounded-lg"
 				style={{
 					background: isActive ? "var(--color-chat-sidebar-active-bg)"
 						: highlighted ? "var(--color-surface-hover)" : "transparent",
@@ -322,26 +260,16 @@ function WebSessionRow({
 						/>
 					</form>
 				) : (
-					<button type="button" onClick={() => onSelect(session.id)} className="flex-1 min-w-0 text-left px-2 py-2 rounded-l-lg transition-colors cursor-pointer">
+					<button type="button" onClick={() => onSelect(session.id)} className="flex-1 min-w-0 text-left px-2 py-1.5 rounded-l-lg cursor-pointer">
 						<div className="flex items-center gap-1.5">
 							{isStreaming && <UnicodeSpinner name="braille" className="text-[10px] flex-shrink-0" style={{ color: "var(--color-chat-sidebar-muted)" }} />}
 							<div className="text-xs font-medium truncate" style={{ color: isActive ? "var(--color-chat-sidebar-active-text)" : "var(--color-text)" }}>
 								{session.title || "Untitled chat"}
 							</div>
 						</div>
-						<div className="flex items-center gap-2 mt-0.5" style={{ paddingLeft: isStreaming ? "calc(0.375rem + 6px)" : undefined }}>
-							<span className="text-[10px]" style={{ color: "var(--color-text-muted)" }}>{timeAgo(session.updatedAt)}</span>
-							{session.messageCount > 0 && (
-								<span className="text-[10px]" style={{ color: "var(--color-text-muted)" }}>
-									{session.messageCount} msg{session.messageCount !== 1 ? "s" : ""}
-								</span>
-							)}
+						<div className="mt-0.5 text-[10px]" style={{ color: "var(--color-text-muted)", paddingLeft: isStreaming ? "calc(0.375rem + 6px)" : undefined }}>
+							{timeAgo(session.updatedAt)}
 						</div>
-						{showFilePath && session.filePath && (
-							<div className="text-[9px] mt-0.5 truncate" style={{ color: "var(--color-text-muted)", opacity: 0.7 }}>
-								{session.filePath}
-							</div>
-						)}
 					</button>
 				)}
 				<div className={`shrink-0 flex items-center pr-1 gap-0.5 transition-opacity ${showMore ? "opacity-100" : "opacity-0"}`}>
@@ -385,7 +313,7 @@ function WebSessionRow({
 						return (
 							<div key={sa.childSessionKey} className="flex items-center">
 								<button type="button" onClick={() => onSelectSubagent?.(sa.childSessionKey)}
-									className="flex-1 text-left pl-3 pr-2 py-1.5 rounded-r-lg transition-colors cursor-pointer"
+									className="flex-1 text-left pl-3 pr-2 py-1.5 rounded-r-lg cursor-pointer"
 									style={{ background: isSubActive ? "var(--color-chat-sidebar-active-bg)" : "transparent" }}>
 									<div className="flex items-center gap-1.5">
 										{isSubRunning && <UnicodeSpinner name="braille" className="text-[9px] flex-shrink-0" style={{ color: "var(--color-chat-sidebar-muted)" }} />}
@@ -435,9 +363,9 @@ function WebSessionRow({
 	);
 }
 
-// ── Gateway session row ──
+// ── Gateway (channel) row ──
 
-function GatewaySessionRow({
+function GatewayRow({
 	gs, isActive, isHovered, onHover, onLeave, onSelect,
 }: {
 	gs: SidebarGatewaySession; isActive: boolean; isHovered: boolean;
@@ -447,23 +375,65 @@ function GatewaySessionRow({
 	return (
 		<div onMouseEnter={() => onHover(gs.sessionKey)} onMouseLeave={onLeave}>
 			<button type="button" onClick={() => onSelect(gs.sessionKey, gs.sessionId)}
-				className="w-full text-left px-2 py-2 rounded-lg transition-colors cursor-pointer"
+				className="w-full text-left px-2 py-1.5 rounded-lg cursor-pointer"
 				style={{
 					background: isActive ? "var(--color-chat-sidebar-active-bg)"
 						: isHovered ? "var(--color-surface-hover)" : "transparent",
 				}}>
 				<div className="flex items-center gap-1.5">
-					<ChannelIcon channel={gs.channel} size={11} />
+					<ChannelMark channel={gs.channel} />
 					<div className="text-xs font-medium truncate" style={{ color: isActive ? "var(--color-chat-sidebar-active-text)" : "var(--color-text)" }}>
 						{gs.title}
 					</div>
 				</div>
-				<div className="flex items-center gap-2 mt-0.5 pl-[calc(11px+0.375rem)]">
-					<span className="text-[10px]" style={{ color: "var(--color-text-muted)" }}>{timeAgo(gs.updatedAt)}</span>
+				<div className="mt-0.5 text-[10px]" style={{ color: "var(--color-text-muted)", paddingLeft: "calc(12px + 0.375rem)" }}>
+					{timeAgo(gs.updatedAt)}
 				</div>
 			</button>
 		</div>
 	);
+}
+
+// ── Unified row plumbing ──
+
+type UnifiedRow =
+	| { kind: "native"; ts: number; session: WebSession }
+	| { kind: "gateway"; ts: number; gs: SidebarGatewaySession };
+
+type RowGroup = {
+	label: string;
+	rows: UnifiedRow[];
+};
+
+function groupRows(rows: UnifiedRow[]): RowGroup[] {
+	const now = new Date();
+	const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+	const yesterdayStart = todayStart - 86400000;
+	const weekStart = todayStart - 7 * 86400000;
+	const monthStart = todayStart - 30 * 86400000;
+
+	const today: UnifiedRow[] = [];
+	const yesterday: UnifiedRow[] = [];
+	const thisWeek: UnifiedRow[] = [];
+	const thisMonth: UnifiedRow[] = [];
+	const older: UnifiedRow[] = [];
+
+	for (const r of rows) {
+		const t = r.ts;
+		if (t >= todayStart) today.push(r);
+		else if (t >= yesterdayStart) yesterday.push(r);
+		else if (t >= weekStart) thisWeek.push(r);
+		else if (t >= monthStart) thisMonth.push(r);
+		else older.push(r);
+	}
+
+	const groups: RowGroup[] = [];
+	if (today.length > 0) groups.push({ label: "today", rows: today });
+	if (yesterday.length > 0) groups.push({ label: "yesterday", rows: yesterday });
+	if (thisWeek.length > 0) groups.push({ label: "this week", rows: thisWeek });
+	if (thisMonth.length > 0) groups.push({ label: "this month", rows: thisMonth });
+	if (older.length > 0) groups.push({ label: "older", rows: older });
+	return groups;
 }
 
 export function ChatSessionsSidebar({
@@ -487,16 +457,12 @@ export function ChatSessionsSidebar({
 	loading = false,
 	embedded = false,
 	gatewaySessions,
-	channelStatuses,
 	activeGatewaySessionKey,
 	onSelectGatewaySession,
-	fileScopedSessions,
-	heartbeatInfo,
 }: ChatSessionsSidebarProps) {
 	const [hoveredId, setHoveredId] = useState<string | null>(null);
 	const [renamingId, setRenamingId] = useState<string | null>(null);
 	const [renameValue, setRenameValue] = useState("");
-	const [activeFilter, setActiveFilter] = useState("denchclaw");
 
 	const handleSelect = useCallback(
 		(id: string) => { onSelectSession(id); onClose?.(); },
@@ -545,86 +511,28 @@ export function ChatSessionsSidebar({
 		return map;
 	}, [subagents]);
 
-	const denchClawSessions = useMemo(
-		() => sessions.filter((s) => !s.id.includes(":subagent:") && !s.filePath),
-		[sessions],
-	);
-
-	const grouped = groupSessions(denchClawSessions);
-
-	const channelStatusMap = useMemo(() => {
-		const map = new Map<string, SidebarChannelStatus>();
-		if (!channelStatuses) return map;
-		for (const cs of channelStatuses) map.set(cs.id, cs);
-		return map;
-	}, [channelStatuses]);
-
-	const gatewayByChannel = useMemo(() => {
-		const map = new Map<string, SidebarGatewaySession[]>();
-		if (!gatewaySessions) return map;
-		for (const gs of gatewaySessions) {
-			let list = map.get(gs.channel);
-			if (!list) { list = []; map.set(gs.channel, list); }
-			list.push(gs);
+	const groups = useMemo(() => {
+		const rows: UnifiedRow[] = [];
+		for (const s of sessions) {
+			if (s.id.includes(":subagent:") || s.filePath) continue;
+			rows.push({ kind: "native", ts: s.updatedAt, session: s });
 		}
-		return map;
-	}, [gatewaySessions]);
-
-	const fileScopedGrouped = useMemo(
-		() => groupSessions(fileScopedSessions ?? []),
-		[fileScopedSessions],
-	);
-
-	const cronSessions = gatewayByChannel.get("cron");
-
-	// ── Dynamic tab list ──
-	const tabs = useMemo(() => {
-		const result: SidebarTab[] = [
-			{ id: "denchclaw", label: "DenchClaw", count: denchClawSessions.length },
-		];
-		const channelOrder = ["telegram", "whatsapp", "discord", "slack", "signal", "imessage", "googlechat", "nostr"];
-		for (const channel of channelOrder) {
-			const channelSessions = gatewayByChannel.get(channel);
-			if (!channelSessions?.length) continue;
-			const meta = CHANNEL_META[channel];
-			result.push({
-				id: channel,
-				label: meta?.label ?? channel,
-				icon: meta?.icon,
-				iconColor: meta?.color,
-				count: channelSessions.length,
-			});
+		if (gatewaySessions) {
+			for (const gs of gatewaySessions) {
+				if (gs.channel === "cron" || gs.channel === "unknown") continue;
+				rows.push({ kind: "gateway", ts: gs.updatedAt, gs });
+			}
 		}
-		for (const [channel, channelSessions] of gatewayByChannel.entries()) {
-			if (channelOrder.includes(channel) || channel === "cron" || channel === "unknown") continue;
-			const meta = CHANNEL_META[channel];
-			result.push({
-				id: channel,
-				label: meta?.label ?? channel,
-				icon: meta?.icon,
-				iconColor: meta?.color,
-				count: channelSessions.length,
-			});
-		}
-		if (cronSessions?.length) {
-			result.push({ id: "cron", label: "Crons", icon: CronIcon, count: cronSessions.length });
-			result.push({ id: "heartbeat", label: "Heartbeat", icon: HeartbeatIcon });
-		}
-		if ((fileScopedSessions?.length ?? 0) > 0) {
-			result.push({ id: "other", label: "Other", icon: FileIcon, count: fileScopedSessions!.length });
-		}
-		return result;
-	}, [denchClawSessions, gatewayByChannel, cronSessions, fileScopedSessions]);
+		rows.sort((a, b) => b.ts - a.ts);
+		return groupRows(rows);
+	}, [sessions, gatewaySessions]);
 
-	const hasTabs = tabs.length > 1;
+	const totalRows = groups.reduce((acc, g) => acc + g.rows.length, 0);
 
-	const width = mobile ? "280px" : (widthProp ?? 260);
 	const headerHeight = embedded ? 36 : 40;
-	const filterHeight = hasTabs ? 30 : 0;
 
-	// ── Content renderer per active filter ──
 	const renderContent = () => {
-		if (loading && sessions.length === 0 && !(gatewaySessions?.length)) {
+		if (loading && totalRows === 0) {
 			return (
 				<div className="px-4 py-8 flex flex-col items-center justify-center min-h-[120px]">
 					<UnicodeSpinner name="braille" className="text-xl mb-2" style={{ color: "var(--color-text-muted)" }} />
@@ -633,171 +541,64 @@ export function ChatSessionsSidebar({
 			);
 		}
 
-		if (activeFilter === "denchclaw") {
-			if (denchClawSessions.length === 0) {
-				return (
-					<div className="px-4 py-8 text-center">
-						<div className="mx-auto w-10 h-10 rounded-xl flex items-center justify-center mb-3" style={{ background: "var(--color-surface-hover)", color: "var(--color-text-muted)" }}>
-							<ChatBubbleIcon />
-						</div>
-						<p className="text-xs" style={{ color: "var(--color-text-muted)" }}>
-							No conversations yet.<br />Start a new chat to begin.
-						</p>
-					</div>
-				);
-			}
-			return (
-				<div className="px-2 py-1">
-					{grouped.map((group) => (
-						<div key={group.label}>
-							<div className="px-2 pt-3 pb-1 text-[10px] font-medium uppercase tracking-wider" style={{ color: "var(--color-text-muted)" }}>
-								{group.label}
-							</div>
-							{group.sessions.map((session) => (
-								<WebSessionRow
-									key={session.id}
-									session={session}
-									isActive={session.id === activeSessionId && !activeSubagentKey && !activeGatewaySessionKey}
-									isHovered={session.id === hoveredId}
-									isStreaming={streamingSessionIds?.has(session.id) ?? false}
-									sessionSubagents={subagentsByParent.get(session.id)}
-									activeSubagentKey={activeSubagentKey}
-									renamingId={renamingId} renameValue={renameValue}
-									onHover={setHoveredId} onLeave={() => setHoveredId(null)}
-									onSelect={handleSelect}
-									onStartRename={onRenameSession ? handleStartRename : undefined}
-									onCommitRename={handleCommitRename} onCancelRename={handleCancelRename}
-									onRenameChange={setRenameValue}
-									onDelete={onDeleteSession ? handleDeleteSession : undefined}
-									onStop={onStopSession}
-									onSelectSubagent={handleSelectSubagentItem}
-									onStopSubagent={onStopSubagent}
-								/>
-							))}
-						</div>
-					))}
-				</div>
-			);
-		}
-
-		if (activeFilter === "heartbeat") {
-			return (
-				<div className="px-2 py-1">
-					{/* Gateway health card */}
-					<div className="mx-1 mb-2 p-2.5 rounded-lg" style={{ background: "var(--color-surface-hover)" }}>
-						<div className="flex items-center gap-2 mb-1.5">
-							<ConnectionDot status={channelStatuses?.some((c) => c.connected) ? "connected" : channelStatuses?.some((c) => c.running) ? "running" : "configured"} />
-							<span className="text-[11px] font-medium" style={{ color: "var(--color-text)" }}>
-								Gateway {channelStatuses?.some((c) => c.connected) ? "Connected" : "Disconnected"}
-							</span>
-						</div>
-						{heartbeatInfo && (
-							<div className="space-y-0.5">
-								<div className="text-[10px]" style={{ color: "var(--color-text-muted)" }}>
-									Interval: {Math.round(heartbeatInfo.intervalMs / 60000)}m
-								</div>
-								{heartbeatInfo.nextDueEstimateMs && (
-									<div className="text-[10px]" style={{ color: "var(--color-text-muted)" }}>
-										Next: {timeAgo(heartbeatInfo.nextDueEstimateMs).replace(" ago", "")} from now
-									</div>
-								)}
-							</div>
-						)}
-						{!heartbeatInfo && (
-							<div className="text-[10px]" style={{ color: "var(--color-text-muted)" }}>No heartbeat data</div>
-						)}
-					</div>
-					{/* Cron sessions */}
-					{cronSessions?.map((gs) => (
-						<GatewaySessionRow
-							key={gs.sessionKey} gs={gs}
-							isActive={activeGatewaySessionKey === gs.sessionKey}
-							isHovered={hoveredId === gs.sessionKey}
-							onHover={setHoveredId} onLeave={() => setHoveredId(null)}
-							onSelect={handleSelectGateway}
-						/>
-					))}
-					{!cronSessions?.length && (
-						<div className="px-4 py-6 text-center">
-							<p className="text-xs" style={{ color: "var(--color-text-muted)" }}>No cron sessions</p>
-						</div>
-					)}
-				</div>
-			);
-		}
-
-		if (activeFilter === "other") {
-			if (!fileScopedSessions?.length) {
-				return (
-					<div className="px-4 py-8 text-center">
-						<p className="text-xs" style={{ color: "var(--color-text-muted)" }}>No file-scoped sessions</p>
-					</div>
-				);
-			}
-			return (
-				<div className="px-2 py-1">
-					{fileScopedGrouped.map((group) => (
-						<div key={group.label}>
-							<div className="px-2 pt-3 pb-1 text-[10px] font-medium uppercase tracking-wider" style={{ color: "var(--color-text-muted)" }}>
-								{group.label}
-							</div>
-							{group.sessions.map((session) => (
-								<WebSessionRow
-									key={session.id}
-									session={session}
-									isActive={session.id === activeSessionId && !activeSubagentKey && !activeGatewaySessionKey}
-									isHovered={session.id === hoveredId}
-									isStreaming={streamingSessionIds?.has(session.id) ?? false}
-									renamingId={renamingId} renameValue={renameValue}
-									onHover={setHoveredId} onLeave={() => setHoveredId(null)}
-									onSelect={handleSelect}
-									onCommitRename={handleCommitRename} onCancelRename={handleCancelRename}
-									onRenameChange={setRenameValue}
-									onDelete={onDeleteSession ? handleDeleteSession : undefined}
-									showFilePath
-								/>
-							))}
-						</div>
-					))}
-				</div>
-			);
-		}
-
-		// Channel-specific tab (telegram, whatsapp, discord, cron, etc.)
-		const channelSessions = gatewayByChannel.get(activeFilter);
-		const status = channelStatusMap.get(activeFilter);
-		const connectionState = status?.connected ? "connected"
-			: status?.running ? "running"
-			: status?.error ? "error"
-			: status?.configured ? "configured"
-			: undefined;
-
-		if (!channelSessions?.length) {
+		if (totalRows === 0) {
 			return (
 				<div className="px-4 py-8 text-center">
-					<p className="text-xs" style={{ color: "var(--color-text-muted)" }}>No sessions</p>
+					<p className="text-xs" style={{ color: "var(--color-text-muted)" }}>
+						No conversations yet.
+					</p>
 				</div>
 			);
 		}
 
 		return (
 			<div className="px-2 py-1">
-				{connectionState && (
-					<div className="px-2 pt-2 pb-1 flex items-center gap-1.5">
-						<ConnectionDot status={connectionState} />
-						<span className="text-[10px]" style={{ color: "var(--color-text-muted)" }}>
-							{connectionState === "connected" ? "Connected" : connectionState === "running" ? "Running" : connectionState === "error" ? "Error" : "Configured"}
-						</span>
+				{groups.map((group) => (
+					<div key={group.label}>
+						<div
+							className="px-2 pt-4 pb-1 text-[9px] lowercase"
+							style={{ color: "var(--color-text-muted)", letterSpacing: "0.05em" }}
+						>
+							{group.label}
+						</div>
+						{group.rows.map((row) => {
+							if (row.kind === "native") {
+								const session = row.session;
+								return (
+									<NativeRow
+										key={`n-${session.id}`}
+										session={session}
+										isActive={session.id === activeSessionId && !activeSubagentKey && !activeGatewaySessionKey}
+										isHovered={session.id === hoveredId}
+										isStreaming={streamingSessionIds?.has(session.id) ?? false}
+										sessionSubagents={subagentsByParent.get(session.id)}
+										activeSubagentKey={activeSubagentKey}
+										renamingId={renamingId} renameValue={renameValue}
+										onHover={setHoveredId} onLeave={() => setHoveredId(null)}
+										onSelect={handleSelect}
+										onStartRename={onRenameSession ? handleStartRename : undefined}
+										onCommitRename={handleCommitRename} onCancelRename={handleCancelRename}
+										onRenameChange={setRenameValue}
+										onDelete={onDeleteSession ? handleDeleteSession : undefined}
+										onStop={onStopSession}
+										onSelectSubagent={handleSelectSubagentItem}
+										onStopSubagent={onStopSubagent}
+									/>
+								);
+							}
+							const gs = row.gs;
+							return (
+								<GatewayRow
+									key={`g-${gs.sessionKey}`}
+									gs={gs}
+									isActive={activeGatewaySessionKey === gs.sessionKey}
+									isHovered={hoveredId === gs.sessionKey}
+									onHover={setHoveredId} onLeave={() => setHoveredId(null)}
+									onSelect={handleSelectGateway}
+								/>
+							);
+						})}
 					</div>
-				)}
-				{channelSessions.map((gs) => (
-					<GatewaySessionRow
-						key={gs.sessionKey} gs={gs}
-						isActive={activeGatewaySessionKey === gs.sessionKey}
-						isHovered={hoveredId === gs.sessionKey}
-						onHover={setHoveredId} onLeave={() => setHoveredId(null)}
-						onSelect={handleSelectGateway}
-					/>
 				))}
 			</div>
 		);
@@ -805,77 +606,49 @@ export function ChatSessionsSidebar({
 
 	const content = (
 		<div className="flex-1 min-h-0 relative">
-			<div className="absolute inset-0 overflow-y-auto" style={{ paddingTop: headerHeight + filterHeight }}>
+			<div className="absolute inset-0 overflow-y-auto" style={{ paddingTop: headerHeight }}>
 				{renderContent()}
 			</div>
 
 			{/* Header */}
 			<div
-			className={`absolute top-0 left-0 right-0 z-10 backdrop-blur-md ${embedded ? "" : "border-b"}`}
-			style={{
-				borderColor: embedded ? undefined : "var(--color-border)",
-				background: "color-mix(in srgb, var(--color-bg) 80%, transparent)",
-			}}
+				className={`absolute top-0 left-0 right-0 z-10 backdrop-blur-md ${embedded ? "" : "border-b"}`}
+				style={{
+					borderColor: embedded ? undefined : "var(--color-border)",
+					background: "color-mix(in srgb, var(--color-bg) 80%, transparent)",
+				}}
 			>
-				<div className="flex items-center justify-between px-4" style={{ height: headerHeight }}>
-					<div className="min-w-0 flex-1 flex items-center gap-1.5">
-						{onCollapse && (
-							<button type="button" onClick={onCollapse}
-								className="p-1 rounded-md shrink-0 transition-colors hover:bg-black/5"
-								style={{ color: "var(--color-text-muted)" }} title="Hide chat sidebar">
-								<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-									<rect width="18" height="18" x="3" y="3" rx="2" /><path d="M15 3v18" />
-								</svg>
-							</button>
-						)}
-						<span
-							className={embedded ? "text-[10px] font-semibold uppercase tracking-[0.14em] truncate block" : "text-xs font-medium truncate block"}
-							style={{ color: embedded ? "var(--color-text-muted)" : "var(--color-text)" }}
+				<div className="flex items-center justify-between px-3" style={{ height: headerHeight }}>
+					{onCollapse ? (
+						<button
+							type="button" onClick={onCollapse}
+							className="p-1 rounded-md transition-colors hover:bg-black/5"
+							style={{ color: "var(--color-text-muted)" }}
+							title="Hide chat sidebar"
 						>
-							Chats
-						</span>
-					</div>
-					<button type="button" onClick={onNewSession}
-						className={`flex items-center gap-1 px-2 py-1 rounded-lg text-[11px] font-medium transition-all cursor-pointer shrink-0 ml-1.5 ${embedded ? "bg-stone-200 text-stone-700 hover:bg-stone-300 dark:bg-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-600" : ""}`}
-						style={{
-							color: embedded ? undefined : "var(--color-chat-sidebar-active-text)",
-							background: embedded ? undefined : "var(--color-chat-sidebar-active-bg)",
+							<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+								<rect width="18" height="18" x="3" y="3" rx="2" /><path d="M15 3v18" />
+							</svg>
+						</button>
+					) : <span />}
+					<button
+						type="button" onClick={onNewSession}
+						className="flex items-center gap-1 px-2 py-1 rounded-lg text-[11px] font-medium transition-colors cursor-pointer"
+						style={{ color: "var(--color-text-muted)" }}
+						onMouseEnter={(e) => {
+							(e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)";
+							(e.currentTarget as HTMLElement).style.color = "var(--color-text)";
 						}}
-						title="New chat">
+						onMouseLeave={(e) => {
+							(e.currentTarget as HTMLElement).style.background = "transparent";
+							(e.currentTarget as HTMLElement).style.color = "var(--color-text-muted)";
+						}}
+						title="New chat"
+					>
 						<PlusIcon />
 						New
 					</button>
 				</div>
-				{/* Dynamic tab strip */}
-				{hasTabs && (
-					<div className="flex items-center gap-0.5 px-2 pb-1.5 overflow-x-auto scrollbar-none">
-						{tabs.map((tab) => {
-							const isActive = activeFilter === tab.id;
-							const TabIcon = tab.icon;
-							return (
-								<button
-									key={tab.id} type="button"
-									onClick={() => setActiveFilter(tab.id)}
-									className="flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium transition-colors cursor-pointer shrink-0 whitespace-nowrap"
-									style={{
-										color: isActive ? "var(--color-chat-sidebar-active-text)" : "var(--color-text-muted)",
-										background: isActive ? "var(--color-chat-sidebar-active-bg)" : "transparent",
-									}}
-								>
-									{TabIcon && (
-										<span style={{ color: isActive ? undefined : (tab.iconColor ?? "var(--color-text-muted)"), display: "inline-flex" }}>
-											<TabIcon />
-										</span>
-									)}
-									{tab.label}
-									{tab.count !== undefined && tab.count > 0 && (
-										<span className="text-[9px] opacity-60">{tab.count}</span>
-									)}
-								</button>
-							);
-						})}
-					</div>
-				)}
 			</div>
 		</div>
 	);
@@ -884,6 +657,7 @@ export function ChatSessionsSidebar({
 		return content;
 	}
 
+	const width = mobile ? "280px" : (widthProp ?? 260);
 	const sidebar = (
 		<aside
 			className={`flex flex-col h-full shrink-0 ${mobile ? "drawer-right" : "border-l"}`}
@@ -908,42 +682,4 @@ export function ChatSessionsSidebar({
 			</div>
 		</div>
 	);
-}
-
-// ── Grouping helpers ──
-
-type SessionGroup = {
-	label: string;
-	sessions: WebSession[];
-};
-
-function groupSessions(sessions: WebSession[]): SessionGroup[] {
-	const now = new Date();
-	const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
-	const yesterdayStart = todayStart - 86400000;
-	const weekStart = todayStart - 7 * 86400000;
-	const monthStart = todayStart - 30 * 86400000;
-
-	const today: WebSession[] = [];
-	const yesterday: WebSession[] = [];
-	const thisWeek: WebSession[] = [];
-	const thisMonth: WebSession[] = [];
-	const older: WebSession[] = [];
-
-	for (const s of sessions) {
-		const t = s.updatedAt;
-		if (t >= todayStart) today.push(s);
-		else if (t >= yesterdayStart) yesterday.push(s);
-		else if (t >= weekStart) thisWeek.push(s);
-		else if (t >= monthStart) thisMonth.push(s);
-		else older.push(s);
-	}
-
-	const groups: SessionGroup[] = [];
-	if (today.length > 0) groups.push({ label: "Today", sessions: today });
-	if (yesterday.length > 0) groups.push({ label: "Yesterday", sessions: yesterday });
-	if (thisWeek.length > 0) groups.push({ label: "This Week", sessions: thisWeek });
-	if (thisMonth.length > 0) groups.push({ label: "This Month", sessions: thisMonth });
-	if (older.length > 0) groups.push({ label: "Older", sessions: older });
-	return groups;
 }

--- a/apps/web/app/components/workspace/crm-object-icon.tsx
+++ b/apps/web/app/components/workspace/crm-object-icon.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { DynamicIcon, type IconName } from "lucide-react/dynamic";
+import { IconTableFilled } from "@tabler/icons-react";
+
+/**
+ * Renders a lucide icon by its kebab-case name (matches the convention used by
+ * `<object>/.object.yaml` `icon:` fields, e.g. `user-plus`, `check-square`).
+ *
+ * Lazy-loads each icon via `lucide-react/dynamic` so the bundle stays small —
+ * only icons that actually appear in a workspace's sidebar are downloaded.
+ * Falls back to the Tabler table icon when `name` is missing, unknown, or
+ * still loading.
+ */
+export function CrmObjectIcon({
+	name,
+	size = 16,
+}: {
+	name?: string | null;
+	size?: number;
+}) {
+	const fallback = () => (
+		<IconTableFilled size={size} style={{ flexShrink: 0 }} />
+	);
+	if (!name) return fallback();
+	return (
+		<DynamicIcon
+			name={name as IconName}
+			size={size}
+			fallback={fallback}
+			className="shrink-0"
+		/>
+	);
+}

--- a/apps/web/app/components/workspace/entry-detail-modal.tsx
+++ b/apps/web/app/components/workspace/entry-detail-modal.tsx
@@ -5,6 +5,7 @@ import { RelationSelect } from "./relation-select";
 import { FormattedFieldValue } from "./formatted-field-value";
 import { formatWorkspaceFieldValue } from "@/lib/workspace-cell-format";
 import { parseTagsValue } from "@/lib/parse-tags";
+import { displayObjectName, displayObjectNameSingular } from "@/lib/object-display-name";
 import { UrlFavicon } from "./url-favicon";
 import { LinkOpenButton } from "./link-open-button";
 
@@ -360,7 +361,7 @@ function ReverseRelationSection({
         <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: 0.4 }}>
           <path d="m12 19-7-7 7-7" /><path d="M19 12H5" />
         </svg>
-        <span className="capitalize">{relation.sourceObjectName}</span>
+        <span>{displayObjectName(relation.sourceObjectName)}</span>
         <span className="normal-case tracking-normal font-normal opacity-60">
           via {relation.fieldName}
         </span>
@@ -377,7 +378,7 @@ function ReverseRelationSection({
               color: "#c084fc",
               border: "1px solid rgba(192, 132, 252, 0.2)",
             }}
-            title={`Open ${link.label} in ${relation.sourceObjectName}`}
+            title={`Open ${link.label} in ${displayObjectName(relation.sourceObjectName)}`}
           >
             <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="flex-shrink-0" style={{ opacity: 0.5 }}>
               <path d="M7 7h10v10" /><path d="M7 17 17 7" />
@@ -564,9 +565,10 @@ export function EntryDetailModal({
   }, [objectName, entryId, onRefresh, onClose]);
 
   const displayField = data?.effectiveDisplayField;
+  const objectLabel = displayObjectNameSingular(String(objectName));
   const title = displayField && data?.entry[displayField]
     ? safeString(data.entry[displayField])
-    : `${String(objectName)} entry`;
+    : `${objectLabel} entry`;
   const createdAtValue = data ? resolveEntryMetaValue(data.entry, CREATED_AT_KEYS) : undefined;
   const updatedAtValue = data ? resolveEntryMetaValue(data.entry, UPDATED_AT_KEYS) : undefined;
 
@@ -595,18 +597,18 @@ export function EntryDetailModal({
             <button
               type="button"
               onClick={() => void onNavigateObject?.(objectName)}
-              className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium capitalize transition-colors hover:opacity-80 flex-shrink-0"
+              className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium transition-colors hover:opacity-80 flex-shrink-0"
               style={{
                 background: "var(--color-accent-light)",
                 color: "var(--color-accent)",
                 border: "1px solid var(--color-border)",
               }}
-              title={`Go to ${objectName}`}
+              title={`Go to ${objectLabel}`}
             >
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M12 3v18" /><rect width="18" height="18" x="3" y="3" rx="2" /><path d="M3 9h18" /><path d="M3 15h18" />
               </svg>
-              {objectName}
+              {objectLabel}
             </button>
             <h2
               className="text-lg font-semibold truncate"

--- a/apps/web/app/components/workspace/entry-detail-panel.tsx
+++ b/apps/web/app/components/workspace/entry-detail-panel.tsx
@@ -5,6 +5,7 @@ import { RelationSelect } from "./relation-select";
 import { FormattedFieldValue } from "./formatted-field-value";
 import { formatWorkspaceFieldValue } from "@/lib/workspace-cell-format";
 import { parseTagsValue } from "@/lib/parse-tags";
+import { displayObjectName, displayObjectNameSingular } from "@/lib/object-display-name";
 import { MarkdownEditor } from "./markdown-editor";
 import type { TreeNode, MentionSearchFn } from "./slash-command";
 import { ActionButton, type ActionConfig } from "./action-button";
@@ -309,7 +310,7 @@ function ReverseRelationSection({ relation, onNavigateEntry }: { relation: Rever
     <div>
       <label className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider mb-1" style={{ color: "var(--color-text-muted)" }}>
         <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: 0.4 }}><path d="m12 19-7-7 7-7" /><path d="M19 12H5" /></svg>
-        <span className="capitalize">{relation.sourceObjectName}</span>
+        <span>{displayObjectName(relation.sourceObjectName)}</span>
         <span className="normal-case tracking-normal font-normal opacity-60">via {relation.fieldName}</span>
       </label>
       <div className="flex items-center gap-1 flex-wrap text-sm min-h-[1.5rem]">
@@ -317,7 +318,7 @@ function ReverseRelationSection({ relation, onNavigateEntry }: { relation: Rever
           <button type="button" key={link.id} onClick={() => onNavigateEntry?.(relation.sourceObjectName, link.id)}
             className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-medium cursor-pointer hover:opacity-80"
             style={{ background: "rgba(192, 132, 252, 0.1)", color: "#c084fc", border: "1px solid rgba(192, 132, 252, 0.2)" }}
-            title={`Open ${link.label} in ${relation.sourceObjectName}`}
+            title={`Open ${link.label} in ${displayObjectName(relation.sourceObjectName)}`}
           >
             <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: 0.5 }}><path d="M7 7h10v10" /><path d="M7 17 17 7" /></svg>
             <span className="truncate max-w-[180px]">{link.label}</span>
@@ -555,7 +556,8 @@ export function EntryDetailPanel({
   }, [objectName, entryId, onRefresh]);
 
   const displayField = data?.effectiveDisplayField;
-  const title = displayField && data?.entry[displayField] ? safeString(data.entry[displayField]) : `${String(objectName)} entry`;
+  const objectLabel = displayObjectNameSingular(String(objectName));
+  const title = displayField && data?.entry[displayField] ? safeString(data.entry[displayField]) : `${objectLabel} entry`;
   const createdAtValue = data ? resolveEntryMetaValue(data.entry, CREATED_AT_KEYS) : undefined;
   const updatedAtValue = data ? resolveEntryMetaValue(data.entry, UPDATED_AT_KEYS) : undefined;
 
@@ -570,14 +572,14 @@ export function EntryDetailPanel({
       <div className="flex items-center justify-between px-4 py-2 border-b flex-shrink-0" style={{ borderColor: "var(--color-border)" }}>
         <div className="flex items-center gap-2 min-w-0 flex-1">
           <button type="button" onClick={() => void onNavigateObject?.(objectName)}
-            className="flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-medium capitalize transition-colors hover:opacity-80 flex-shrink-0"
+            className="flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-medium transition-colors hover:opacity-80 flex-shrink-0"
             style={{ background: "var(--color-accent-light)", color: "var(--color-accent)", border: "1px solid var(--color-border)" }}
-            title={`Go to ${objectName}`}
+            title={`Go to ${objectLabel}`}
           >
             <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M12 3v18" /><rect width="18" height="18" x="3" y="3" rx="2" /><path d="M3 9h18" /><path d="M3 15h18" />
             </svg>
-            {objectName}
+            {objectLabel}
           </button>
           <h2 className="text-sm font-semibold truncate" style={{ color: "var(--color-text)" }}>
             {loading ? "" : title}

--- a/apps/web/app/components/workspace/file-manager-tree.tsx
+++ b/apps/web/app/components/workspace/file-manager-tree.tsx
@@ -41,6 +41,7 @@ import {
   isVirtualPath,
   toLocalClipboardPath,
 } from "@/lib/workspace-paths";
+import { displayObjectName } from "@/lib/object-display-name";
 
 // --- Types ---
 
@@ -525,7 +526,9 @@ function DraggableNode({
             onCancel={onCancelRename}
           />
         ) : (
-          <span className="truncate flex-1">{node.name}</span>
+          <span className="truncate flex-1">
+            {node.type === "object" ? displayObjectName(node.name) : node.name}
+          </span>
         )}
 
       </div>
@@ -609,7 +612,7 @@ function DragOverlayContent({ node }: { node: TreeNode }) {
       <span style={{ color: typeColor(node) }}>
         <NodeIcon node={node} />
       </span>
-      <span>{node.name}</span>
+      <span>{node.type === "object" ? displayObjectName(node.name) : node.name}</span>
     </div>
   );
 }

--- a/apps/web/app/components/workspace/object-filter-bar.tsx
+++ b/apps/web/app/components/workspace/object-filter-bar.tsx
@@ -12,6 +12,7 @@ import {
 	filterId,
 	emptyFilterGroup,
 } from "@/lib/object-filters";
+import { displayObjectName } from "@/lib/object-display-name";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -483,7 +484,7 @@ function RelationValueEditor({
 				const ids = v.split(",").map((s) => s.trim()).filter(Boolean);
 				onChange(ids.length === 1 ? ids[0] : ids);
 			}}
-			placeholder={relatedObjectName ? `Search ${relatedObjectName}...` : "ID..."}
+			placeholder={relatedObjectName ? `Search ${displayObjectName(relatedObjectName)}...` : "ID..."}
 		/>
 	);
 }

--- a/apps/web/app/components/workspace/object-kanban.tsx
+++ b/apps/web/app/components/workspace/object-kanban.tsx
@@ -15,6 +15,7 @@ import {
 } from "@dnd-kit/core";
 import { formatWorkspaceFieldValue } from "@/lib/workspace-cell-format";
 import { parseTagsValue } from "@/lib/parse-tags";
+import { displayObjectName } from "@/lib/object-display-name";
 import { ActionButton, type ActionConfig } from "./action-button";
 import { useToast } from "./toast";
 import { UrlFavicon } from "./url-favicon";
@@ -698,7 +699,7 @@ export function ObjectKanban({
         <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>
           No enum field found for kanban grouping in{" "}
           <span className="font-medium" style={{ color: "var(--color-text)" }}>
-            {objectName}
+            {displayObjectName(objectName)}
           </span>
         </p>
       </div>

--- a/apps/web/app/components/workspace/object-table.tsx
+++ b/apps/web/app/components/workspace/object-table.tsx
@@ -7,6 +7,7 @@ import { RelationSelect } from "./relation-select";
 import { FormattedFieldValue } from "./formatted-field-value";
 import { formatWorkspaceFieldValue } from "@/lib/workspace-cell-format";
 import { parseTagsValue } from "@/lib/parse-tags";
+import { displayObjectName, displayObjectNameSingular } from "@/lib/object-display-name";
 import { ActionButton, useActionStates, type ActionConfig } from "./action-button";
 import { ConfirmDialog } from "./confirm-dialog";
 import { BulkActionBar } from "./bulk-action-bar";
@@ -820,7 +821,7 @@ export function ObjectTable({
 						<span className="truncate">{field.name}</span>
 						{field.type === "relation" && field.related_object_name && (
 							<span className="text-[9px] font-normal normal-case tracking-normal opacity-60 shrink-0">
-								({field.related_object_name})
+								({displayObjectName(field.related_object_name)})
 							</span>
 						)}
 						<ColumnHeaderMenu
@@ -918,13 +919,13 @@ export function ObjectTable({
 		for (const rr of activeReverseRelations) {
 			cols.push({
 				id: `rev_${rr.sourceObjectName}_${rr.fieldName}`,
-				meta: { label: `${rr.sourceObjectName} (via ${rr.fieldName})`, fieldType: "relation" },
+				meta: { label: `${displayObjectName(rr.sourceObjectName)} (via ${rr.fieldName})`, fieldType: "relation" },
 				header: () => (
 					<span className="flex items-center gap-1.5" style={{ color: "var(--color-text-muted)" }}>
 						<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: 0.4 }}>
 							<path d="m12 19-7-7 7-7" /><path d="M19 12H5" />
 						</svg>
-						<span className="capitalize">{rr.sourceObjectName}</span>
+						<span>{displayObjectName(rr.sourceObjectName)}</span>
 						<span className="text-[9px] font-normal normal-case tracking-normal opacity-50">via {rr.fieldName}</span>
 					</span>
 				),
@@ -1133,7 +1134,7 @@ export function ObjectTable({
 			rowSelection={rowSelection}
 			onRowSelectionChange={setRowSelection}
 			onColumnReorder={handleColumnReorder}
-			searchPlaceholder={`Search ${objectName}...`}
+			searchPlaceholder={`Search ${displayObjectName(objectName)}...`}
 			onRefresh={onRefresh}
 			onAdd={handleAdd}
 			addButtonLabel="+ Add"
@@ -1259,8 +1260,8 @@ export function AddEntryModal({
 					className="flex items-center justify-between px-6 py-4 border-b flex-shrink-0"
 					style={{ borderColor: "var(--color-border)" }}
 				>
-					<h2 className="text-lg font-semibold capitalize" style={{ color: "var(--color-text)" }}>
-						Add {objectName}
+					<h2 className="text-lg font-semibold" style={{ color: "var(--color-text)" }}>
+						Add {displayObjectNameSingular(objectName)}
 					</h2>
 					<button type="button" onClick={onClose} className="p-1.5 rounded-lg" style={{ color: "var(--color-text-muted)" }}>
 						<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -1287,7 +1288,7 @@ export function AddEntryModal({
 									{field.name}
 									{isRelation && field.related_object_name && (
 										<span className="normal-case tracking-normal font-normal opacity-60 ml-1">
-											({field.related_object_name})
+											({displayObjectName(field.related_object_name)})
 										</span>
 									)}
 								</label>
@@ -1355,7 +1356,7 @@ export function AddEntryModal({
 										value={values[field.name] ?? ""}
 										multiple={field.relationship_type === "many_to_many"}
 										onChange={(v) => updateField(field.name, v)}
-										placeholder={`Select ${field.related_object_name}...`}
+										placeholder={`Select ${displayObjectNameSingular(field.related_object_name)}...`}
 									/>
 								) : isUser ? (
 									<select

--- a/apps/web/app/components/workspace/relation-select.tsx
+++ b/apps/web/app/components/workspace/relation-select.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
+import { displayObjectName, displayObjectNameSingular } from "@/lib/object-display-name";
 
 type Option = { id: string; label: string };
 
@@ -178,7 +179,7 @@ export function RelationSelect({
 					))
 				) : (
 					<span style={{ color: "var(--color-text-muted)", opacity: 0.5 }}>
-						{placeholder ?? `Select ${relatedObjectName}...`}
+						{placeholder ?? `Select ${displayObjectNameSingular(relatedObjectName)}...`}
 					</span>
 				)}
 				{/* Chevron */}
@@ -209,7 +210,7 @@ export function RelationSelect({
 							type="text"
 							value={search}
 							onChange={(e) => setSearch(e.target.value)}
-							placeholder={`Search ${relatedObjectName}...`}
+							placeholder={`Search ${displayObjectName(relatedObjectName)}...`}
 							className="w-full px-2.5 py-1.5 text-xs rounded-md outline-none"
 							style={{
 								background: "var(--color-surface)",

--- a/apps/web/app/components/workspace/right-panel.tsx
+++ b/apps/web/app/components/workspace/right-panel.tsx
@@ -1,175 +1,21 @@
 "use client";
 
 import { type ReactNode } from "react";
-import { type Tab, HOME_TAB_ID } from "@/lib/tab-state";
 
 type RightPanelProps = {
-	/** Content tabs shown in the right panel's tab strip (opened files, CRM, cloud, etc.). */
-	tabs: Tab[];
-	activeTabId: string | null;
-	onActivate: (tabId: string) => void;
-	onClose: (tabId: string) => void;
-	onCloseOthers: (tabId: string) => void;
-	onCloseToRight: (tabId: string) => void;
-	onCloseAll: () => void;
-	onReorder: (tabId: string, from: number, to: number) => void;
-	onTogglePin: (tabId: string) => void;
-	onMakePermanent?: (tabId: string) => void;
-	/** Toggle the panel's visibility. */
-	onCollapse?: () => void;
-	/** Whether the permanent Files tab is the current surface. */
-	filesTabActive?: boolean;
-	/** Activate the permanent Files tab. */
-	onActivateFilesTab?: () => void;
 	children: ReactNode;
 };
 
-function tabDisplayTitle(tab: Tab): string {
-	if (!tab.title) return "Untitled";
-	return tab.title.length > 24 ? tab.title.slice(0, 22) + "…" : tab.title;
-}
-
 /**
- * Right-side workspace panel. Hosts Files (tree + preview), CRM pages, entry details,
- * cloud settings, etc. Center is always the chat panel.
- *
- * v3 design: pill-style tabs at the top. "Files" is always the first (permanent) tab.
- * Opening a file / CRM / cloud page adds a new pill next to Files.
+ * Right-side workspace panel container. Hosts the togglable Files sidebar plus
+ * the unified tab strip + active content area (files, CRM pages, entry detail,
+ * cloud, cron, etc.). The tab strip and Files toggle live in workspace-content
+ * so the same layout can be reused for the mobile drawer.
  */
-export function RightPanel({
-	tabs,
-	activeTabId,
-	onActivate,
-	onClose,
-	onCollapse,
-	filesTabActive,
-	onActivateFilesTab,
-	children,
-}: RightPanelProps) {
-	const visibleTabs = tabs.filter((t) => t.id !== HOME_TAB_ID);
-
+export function RightPanel({ children }: RightPanelProps) {
 	return (
 		<div className="flex h-full min-h-0 flex-col overflow-hidden">
-			{/* Pill tab strip */}
-			<div
-				className="flex items-center gap-1 px-3 h-11 shrink-0 border-b overflow-x-auto"
-				style={{ borderColor: "var(--color-border)", background: "var(--color-bg)" }}
-			>
-				<button
-					type="button"
-					onClick={onActivateFilesTab}
-					className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[12px] font-medium transition-colors cursor-pointer shrink-0"
-					style={{
-						color: filesTabActive ? "var(--color-text)" : "var(--color-text-muted)",
-						background: filesTabActive ? "var(--color-surface-hover)" : "transparent",
-					}}
-					title="Files"
-				>
-					<svg
-						width="13"
-						height="13"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						strokeWidth="2"
-						strokeLinecap="round"
-						strokeLinejoin="round"
-						aria-hidden
-					>
-						<path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
-					</svg>
-					Files
-				</button>
-
-				{visibleTabs.map((tab) => {
-					const isActive = tab.id === activeTabId && !filesTabActive;
-					return (
-						<div
-							key={tab.id}
-							className="flex items-center rounded-md shrink-0"
-							style={{
-								background: isActive ? "var(--color-surface-hover)" : "transparent",
-							}}
-						>
-							<button
-								type="button"
-								onClick={() => onActivate(tab.id)}
-								className="pl-2.5 pr-1 py-1 text-[12px] font-medium transition-colors cursor-pointer"
-								style={{
-									color: isActive ? "var(--color-text)" : "var(--color-text-muted)",
-									fontStyle: tab.preview ? "italic" : "normal",
-								}}
-								title={tab.title}
-							>
-								{tabDisplayTitle(tab)}
-							</button>
-							<button
-								type="button"
-								onClick={(e) => {
-									e.stopPropagation();
-									onClose(tab.id);
-								}}
-								className="p-0.5 rounded-md mr-0.5 cursor-pointer"
-								style={{ color: "var(--color-text-muted)" }}
-								title="Close tab"
-								onMouseEnter={(e) => {
-									(e.currentTarget as HTMLElement).style.background = "var(--color-border)";
-								}}
-								onMouseLeave={(e) => {
-									(e.currentTarget as HTMLElement).style.background = "transparent";
-								}}
-							>
-								<svg
-									width="12"
-									height="12"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-									strokeLinecap="round"
-									strokeLinejoin="round"
-								>
-									<path d="M18 6 6 18" />
-									<path d="m6 6 12 12" />
-								</svg>
-							</button>
-						</div>
-					);
-				})}
-
-				<div className="flex-1" />
-
-				{onCollapse && (
-					<button
-						type="button"
-						onClick={onCollapse}
-						className="p-1.5 rounded-md cursor-pointer shrink-0"
-						style={{ color: "var(--color-text-muted)" }}
-						title="Hide right panel (⌘⇧B)"
-						onMouseEnter={(e) => {
-							(e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)";
-						}}
-						onMouseLeave={(e) => {
-							(e.currentTarget as HTMLElement).style.background = "transparent";
-						}}
-					>
-						<svg
-							width="14"
-							height="14"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							strokeWidth="2"
-							strokeLinecap="round"
-							strokeLinejoin="round"
-						>
-							<rect width="18" height="18" x="3" y="3" rx="2" />
-							<path d="M15 3v18" />
-						</svg>
-					</button>
-				)}
-			</div>
-			<div className="flex-1 min-h-0 overflow-hidden">{children}</div>
+			{children}
 		</div>
 	);
 }

--- a/apps/web/app/components/workspace/slash-command.tsx
+++ b/apps/web/app/components/workspace/slash-command.tsx
@@ -16,6 +16,7 @@ import { createPortal } from "react-dom";
 import type { Editor, Range } from "@tiptap/core";
 import type { SearchIndexItem } from "@/lib/search-index";
 import { buildEntryLink, buildFileLink } from "@/lib/workspace-links";
+import { displayObjectName, displayObjectNameSingular } from "@/lib/object-display-name";
 
 // Unique plugin keys so both suggestions can coexist
 const slashCommandPluginKey = new PluginKey("slashCommand");
@@ -156,16 +157,18 @@ const entryIcon = (
 /** Convert a SearchIndexItem to a SlashItem for the @ mention popup. */
 function searchItemToSlashItem(item: SearchIndexItem): SlashItem {
   if (item.kind === "entry") {
-    const label = item.label || `(${item.objectName} entry)`;
+    const insertedLabel = item.label || `(${item.objectName} entry)`;
+    const displayObjLabel = item.objectName ? displayObjectNameSingular(item.objectName) : "";
+    const displayTitle = item.label || (item.objectName ? `(${displayObjLabel} entry)` : insertedLabel);
     return {
-      title: label,
+      title: displayTitle,
       description: item.fields
         ? Object.entries(item.fields)
             .slice(0, 2)
             .map(([k, v]) => `${k}: ${v}`)
             .join(" | ")
         : undefined,
-      badge: item.objectName,
+      badge: displayObjLabel || item.objectName,
       icon: entryIcon,
       category: "entry",
       command: ({ editor, range }: { editor: Editor; range: Range }) => {
@@ -176,7 +179,7 @@ function searchItemToSlashItem(item: SearchIndexItem): SlashItem {
           .deleteRange(range)
           .insertContent({
             type: "text",
-            text: label,
+            text: insertedLabel,
             marks: [{ type: "link", attrs: { href, target: null } }],
           })
           .run();
@@ -186,8 +189,9 @@ function searchItemToSlashItem(item: SearchIndexItem): SlashItem {
 
   const nodeType = item.nodeType ?? (item.kind === "object" ? "object" : "file");
   const label = item.label || item.path || item.id;
+  const displayLabel = item.kind === "object" ? displayObjectName(label) : label;
   return {
-    title: label,
+    title: displayLabel,
     description: item.sublabel,
     icon: nodeTypeIcon(nodeType),
     category: "file",

--- a/apps/web/app/components/workspace/workspace-sidebar.tsx
+++ b/apps/web/app/components/workspace/workspace-sidebar.tsx
@@ -20,8 +20,17 @@ import { type TreeNode } from "./file-manager-tree";
 import { ProfileSwitcher } from "./profile-switcher";
 import { CreateWorkspaceDialog } from "./create-workspace-dialog";
 import { ChatSessionsSidebar } from "./chat-sessions-sidebar";
-import type { WebSession, SidebarSubagentInfo, SidebarGatewaySession, SidebarChannelStatus } from "./chat-sessions-sidebar";
+import type { WebSession, SidebarSubagentInfo, SidebarGatewaySession } from "./chat-sessions-sidebar";
 import type { SearchIndexItem } from "@/lib/search-index";
+import { displayObjectName } from "@/lib/object-display-name";
+import { CrmObjectIcon } from "./crm-object-icon";
+
+/** Descriptor for a custom CRM table rendered in the sidebar's CRM section. */
+export type CustomCrmObject = {
+	name: string;
+	icon?: string;
+	defaultView?: "table" | "kanban";
+};
 
 /** Shape returned by /api/workspace/suggest-files */
 export type SuggestItem = {
@@ -34,7 +43,7 @@ function indexItemToSuggestItem(item: SearchIndexItem): SuggestItem {
 	const fullPath = item.path ?? item.id;
 	const fileName = fullPath.split("/").pop() ?? item.label;
 	return {
-		name: item.kind === "object" ? item.label : fileName,
+		name: item.kind === "object" ? displayObjectName(item.label) : fileName,
 		path: fullPath,
 		type: (item.nodeType ?? (item.kind === "object" ? "folder" : "file")) as SuggestItem["type"],
 	};
@@ -67,6 +76,10 @@ type WorkspaceSidebarProps = {
 	onToggleHidden?: () => void;
 	/** Called when the user clicks the collapse/hide sidebar button. */
 	onCollapse?: () => void;
+	/** When true, render an icon-only minimal layout (collapsed-but-visible). */
+	compact?: boolean;
+	/** Toggle between compact (icon-only) and full mode. */
+	onToggleCompact?: () => void;
   /** Active workspace hint used by the switcher. */
   activeWorkspace?: string | null;
   /** Called after workspace switches or workspace creation so parent can refresh state. */
@@ -87,11 +100,8 @@ type WorkspaceSidebarProps = {
   onStopChatSession?: (sessionId: string) => void;
   onStopChatSubagent?: (sessionKey: string) => void;
   chatGatewaySessions?: SidebarGatewaySession[];
-  chatChannelStatuses?: SidebarChannelStatus[];
   chatActiveGatewaySessionKey?: string | null;
   onSelectGatewayChatSession?: (sessionKey: string, sessionId: string) => void;
-  chatFileScopedSessions?: WebSession[];
-  chatHeartbeatInfo?: { intervalMs: number; nextDueEstimateMs: number | null } | null;
   /** Navigate to a sidebar section (cloud, integrations, skills, cron). */
   onNavigate?: (
     target:
@@ -106,6 +116,12 @@ type WorkspaceSidebarProps = {
   ) => void;
   /** Currently-active CRM nav item, used to highlight the row. */
   activeCrmTarget?: "people" | "companies" | "inbox" | "calendar" | null;
+  /** Custom CRM tables (workspace.duckdb objects) to list under the default CRM nav. */
+  customCrmObjects?: CustomCrmObject[];
+  /** Currently-active custom CRM object name, used to highlight the row. */
+  activeCrmObjectName?: string | null;
+  /** Click handler invoked with the custom CRM object's name. */
+  onNavigateToCrmObject?: (objectName: string) => void;
   /** Client-side search function from useSearchIndex for instant results. */
   searchFn?: (query: string, limit?: number) => SearchIndexItem[];
 };
@@ -114,18 +130,20 @@ function ThemeToggle() {
 	const { resolvedTheme, setTheme } = useTheme();
 	const [mounted, setMounted] = useState(false);
 	useEffect(() => setMounted(true), []);
-	if (!mounted) return <div className="w-[28px] h-[28px]" />;
+	if (!mounted) return <div className="w-[26px] h-[26px]" />;
 	const isDark = resolvedTheme === "dark";
 	return (
 		<button
 			type="button"
 			onClick={() => setTheme(isDark ? "light" : "dark")}
-			className="p-1.5 rounded-lg"
+			className="p-1.5 rounded-lg transition-colors"
 			style={{ color: "var(--color-text-muted)" }}
+			onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)"; }}
+			onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = "transparent"; }}
 			title={isDark ? "Switch to light mode" : "Switch to dark mode"}
 		>
 			{isDark ? (
-				<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+				<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
 					<circle cx="12" cy="12" r="4" />
 					<path d="M12 2v2" /><path d="M12 20v2" />
 					<path d="m4.93 4.93 1.41 1.41" /><path d="m17.66 17.66 1.41 1.41" />
@@ -133,7 +151,7 @@ function ThemeToggle() {
 					<path d="m6.34 17.66-1.41 1.41" /><path d="m19.07 4.93-1.41 1.41" />
 				</svg>
 			) : (
-				<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+				<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
 					<path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
 				</svg>
 			)}
@@ -283,10 +301,15 @@ export function WorkspaceSidebar({
 	onToggleHidden,
 	width: widthProp,
 	onCollapse,
+	compact = false,
+	onToggleCompact,
   activeWorkspace,
   onWorkspaceChanged,
   onNavigate,
   activeCrmTarget = null,
+  customCrmObjects,
+  activeCrmObjectName = null,
+  onNavigateToCrmObject,
   searchFn,
   chatSessions,
   activeChatSessionId,
@@ -303,14 +326,296 @@ export function WorkspaceSidebar({
   onStopChatSession,
   onStopChatSubagent,
   chatGatewaySessions,
-  chatChannelStatuses,
   chatActiveGatewaySessionKey,
   onSelectGatewayChatSession,
-  chatFileScopedSessions,
-  chatHeartbeatInfo,
 }: WorkspaceSidebarProps) {
 	const width = mobile ? "280px" : (widthProp ?? 260);
+	const isCompact = !mobile && compact;
 	const [createWorkspaceOpen, setCreateWorkspaceOpen] = useState(false);
+
+	const orgInitial = (orgName || "W").trim().slice(0, 1).toUpperCase() || "W";
+
+	const crmNavItems = [
+		{
+			id: "crm-people" as const,
+			label: "People",
+			target: "people" as const,
+			icon: (
+				<svg className="h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+					<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+					<circle cx="9" cy="7" r="4" />
+					<path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+					<path d="M16 3.13a4 4 0 0 1 0 7.75" />
+				</svg>
+			),
+		},
+		{
+			id: "crm-companies" as const,
+			label: "Companies",
+			target: "companies" as const,
+			icon: (
+				<svg className="h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+					<path d="M3 21h18" />
+					<path d="M5 21V7l8-4v18" />
+					<path d="M19 21V11l-6-4" />
+					<path d="M9 9h0" />
+					<path d="M9 13h0" />
+					<path d="M9 17h0" />
+				</svg>
+			),
+		},
+		{
+			id: "crm-inbox" as const,
+			label: "Inbox",
+			target: "inbox" as const,
+			icon: (
+				<svg className="h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+					<polyline points="22 12 16 12 14 15 10 15 8 12 2 12" />
+					<path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11Z" />
+				</svg>
+			),
+		},
+		{
+			id: "crm-calendar" as const,
+			label: "Calendar",
+			target: "calendar" as const,
+			icon: (
+				<svg className="h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+					<rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+					<line x1="16" y1="2" x2="16" y2="6" />
+					<line x1="8" y1="2" x2="8" y2="6" />
+					<line x1="3" y1="10" x2="21" y2="10" />
+				</svg>
+			),
+		},
+	];
+
+	const bottomNavItems = [
+		{
+			id: "cloud" as const,
+			label: "Cloud",
+			icon: (
+				<svg className="h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+					<path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z" />
+				</svg>
+			),
+		},
+		{
+			id: "integrations" as const,
+			label: "Integrations",
+			icon: <RiApps2AiLine className="h-4 w-4 shrink-0" aria-hidden />,
+		},
+		{
+			id: "skills" as const,
+			label: "Skills",
+			icon: <GoTools className="h-4 w-4 shrink-0" aria-hidden />,
+		},
+		{
+			id: "cron" as const,
+			label: "Cron",
+			icon: (
+				<svg className="h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+					<circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" />
+				</svg>
+			),
+		},
+	];
+
+	const compactSidebar = (
+		<aside
+			className="flex flex-col h-screen shrink-0 border-r"
+			style={{
+				width: typeof width === "number" ? `${width}px` : width,
+				minWidth: typeof width === "number" ? `${width}px` : width,
+				background: "var(--color-bg)",
+				borderColor: "var(--color-border)",
+			}}
+		>
+			{/* Header: workspace switcher (icon-only). Click opens dropdown to switch workspaces. */}
+			<div className="flex items-center justify-center h-[44px] shrink-0">
+				<div className="w-9">
+					<ProfileSwitcher
+						activeWorkspaceHint={activeWorkspace ?? null}
+						onWorkspaceSwitch={() => { onWorkspaceChanged?.(); }}
+						onWorkspaceDelete={() => { onWorkspaceChanged?.(); }}
+						onCreateWorkspace={() => { setCreateWorkspaceOpen(true); }}
+						trigger={({ onClick, activeWorkspace: workspaceName, switching }) => (
+							<button
+								type="button"
+								onClick={onClick}
+								disabled={switching}
+								className="w-9 h-9 rounded-lg flex items-center justify-center font-semibold text-[13px] transition-colors"
+								style={{
+									color: "var(--color-text)",
+									background: "var(--color-surface-hover)",
+								}}
+								title={`${orgName || "Workspace"}${workspaceName ? ` — ${workspaceName}` : ""}`}
+							>
+								{orgInitial}
+							</button>
+						)}
+					/>
+				</div>
+			</div>
+
+			{/* Expand button — primary discoverability hint for compact mode. */}
+			{onToggleCompact && (
+				<div className="flex justify-center pb-0.5">
+					<button
+						type="button"
+						onClick={onToggleCompact}
+						className="w-9 h-9 rounded-lg flex items-center justify-center transition-colors"
+						style={{ color: "var(--color-text-muted)" }}
+						onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)"; }}
+						onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = "transparent"; }}
+						title="Expand sidebar"
+					>
+						<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+							<rect width="18" height="18" x="3" y="3" rx="2" />
+							<path d="M15 3v18" />
+							<path d="m8 9 3 3-3 3" />
+						</svg>
+					</button>
+				</div>
+			)}
+
+			{/* New chat icon — ghost style to match the chat sidebar's New button. */}
+			{onSelectChatSession && onNewChatSession && (
+				<div className="flex justify-center pt-0.5 pb-0.5">
+					<button
+						type="button"
+						onClick={onNewChatSession}
+						className="w-9 h-9 rounded-lg flex items-center justify-center transition-colors"
+						style={{ color: "var(--color-text-muted)" }}
+						onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)"; }}
+						onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = "transparent"; }}
+						title="New chat"
+					>
+						<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+							<path d="M5 12h14" /><path d="M12 5v14" />
+						</svg>
+					</button>
+				</div>
+			)}
+
+			{/* CRM nav (icons only). */}
+			{onNavigate && (
+				<div className="flex flex-col items-center gap-0.5 pt-1 pb-1">
+					{crmNavItems.map((item) => {
+						const active = activeCrmTarget === item.target;
+						return (
+							<button
+								key={item.id}
+								type="button"
+								onClick={() => onNavigate(item.id)}
+								className="w-9 h-9 rounded-lg flex items-center justify-center transition-colors"
+								style={{
+									color: "var(--color-text)",
+									background: active ? "var(--color-surface-hover)" : "transparent",
+								}}
+								onMouseEnter={(e) => {
+									if (active) return;
+									(e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)";
+								}}
+								onMouseLeave={(e) => {
+									if (active) return;
+									(e.currentTarget as HTMLElement).style.background = "transparent";
+								}}
+								title={item.label}
+								aria-label={item.label}
+							>
+								{item.icon}
+							</button>
+						);
+					})}
+					{customCrmObjects && customCrmObjects.length > 0 && onNavigateToCrmObject && customCrmObjects.map((obj) => {
+						const active = activeCrmObjectName === obj.name;
+						const label = displayObjectName(obj.name);
+						return (
+							<button
+								key={`crm-object-${obj.name}`}
+								type="button"
+								onClick={() => onNavigateToCrmObject(obj.name)}
+								className="w-9 h-9 rounded-lg flex items-center justify-center transition-colors"
+								style={{
+									color: "var(--color-text)",
+									background: active ? "var(--color-surface-hover)" : "transparent",
+								}}
+								onMouseEnter={(e) => {
+									if (active) return;
+									(e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)";
+								}}
+								onMouseLeave={(e) => {
+									if (active) return;
+									(e.currentTarget as HTMLElement).style.background = "transparent";
+								}}
+								title={label}
+								aria-label={label}
+							>
+								<CrmObjectIcon name={obj.icon} size={16} />
+							</button>
+						);
+					})}
+				</div>
+			)}
+
+			{/* Spacer pushes bottom nav + footer down. */}
+			<div className="flex-1 min-h-0" />
+
+			{/* Bottom nav (icons only). */}
+			{onNavigate && (
+				<div className="flex flex-col items-center gap-0.5 py-1">
+					{bottomNavItems.map((item) => (
+						<button
+							key={item.id}
+							type="button"
+							onClick={() => onNavigate(item.id)}
+							className="w-9 h-9 rounded-lg flex items-center justify-center transition-colors"
+							style={{ color: "var(--color-text)" }}
+							onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)"; }}
+							onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = "transparent"; }}
+							title={item.label}
+							aria-label={item.label}
+						>
+							{item.icon}
+						</button>
+					))}
+				</div>
+			)}
+
+			{/* Footer: theme toggle + dotfiles toggle, stacked. */}
+			<div className="flex flex-col items-center py-1.5 gap-0.5">
+				{onToggleHidden && (
+					<button
+						type="button"
+						onClick={onToggleHidden}
+						className="w-9 h-9 rounded-lg flex items-center justify-center transition-colors"
+						style={{ color: showHidden ? "var(--color-text)" : "var(--color-text-muted)" }}
+						onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)"; }}
+						onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = "transparent"; }}
+						title={showHidden ? "Hide dotfiles" : "Show dotfiles"}
+					>
+						<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+							{showHidden ? (
+								<>
+									<path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0" />
+									<circle cx="12" cy="12" r="3" />
+								</>
+							) : (
+								<>
+									<path d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49" />
+									<path d="M14.084 14.158a3 3 0 0 1-4.242-4.242" />
+									<path d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143" />
+									<path d="m2 2 20 20" />
+								</>
+							)}
+						</svg>
+					</button>
+				)}
+				<ThemeToggle />
+			</div>
+		</aside>
+	);
 
 	const sidebar = (
 		<aside
@@ -324,7 +629,7 @@ export function WorkspaceSidebar({
 		>
 			{/* Header — workspace switcher always visible; browse-mode controls moved to the right panel's Files view */}
 			<div
-				className="flex items-center gap-2 px-3 h-[52px] shrink-0"
+				className="flex items-center gap-1 px-2 h-[44px] shrink-0"
 			>
 				<div className="flex-1 min-w-0">
 					<ProfileSwitcher
@@ -337,17 +642,22 @@ export function WorkspaceSidebar({
 								type="button"
 								onClick={onClick}
 								disabled={switching}
-								className="group/ws text-[13px] flex items-center gap-2 truncate w-full transition-colors font-semibold rounded-xl px-2 py-1.5"
+								className="text-[13px] flex items-center gap-1.5 truncate w-full transition-colors rounded-lg px-2 py-1.5"
 								style={{ color: "var(--color-text)" }}
 								onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)"; }}
 								onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = "transparent"; }}
 								title="Switch workspace"
 							>
-								<span className="truncate">{orgName || "Workspace"}</span>
+								<span className="truncate font-semibold">{orgName || "Workspace"}</span>
+								{workspaceName && (
+									<>
+										<span className="shrink-0 opacity-40">/</span>
+										<span className="truncate text-[12px]" style={{ color: "var(--color-text-muted)" }}>
+											{workspaceName}
+										</span>
+									</>
+								)}
 								<span className="flex-1" />
-								<span className="px-2 py-0.5 rounded-lg text-[10px] leading-tight shrink-0 bg-stone-200 text-stone-600 dark:bg-stone-700 dark:text-stone-300">
-									{workspaceName || "-"}
-								</span>
 								<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0" style={{ color: "var(--color-text-muted)" }}>
 									<path d="m6 9 6 6 6-6" />
 								</svg>
@@ -355,95 +665,91 @@ export function WorkspaceSidebar({
 						)}
 					/>
 				</div>
-				{onCollapse && (
+				{(onToggleCompact || onCollapse) && (
 					<button
 						type="button"
-						onClick={onCollapse}
+						onClick={onToggleCompact ?? onCollapse}
 						className="p-1.5 rounded-lg shrink-0 transition-colors"
 						style={{ color: "var(--color-text-muted)" }}
 						onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)"; }}
 						onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = "transparent"; }}
-						title="Hide sidebar (⌘B)"
+						title={onToggleCompact ? "Collapse to icons" : "Hide sidebar (⌘B)"}
 					>
 						<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
 							<rect width="18" height="18" x="3" y="3" rx="2" />
-							<path d="M9 3v18" />
+							<path d="M15 3v18" />
+							<path d="m11 9-3 3 3 3" />
 						</svg>
 					</button>
 				)}
 			</div>
 
 		{onNavigate && (
-			<div className="px-2 pt-2 pb-1 space-y-0.5">
+			<div className="px-2 pt-1 pb-1">
 				<div
-					className="px-2 pb-1 text-[10px] font-semibold uppercase tracking-[0.14em]"
-					style={{ color: "var(--color-text-muted)" }}
+					className="px-2 pt-2 pb-1 text-[9px] lowercase"
+					style={{ color: "var(--color-text-muted)", letterSpacing: "0.05em" }}
 				>
-					CRM
+					workspace
 				</div>
-				{(
-					[
-						{ id: "crm-people" as const, label: "People", target: "people" as const, icon: (
-							<svg className="h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-								<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-								<circle cx="9" cy="7" r="4" />
-								<path d="M22 21v-2a4 4 0 0 0-3-3.87" />
-								<path d="M16 3.13a4 4 0 0 1 0 7.75" />
-							</svg>
-						) },
-						{ id: "crm-companies" as const, label: "Companies", target: "companies" as const, icon: (
-							<svg className="h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-								<path d="M3 21h18" />
-								<path d="M5 21V7l8-4v18" />
-								<path d="M19 21V11l-6-4" />
-								<path d="M9 9h0" />
-								<path d="M9 13h0" />
-								<path d="M9 17h0" />
-							</svg>
-						) },
-						{ id: "crm-inbox" as const, label: "Inbox", target: "inbox" as const, icon: (
-							<svg className="h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-								<polyline points="22 12 16 12 14 15 10 15 8 12 2 12" />
-								<path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11Z" />
-							</svg>
-						) },
-						{ id: "crm-calendar" as const, label: "Calendar", target: "calendar" as const, icon: (
-							<svg className="h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-								<rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
-								<line x1="16" y1="2" x2="16" y2="6" />
-								<line x1="8" y1="2" x2="8" y2="6" />
-								<line x1="3" y1="10" x2="21" y2="10" />
-							</svg>
-						) },
-					]
-				).map((item) => {
-					const active = activeCrmTarget === item.target;
-					return (
-						<button
-							key={item.id}
-							type="button"
-							onClick={() => onNavigate(item.id)}
-							className="w-full flex items-center gap-2.5 px-2 py-1.5 rounded-xl text-sm font-medium transition-colors"
-							style={{
-								color: active ? "var(--color-text)" : "var(--color-text-muted)",
-								background: active ? "var(--color-surface-hover)" : "transparent",
-							}}
-							onMouseEnter={(e) => {
-								if (active) return;
-								(e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)";
-								(e.currentTarget as HTMLElement).style.color = "var(--color-text)";
-							}}
-							onMouseLeave={(e) => {
-								if (active) return;
-								(e.currentTarget as HTMLElement).style.background = "transparent";
-								(e.currentTarget as HTMLElement).style.color = "var(--color-text-muted)";
-							}}
-						>
-							<span className="shrink-0">{item.icon}</span>
-							{item.label}
-						</button>
-					);
-				})}
+				<div className="space-y-0.5">
+					{crmNavItems.map((item) => {
+						const active = activeCrmTarget === item.target;
+						return (
+							<button
+								key={item.id}
+								type="button"
+								onClick={() => onNavigate(item.id)}
+								className="w-full flex items-center gap-2.5 px-2 py-1.5 rounded-lg text-[13px] transition-colors"
+								style={{
+									color: "var(--color-text)",
+									background: active ? "var(--color-surface-hover)" : "transparent",
+								}}
+								onMouseEnter={(e) => {
+									if (active) return;
+									(e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)";
+								}}
+								onMouseLeave={(e) => {
+									if (active) return;
+									(e.currentTarget as HTMLElement).style.background = "transparent";
+								}}
+							>
+								<span className="shrink-0" style={{ color: "var(--color-text-muted)" }}>{item.icon}</span>
+								{item.label}
+							</button>
+						);
+					})}
+					{customCrmObjects && customCrmObjects.length > 0 && onNavigateToCrmObject && customCrmObjects.map((obj) => {
+						const active = activeCrmObjectName === obj.name;
+						const label = displayObjectName(obj.name);
+						return (
+							<button
+								key={`crm-object-${obj.name}`}
+								type="button"
+								onClick={() => onNavigateToCrmObject(obj.name)}
+								className="w-full flex items-center gap-2.5 px-2 py-1.5 rounded-lg text-[13px] transition-colors"
+								style={{
+									color: "var(--color-text)",
+									background: active ? "var(--color-surface-hover)" : "transparent",
+								}}
+								onMouseEnter={(e) => {
+									if (active) return;
+									(e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)";
+								}}
+								onMouseLeave={(e) => {
+									if (active) return;
+									(e.currentTarget as HTMLElement).style.background = "transparent";
+								}}
+								title={label}
+							>
+								<span className="shrink-0" style={{ color: "var(--color-text-muted)" }}>
+									<CrmObjectIcon name={obj.icon} size={16} />
+								</span>
+								{label}
+							</button>
+						);
+					})}
+				</div>
 			</div>
 		)}
 
@@ -467,64 +773,41 @@ export function WorkspaceSidebar({
 						onStopSession={onStopChatSession}
 						onStopSubagent={onStopChatSubagent}
 						gatewaySessions={chatGatewaySessions ?? []}
-						channelStatuses={chatChannelStatuses ?? []}
 						activeGatewaySessionKey={chatActiveGatewaySessionKey ?? null}
 						onSelectGatewaySession={onSelectGatewayChatSession}
-						fileScopedSessions={chatFileScopedSessions ?? []}
-						heartbeatInfo={chatHeartbeatInfo ?? null}
 						embedded
 					/>
 				) : null}
 			</div>
 
 		{onNavigate && (
-			<div className="px-2 py-1.5 space-y-0.5">
-				{([
-					{ id: "cloud" as const, label: "Cloud", icon: (
-						<svg className="h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-							<path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z" />
-						</svg>
-					)},
-					{ id: "integrations" as const, label: "Integrations", icon: (
-						<RiApps2AiLine className="h-4 w-4 shrink-0" aria-hidden />
-					)},
-					{ id: "skills" as const, label: "Skills", icon: (
-						<GoTools className="h-4 w-4 shrink-0" aria-hidden />
-					)},
-					{ id: "cron" as const, label: "Cron", icon: (
-						<svg className="h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-							<circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" />
-						</svg>
-					)},
-				]).map((item) => (
+			<div className="px-2 py-1 space-y-0.5">
+				{bottomNavItems.map((item) => (
 					<button
 						key={item.id}
 						type="button"
 						onClick={() => onNavigate(item.id)}
-						className="w-full flex items-center gap-2.5 px-2 py-1.5 rounded-xl text-sm font-medium transition-colors"
-						style={{ color: "var(--color-text-muted)" }}
-						onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)"; (e.currentTarget as HTMLElement).style.color = "var(--color-text)"; }}
-						onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = "transparent"; (e.currentTarget as HTMLElement).style.color = "var(--color-text-muted)"; }}
+						className="w-full flex items-center gap-2.5 px-2 py-1.5 rounded-lg text-[13px] transition-colors"
+						style={{ color: "var(--color-text)" }}
+						onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)"; }}
+						onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = "transparent"; }}
 					>
-						<span className="shrink-0">{item.icon}</span>
+						<span className="shrink-0" style={{ color: "var(--color-text-muted)" }}>{item.icon}</span>
 						{item.label}
 					</button>
 				))}
 			</div>
 		)}
 
-		<div
-			className="px-3 py-2.5 border-t flex items-center justify-between"
-			style={{ borderColor: "var(--color-border)" }}
-		>
+		<div className="px-2 py-1.5 flex items-center justify-between">
 			<a
 				href="https://dench.com"
 				target="_blank"
 				rel="noopener noreferrer"
-				className="flex items-center gap-2 px-2 py-1.5 rounded-lg text-sm"
+				className="flex items-center gap-2 px-2 py-1 rounded-lg text-[11px]"
 				style={{ color: "var(--color-text-muted)" }}
 			>
-				dench.com{process.env.NEXT_PUBLIC_DENCHCLAW_VERSION ? ` (v${process.env.NEXT_PUBLIC_DENCHCLAW_VERSION})` : ""}
+				dench.com{process.env.NEXT_PUBLIC_DENCHCLAW_VERSION ? ` v${process.env.NEXT_PUBLIC_DENCHCLAW_VERSION}` : ""}
 			</a>
 			<div className="flex items-center gap-0.5">
 				{onToggleHidden && (
@@ -532,10 +815,10 @@ export function WorkspaceSidebar({
 						type="button"
 						onClick={onToggleHidden}
 						className="p-1.5 rounded-lg transition-colors"
-						style={{ color: showHidden ? "var(--color-accent)" : "var(--color-text-muted)" }}
+						style={{ color: showHidden ? "var(--color-text)" : "var(--color-text-muted)" }}
 						title={showHidden ? "Hide dotfiles" : "Show dotfiles"}
 					>
-						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+						<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
 							{showHidden ? (
 								<>
 									<path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0" />
@@ -562,7 +845,7 @@ export function WorkspaceSidebar({
 	if (!mobile) {
 		return (
 			<>
-				{sidebar}
+				{isCompact ? compactSidebar : sidebar}
 				<CreateWorkspaceDialog
 					isOpen={createWorkspaceOpen}
 					onClose={() => setCreateWorkspaceOpen(false)}

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -36,6 +36,7 @@ import { EntryDetailPanel } from "../components/workspace/entry-detail-panel";
 import { useSearchIndex } from "@/lib/search-index";
 import { parseWorkspaceLink, isWorkspaceLink, parseUrlState, buildUrl, buildWorkspaceSyncParams, type WorkspaceUrlState } from "@/lib/workspace-links";
 import { isCodeFile } from "@/lib/report-utils";
+import { displayObjectName, displayObjectNameSingular } from "@/lib/object-display-name";
 import { CronDashboard } from "../components/cron/cron-dashboard";
 import { SkillStorePanel } from "../components/skill-store/skill-store-panel";
 import { IntegrationsPanel } from "../components/integrations/integrations-panel";
@@ -54,7 +55,7 @@ import {
 } from "@/lib/object-filters";
 import { UnicodeSpinner } from "../components/unicode-spinner";
 import { ToastProvider } from "../components/workspace/toast";
-import { ChatSessionsSidebar, type SidebarGatewaySession, type SidebarChannelStatus } from "../components/workspace/chat-sessions-sidebar";
+import { ChatSessionsSidebar, type SidebarGatewaySession } from "../components/workspace/chat-sessions-sidebar";
 import { RightPanel } from "../components/workspace/right-panel";
 import {
   DropdownMenu,
@@ -229,13 +230,24 @@ type WebSession = {
   filePath?: string;
 };
 
-const LEFT_SIDEBAR_MIN = 200;
+// Left sidebar has two visual modes driven by width:
+// - compact (icon-only) at LEFT_SIDEBAR_COMPACT_WIDTH
+// - full (labels, chat list, CRM nav) at >= LEFT_SIDEBAR_FULL_MIN
+// Dragging the resize handle below LEFT_SIDEBAR_COMPACT_THRESHOLD snaps to compact;
+// dragging into the [threshold, full min) gap snaps to full min.
+const LEFT_SIDEBAR_COMPACT_WIDTH = 56;
+const LEFT_SIDEBAR_COMPACT_THRESHOLD = 140;
+const LEFT_SIDEBAR_FULL_MIN = 200;
+const LEFT_SIDEBAR_FULL_DEFAULT = 260;
+const LEFT_SIDEBAR_MIN = LEFT_SIDEBAR_COMPACT_WIDTH;
 const LEFT_SIDEBAR_MAX = 480;
 const RIGHT_PANEL_MIN = 360;
 const RIGHT_PANEL_MAX = 2000;
 const STORAGE_LEFT = "dench-workspace-left-sidebar-width";
 const STORAGE_RIGHT_PANEL = "dench-workspace-right-panel-width";
 const STORAGE_RIGHT_PANEL_COLLAPSED = "dench-workspace-right-panel-collapsed";
+const STORAGE_FILE_TREE_COLLAPSED = "dench-workspace-file-tree-collapsed";
+const FILE_TREE_WIDTH = 240;
 
 function clamp(n: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, n));
@@ -299,6 +311,138 @@ function ResizeHandle({
 }
 
 /**
+ * Small icon for a content tab in the unified right-panel tab strip. Picks an
+ * SVG by inspecting the tab's path/type so file tabs and CRM/page tabs render
+ * with a recognisable prefix even though they share the same strip.
+ */
+function TabIcon({ tab }: { tab: Tab }) {
+  const path = tab.path ?? "";
+  type IconKind =
+    | "people" | "company" | "inbox" | "calendar"
+    | "cloud" | "skills" | "integrations" | "cron"
+    | "app" | "object" | "folder" | "file";
+  const kind: IconKind = (() => {
+    if (path === "~crm/people") return "people";
+    if (path === "~crm/companies") return "company";
+    if (path === "~crm/inbox") return "inbox";
+    if (path === "~crm/calendar") return "calendar";
+    if (path.startsWith("~cloud")) return "cloud";
+    if (path.startsWith("~skills")) return "skills";
+    if (path.startsWith("~integrations")) return "integrations";
+    if (path.startsWith("~cron")) return "cron";
+    if (tab.type === "app" || path.includes(".dench.app")) return "app";
+    if (tab.type === "object") return "object";
+    if (tab.type === "file" && (!path || !path.includes("."))) return "folder";
+    return "file";
+  })();
+
+  const common = {
+    width: 12,
+    height: 12,
+    viewBox: "0 0 24 24",
+    fill: "none",
+    stroke: "currentColor",
+    strokeWidth: 2,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+    "aria-hidden": true,
+  };
+
+  switch (kind) {
+    case "people":
+      return (
+        <svg {...common}>
+          <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+          <circle cx="9" cy="7" r="4" />
+          <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+          <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+        </svg>
+      );
+    case "company":
+      return (
+        <svg {...common}>
+          <path d="M3 21h18" />
+          <path d="M5 21V7l8-4v18" />
+          <path d="M19 21V11l-6-4" />
+        </svg>
+      );
+    case "inbox":
+      return (
+        <svg {...common}>
+          <polyline points="22 12 16 12 14 15 10 15 8 12 2 12" />
+          <path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11Z" />
+        </svg>
+      );
+    case "calendar":
+      return (
+        <svg {...common}>
+          <rect width="18" height="18" x="3" y="4" rx="2" />
+          <path d="M16 2v4" />
+          <path d="M8 2v4" />
+          <path d="M3 10h18" />
+        </svg>
+      );
+    case "cloud":
+      return (
+        <svg {...common}>
+          <path d="M17.5 19a4.5 4.5 0 1 0-1.97-8.55A6 6 0 1 0 6 18h11.5Z" />
+        </svg>
+      );
+    case "skills":
+      return (
+        <svg {...common}>
+          <path d="m12 3 1.9 5.84H20l-4.95 3.6L16.95 18 12 14.4 7.05 18l1.9-5.56L4 8.84h6.1Z" />
+        </svg>
+      );
+    case "integrations":
+      return (
+        <svg {...common}>
+          <rect width="7" height="7" x="3" y="3" rx="1" />
+          <rect width="7" height="7" x="14" y="3" rx="1" />
+          <rect width="7" height="7" x="14" y="14" rx="1" />
+          <rect width="7" height="7" x="3" y="14" rx="1" />
+        </svg>
+      );
+    case "cron":
+      return (
+        <svg {...common}>
+          <circle cx="12" cy="12" r="10" />
+          <polyline points="12 6 12 12 16 14" />
+        </svg>
+      );
+    case "app":
+      return (
+        <svg {...common}>
+          <rect width="18" height="18" x="3" y="3" rx="2" />
+          <path d="M9 9h6v6H9z" />
+        </svg>
+      );
+    case "object":
+      return (
+        <svg {...common}>
+          <path d="M3 3h18v4H3z" />
+          <path d="M3 11h18v4H3z" />
+          <path d="M3 19h18v2H3z" />
+        </svg>
+      );
+    case "folder":
+      return (
+        <svg {...common}>
+          <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
+        </svg>
+      );
+    case "file":
+    default:
+      return (
+        <svg {...common}>
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+          <polyline points="14 2 14 8 20 8" />
+        </svg>
+      );
+  }
+}
+
+/**
  * v3 invariant: at least one chat tab must exist so the center never goes blank.
  * Wrap any setTabState that could remove the last chat tab with this helper.
  */
@@ -329,6 +473,38 @@ function findNode(
 function objectNameFromPath(path: string): string {
   const segments = path.split("/");
   return segments[segments.length - 1];
+}
+
+/**
+ * Walk the workspace tree and collect every object node that should appear in
+ * the sidebar's CRM section. Excludes `people` / `company` / `companies` since
+ * those already have dedicated rows in the hard-coded CRM nav. Hidden CRM-only
+ * objects (`email_thread` / `email_message` / `calendar_event` / `interaction`)
+ * are filtered out upstream by the tree API and never appear here.
+ */
+const CRM_NAV_EXCLUDED_OBJECT_NAMES: ReadonlySet<string> = new Set([
+  "people",
+  "company",
+  "companies",
+]);
+
+function collectCrmObjectNodes(
+  tree: TreeNode[],
+): Array<{ name: string; icon?: string; defaultView?: "table" | "kanban" }> {
+  const out: Array<{ name: string; icon?: string; defaultView?: "table" | "kanban" }> = [];
+  function walk(nodes: TreeNode[]) {
+    for (const node of nodes) {
+      if (node.type === "object") {
+        const name = objectNameFromPath(node.path);
+        if (!CRM_NAV_EXCLUDED_OBJECT_NAMES.has(name)) {
+          out.push({ name, icon: node.icon, defaultView: node.defaultView });
+        }
+      }
+      if (node.children) {walk(node.children);}
+    }
+  }
+  walk(tree);
+  return out.toSorted((a, b) => a.name.localeCompare(b.name));
 }
 
 /** Infer a tree node type from filename extension for ad-hoc path previews. */
@@ -479,12 +655,10 @@ function WorkspacePageInner() {
 
   // Gateway channel sessions
   const [gatewaySessions, setGatewaySessions] = useState<SidebarGatewaySession[]>([]);
-  const [channelStatuses, setChannelStatuses] = useState<SidebarChannelStatus[]>([]);
   const [activeGatewaySessionKey, setActiveGatewaySessionKey] = useState<string | null>(null);
 
   // Cron jobs state
   const [cronJobs, setCronJobs] = useState<CronJob[]>([]);
-  const [heartbeatInfo, setHeartbeatInfo] = useState<{ intervalMs: number; nextDueEstimateMs: number | null } | null>(null);
 
   // Cron URL-backed view state
   const [cronView, setCronView] = useState<import("@/lib/workspace-links").CronDashboardView>("overview");
@@ -506,6 +680,10 @@ function WorkspacePageInner() {
   const [leftSidebarCollapsed, setLeftSidebarCollapsed] = useState(false);
   const [rightPanelCollapsed, setRightPanelCollapsed] = useState(false);
   const [mobileRightPanelOpen, setMobileRightPanelOpen] = useState(false);
+  // File tree (right panel's left column) is now always available, independently
+  // togglable from the right-panel collapse so users can hide it on CRM/page tabs
+  // when they want more horizontal space. Persisted in localStorage.
+  const [fileTreeCollapsed, setFileTreeCollapsed] = useState(false);
 
   // v3: independent active tab ids per surface.
   // - activeChatTabId: which chat tab is visible in the center (always a chat or gateway-chat tab).
@@ -760,10 +938,14 @@ function WorkspacePageInner() {
   }, [activeSubagentKey, openSessionChatTab, subagents]);
 
   const openTabForNode = useCallback((node: { path: string; name: string; type: string }) => {
+    const isObject = node.type === "object";
+    const title = isObject
+      ? displayObjectName(node.name)
+      : inferTabTitle(node.path, node.name);
     const tab: Tab = {
       id: generateTabId(),
-      type: node.type === "object" ? "object" : inferTabType(node.path),
-      title: inferTabTitle(node.path, node.name),
+      type: isObject ? "object" : inferTabType(node.path),
+      title,
       path: node.path,
     };
     setTabState((prev) => openTab(prev, tab, { preview: true }));
@@ -771,13 +953,19 @@ function WorkspacePageInner() {
 
   // Resizable sidebar widths (desktop only; persisted in localStorage).
   // Use static defaults so server and client match on first render (avoid hydration mismatch).
-  const [leftSidebarWidth, setLeftSidebarWidth] = useState(260);
+  // New default is compact (icon-only); user can drag to expand into full mode.
+  const [leftSidebarWidth, setLeftSidebarWidth] = useState(LEFT_SIDEBAR_COMPACT_WIDTH);
   const [rightPanelWidth, setRightPanelWidth] = useState(520);
   useEffect(() => {
     const left = window.localStorage.getItem(STORAGE_LEFT);
     const nLeft = left ? parseInt(left, 10) : NaN;
     if (Number.isFinite(nLeft)) {
-      setLeftSidebarWidth(clamp(nLeft, LEFT_SIDEBAR_MIN, LEFT_SIDEBAR_MAX));
+      // Snap loaded width into a valid mode (compact or full range).
+      const snapped =
+        nLeft < LEFT_SIDEBAR_COMPACT_THRESHOLD
+          ? LEFT_SIDEBAR_COMPACT_WIDTH
+          : clamp(nLeft, LEFT_SIDEBAR_FULL_MIN, LEFT_SIDEBAR_MAX);
+      setLeftSidebarWidth(snapped);
     }
     const right = window.localStorage.getItem(STORAGE_RIGHT_PANEL);
     const nRight = right ? parseInt(right, 10) : NaN;
@@ -788,6 +976,32 @@ function WorkspacePageInner() {
     if (collapsed === "1") {
       setRightPanelCollapsed(true);
     }
+    const treeCollapsed = window.localStorage.getItem(STORAGE_FILE_TREE_COLLAPSED);
+    if (treeCollapsed === "1") {
+      setFileTreeCollapsed(true);
+    }
+  }, []);
+
+  // Whether the left sidebar is in compact (icon-only) mode.
+  const isLeftSidebarCompact = leftSidebarWidth < LEFT_SIDEBAR_FULL_MIN;
+
+  // Snap-aware resize handler: dragging below the compact threshold snaps to icon mode;
+  // dragging into the gap between threshold and full min snaps to full min.
+  const handleLeftSidebarResize = useCallback((w: number) => {
+    if (w < LEFT_SIDEBAR_COMPACT_THRESHOLD) {
+      setLeftSidebarWidth(LEFT_SIDEBAR_COMPACT_WIDTH);
+    } else if (w < LEFT_SIDEBAR_FULL_MIN) {
+      setLeftSidebarWidth(LEFT_SIDEBAR_FULL_MIN);
+    } else {
+      setLeftSidebarWidth(clamp(w, LEFT_SIDEBAR_FULL_MIN, LEFT_SIDEBAR_MAX));
+    }
+  }, []);
+
+  // Toggle handler for keyboard shortcut and the sidebar's expand/collapse button.
+  const toggleLeftSidebarCompact = useCallback(() => {
+    setLeftSidebarWidth((current) =>
+      current < LEFT_SIDEBAR_FULL_MIN ? LEFT_SIDEBAR_FULL_DEFAULT : LEFT_SIDEBAR_COMPACT_WIDTH,
+    );
   }, []);
   useEffect(() => {
     window.localStorage.setItem(STORAGE_LEFT, String(leftSidebarWidth));
@@ -798,6 +1012,9 @@ function WorkspacePageInner() {
   useEffect(() => {
     window.localStorage.setItem(STORAGE_RIGHT_PANEL_COLLAPSED, rightPanelCollapsed ? "1" : "0");
   }, [rightPanelCollapsed]);
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_FILE_TREE_COLLAPSED, fileTreeCollapsed ? "1" : "0");
+  }, [fileTreeCollapsed]);
 
   // Keyboard shortcuts: Cmd+B = toggle left sidebar, Cmd+Shift+B = toggle right sidebar, Cmd+J = toggle terminal
   useEffect(() => {
@@ -812,6 +1029,12 @@ function WorkspacePageInner() {
         } else {
           setLeftSidebarCollapsed((v) => !v);
         }
+        return;
+      }
+
+      if (mod && key === "e" && !e.shiftKey && !e.altKey) {
+        e.preventDefault();
+        setFileTreeCollapsed((v) => !v);
         return;
       }
 
@@ -888,8 +1111,6 @@ function WorkspacePageInner() {
   }, [refreshContext]);
 
   // Fetch chat sessions
-  const [fileScopedSessions, setFileScopedSessions] = useState<WebSession[]>([]);
-
   const fetchSessions = useCallback(async () => {
     setSessionsLoading(true);
     try {
@@ -897,7 +1118,6 @@ function WorkspacePageInner() {
       const data = await res.json();
       const all: Array<WebSession & { filePath?: string }> = data.sessions ?? [];
       setSessions(all.filter((s) => !s.filePath));
-      setFileScopedSessions(all.filter((s) => !!s.filePath));
     } catch {
       // ignore
     } finally {
@@ -932,21 +1152,11 @@ function WorkspacePageInner() {
     } catch { /* ignore */ }
   }, []);
 
-  const fetchChannelStatuses = useCallback(async () => {
-    try {
-      const res = await fetch("/api/gateway/channels");
-      const data = await res.json();
-      setChannelStatuses(data.channels ?? []);
-    } catch { /* ignore */ }
-  }, []);
-
   useEffect(() => {
     void fetchGatewaySessions();
-    void fetchChannelStatuses();
     const gwInterval = setInterval(fetchGatewaySessions, 10_000);
-    const chInterval = setInterval(fetchChannelStatuses, 30_000);
-    return () => { clearInterval(gwInterval); clearInterval(chInterval); };
-  }, [fetchGatewaySessions, fetchChannelStatuses]);
+    return () => { clearInterval(gwInterval); };
+  }, [fetchGatewaySessions]);
 
   const handleWorkspaceChanged = useCallback(() => {
     resetWorkspaceStateOnSwitch({
@@ -1067,7 +1277,6 @@ function WorkspacePageInner() {
       const res = await fetch("/api/cron/jobs");
       const data: CronJobsResponse = await res.json();
       setCronJobs(data.jobs ?? []);
-      if (data.heartbeat) setHeartbeatInfo(data.heartbeat);
     } catch {
       // ignore - cron might not be configured
     }
@@ -2051,6 +2260,16 @@ function WorkspacePageInner() {
     sendMessageInChatTab(tab.id, sendParam);
   }, [openBlankChatTab, searchParams, router, sendMessageInChatTab]);
 
+  const formatBreadcrumbSegment = useCallback(
+    (segment: string, partialPath: string) => {
+      if (isAbsolutePath(partialPath)) return segment;
+      const node = resolveNode(tree, partialPath);
+      if (node?.type === "object") return displayObjectName(segment);
+      return segment;
+    },
+    [tree],
+  );
+
   const handleBreadcrumbNavigate = useCallback(
     (path: string) => {
       if (!path) {
@@ -2330,39 +2549,14 @@ function WorkspacePageInner() {
 
   // v3 three-column layout derived values.
   // - Center always renders the chat panel stack (one session at a time in the center).
-  // - Right panel renders content tabs (files, CRM, cloud, etc.); when no content tab is
-  //   active it shows the Files home view (the file tree).
+  // - Right panel renders content tabs (files, CRM, cloud, etc.) in a single unified
+  //   tab strip alongside the always-available Files sidebar. When no content tab is
+  //   active the content area shows a placeholder while the file tree (if expanded)
+  //   lets the user pick something.
   const contentTabs = useMemo(
     () => tabState.tabs.filter((tab) => tab.id !== HOME_TAB_ID && tab.type !== "chat" && tab.type !== "gateway-chat"),
     [tabState.tabs],
   );
-
-  // Split the right-panel content tabs between:
-  // - fileContentTabs: workspace files (opened inside the Files surface as sub-tabs above the viewer)
-  // - pageContentTabs: full-width pages (CRM views, cloud settings, cron, etc.) shown in the outer pill strip
-  const isPageTabPath = (path?: string): boolean => !!path && path.startsWith("~");
-  const fileContentTabs = useMemo(
-    () => contentTabs.filter((tab) => !isPageTabPath(tab.path)),
-    [contentTabs],
-  );
-  const pageContentTabs = useMemo(
-    () => contentTabs.filter((tab) => isPageTabPath(tab.path)),
-    [contentTabs],
-  );
-
-  // The right panel runs in one of two modes:
-  // - File surface: file tree on the left, preview/editor on the right (Files tab or any
-  //   content tab pointing at a filesystem item).
-  // - Full surface: tab content takes the entire right panel (CRM pages, cloud settings,
-  //   cron dashboards, object tables, etc.).
-  const FILE_SURFACE_CONTENT_KINDS = useMemo(() => new Set<ContentState["kind"]>([
-    "none", "loading", "file", "document", "code", "media", "spreadsheet",
-    "html", "database", "report", "directory", "richDocument", "app", "duckdb-missing",
-  ]), []);
-  // Drive the split purely off content.kind so switching into CRM/cloud/cron tabs
-  // immediately hides the file tree, even during the transient moment before the
-  // activeContentTabId tracker settles.
-  const isFileSurface = FILE_SURFACE_CONTENT_KINDS.has(content.kind);
 
   // Track the last-focused tab per surface so switching between chat and content tabs
   // preserves each surface's selection independently (user requirement: "chat doesn't split").
@@ -2379,11 +2573,33 @@ function WorkspacePageInner() {
   }, [tabState.activeTabId, tabState.tabs]);
 
   // Clear stale active-content-tab-id if the content tab was closed externally.
+  // Also reset activePath/content so the right panel falls back to the placeholder
+  // instead of continuing to show the closed tab's content (this mirrors what the
+  // old outer "Files" pill click did, which no longer exists in the unified layout).
+  //
+  // IMPORTANT: when openTab() REPLACES a preview tab with another preview tab
+  // (e.g. clicking Integrations while a markdown file preview is active), the old
+  // tab id disappears from contentTabs but the new one is already the active tab.
+  // We must NOT wipe activePath/content in that case — the trackTab effect above
+  // will re-point activeContentTabId to the new tab on the next tick. Only clear
+  // when the current activeTabId is NOT itself a content tab (i.e. the user
+  // really did close the active content tab and focus moved to home/chat).
   useEffect(() => {
     if (activeContentTabId && !contentTabs.some((t) => t.id === activeContentTabId)) {
+      const activeTabIsContent = contentTabs.some((t) => t.id === tabState.activeTabId);
+      if (activeTabIsContent) {
+        // The new active tab is itself a content tab (e.g. preview-replaced via openTab).
+        // The trackTab effect will sync activeContentTabId on the next tick — don't clobber
+        // activePath/content that handleNavigate / loadContent / applyActivatedTab just set.
+        return;
+      }
       setActiveContentTabId(null);
+      setActivePath(null);
+      setContent({ kind: "none" });
     }
-  }, [activeContentTabId, contentTabs]);
+  }, [activeContentTabId, contentTabs, tabState.activeTabId]);
+
+
 
   // v3: the center always shows a chat panel. If no chat tab exists (e.g. after
   // closing the last one, on a fresh refresh, or before tab hydration completes),
@@ -2421,6 +2637,10 @@ function WorkspacePageInner() {
     setTabState((prev) => closeTab(prev, tabId));
   }, []);
 
+  // Custom CRM tables surfaced in the sidebar's CRM section. Derived from the
+  // already-watched workspace tree so adds/renames/deletes propagate live via SSE.
+  const customCrmObjects = useMemo(() => collectCrmObjectNodes(enhancedTree), [enhancedTree]);
+
   const sidebarCommonProps = {
     activePath: null,
     orgName: context?.organization?.name,
@@ -2442,10 +2662,7 @@ function WorkspacePageInner() {
     onDeleteChatSession: handleDeleteSession,
     onRenameChatSession: handleRenameSession,
     chatGatewaySessions: gatewaySessions,
-    chatChannelStatuses: channelStatuses,
     chatActiveGatewaySessionKey: activeGatewaySessionKey,
-    chatFileScopedSessions: fileScopedSessions,
-    chatHeartbeatInfo: heartbeatInfo,
     activeCrmTarget: (
       content.kind === "crm-people" || content.kind === "crm-person"
         ? "people" as const
@@ -2457,6 +2674,9 @@ function WorkspacePageInner() {
               ? "calendar" as const
               : null
     ),
+    customCrmObjects,
+    activeCrmObjectName: content.kind === "object" ? content.data.object.name : null,
+    onNavigateToCrmObject: handleNavigateToObject,
   };
 
   return (
@@ -2516,7 +2736,7 @@ function WorkspacePageInner() {
               containerRef={layoutRef}
               min={LEFT_SIDEBAR_MIN}
               max={LEFT_SIDEBAR_MAX}
-              onResize={setLeftSidebarWidth}
+              onResize={handleLeftSidebarResize}
             />
             <WorkspaceSidebar
               {...sidebarCommonProps}
@@ -2531,6 +2751,8 @@ function WorkspacePageInner() {
               showHidden={showHidden}
               onToggleHidden={() => setShowHidden((v) => !v)}
               width={leftSidebarWidth}
+              compact={isLeftSidebarCompact}
+              onToggleCompact={toggleLeftSidebarCompact}
               onCollapse={() => setLeftSidebarCollapsed(true)}
               onSelectChatSession={(sessionId) => {
                 const session = sessions.find((entry) => entry.id === sessionId);
@@ -2728,53 +2950,33 @@ function WorkspacePageInner() {
               max={RIGHT_PANEL_MAX}
               onResize={setRightPanelWidth}
             />
-            <RightPanel
-              tabs={pageContentTabs}
-              activeTabId={activeContentTabId}
-              onActivate={handleContentTabActivate}
-              onClose={handleContentTabClose}
-              onCloseOthers={handleTabCloseOthers}
-              onCloseToRight={handleTabCloseToRight}
-              onCloseAll={handleTabCloseAll}
-              onReorder={handleTabReorder}
-              onTogglePin={handleTabTogglePin}
-              onMakePermanent={promoteTabById}
-              onCollapse={() => setRightPanelCollapsed(true)}
-              filesTabActive={activeContentTabId === null}
-              onActivateFilesTab={() => {
-                setActiveContentTabId(null);
-                setActivePath(null);
-                setContent({ kind: "none" });
-              }}
-            >
-              {entryModal ? (
-                <div className="h-full min-h-0 overflow-hidden">
-                  <EntryDetailPanel
-                    objectName={entryModal.objectName}
-                    entryId={entryModal.entryId}
-                    members={context?.members}
-                    tree={tree}
-                    searchFn={searchIndex}
-                    onClose={handleCloseEntry}
-                    onNavigateEntry={(objName, eid) => handleOpenEntry(objName, eid)}
-                    onNavigateObject={(objName) => {
-                      handleCloseEntry();
-                      handleNavigateToObject(objName);
-                    }}
-                    onRefresh={refreshCurrentObject}
-                    onNavigate={handleEditorNavigate}
-                  />
-                </div>
-              ) : isFileSurface ? (
-                <div className="flex h-full min-h-0 overflow-hidden">
-                  {/* File tree column (always visible in the Files surface) */}
+            <RightPanel>
+              <div className="flex h-full min-h-0 overflow-hidden">
+                {/* File tree column — always available, togglable independently of the right panel itself. */}
+                {!fileTreeCollapsed && (
                   <div
                     className="flex flex-col min-h-0 shrink-0 border-r overflow-hidden"
-                    style={{ width: 240, minWidth: 240, borderColor: "var(--color-border)" }}
+                    style={{ width: FILE_TREE_WIDTH, minWidth: FILE_TREE_WIDTH, borderColor: "var(--color-border)" }}
                   >
                     {handleFileSearchSelect && (
-                      <div className="px-2 pt-2 pb-1 shrink-0">
-                        <FileSearch onSelect={handleFileSearchSelect} searchFn={searchIndex} />
+                      <div className="px-2 pt-2 pb-1 shrink-0 flex items-center gap-1">
+                        <div className="flex-1 min-w-0">
+                          <FileSearch onSelect={handleFileSearchSelect} searchFn={searchIndex} />
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => setFileTreeCollapsed(true)}
+                          className="p-1 rounded-md cursor-pointer shrink-0"
+                          style={{ color: "var(--color-text-muted)" }}
+                          title="Hide files (⌘E)"
+                          onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)"; }}
+                          onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = "transparent"; }}
+                        >
+                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                            <polyline points="11 17 6 12 11 7" />
+                            <polyline points="18 17 13 12 18 7" />
+                          </svg>
+                        </button>
                       </div>
                     )}
                     {browseDir && (
@@ -2822,59 +3024,307 @@ function WorkspacePageInner() {
                       />
                     </div>
                   </div>
-                  {/* File preview / editor area (right) */}
-                  <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
-                    {fileContentTabs.length > 0 && (
-                      <div
-                        className="flex items-center gap-1 px-2 h-9 shrink-0 border-b overflow-x-auto"
-                        style={{ borderColor: "var(--color-border)" }}
+                )}
+
+                {/* Content column: unified tab strip + (entry detail | content | placeholder) */}
+                <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+                  <div
+                    className="flex items-center gap-1 px-2 h-10 shrink-0 border-b overflow-x-auto"
+                    style={{ borderColor: "var(--color-border)" }}
+                  >
+                    {fileTreeCollapsed && (
+                      <button
+                        type="button"
+                        onClick={() => setFileTreeCollapsed(false)}
+                        className="p-1 rounded-md cursor-pointer shrink-0"
+                        style={{ color: "var(--color-text-muted)" }}
+                        title="Show files (⌘E)"
+                        onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)"; }}
+                        onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = "transparent"; }}
                       >
-                        {fileContentTabs.map((tab) => {
-                          const isActive = tab.id === activeContentTabId;
-                          return (
-                            <div
-                              key={tab.id}
-                              className="flex items-center rounded-md shrink-0"
-                              style={{ background: isActive ? "var(--color-surface-hover)" : "transparent" }}
-                            >
-                              <button
-                                type="button"
-                                onClick={() => handleContentTabActivate(tab.id)}
-                                className="pl-2.5 pr-1 py-0.5 text-[12px] font-medium transition-colors cursor-pointer"
-                                style={{
-                                  color: isActive ? "var(--color-text)" : "var(--color-text-muted)",
-                                  fontStyle: tab.preview ? "italic" : "normal",
-                                }}
-                                title={tab.title}
-                              >
-                                {tab.title.length > 24 ? tab.title.slice(0, 22) + "…" : tab.title}
-                              </button>
-                              <button
-                                type="button"
-                                onClick={(e) => { e.stopPropagation(); handleContentTabClose(tab.id); }}
-                                className="p-0.5 rounded-md mr-0.5 cursor-pointer"
-                                style={{ color: "var(--color-text-muted)" }}
-                                title="Close tab"
-                                onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = "var(--color-border)"; }}
-                                onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = "transparent"; }}
-                              >
-                                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                                  <path d="M18 6 6 18" /><path d="m6 6 12 12" />
-                                </svg>
-                              </button>
-                            </div>
-                          );
-                        })}
-                      </div>
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                          <polyline points="13 17 18 12 13 7" />
+                          <polyline points="6 17 11 12 6 7" />
+                        </svg>
+                      </button>
                     )}
-                    {activePath && content.kind !== "none" ? (
-                      <>
+                    {contentTabs.map((tab) => {
+                      const isActive = tab.id === activeContentTabId;
+                      return (
+                        <div
+                          key={tab.id}
+                          className="flex items-center rounded-md shrink-0"
+                          style={{ background: isActive ? "var(--color-surface-hover)" : "transparent" }}
+                        >
+                          <button
+                            type="button"
+                            onClick={() => handleContentTabActivate(tab.id)}
+                            className="flex items-center gap-1.5 pl-2 pr-1 py-1 text-[12px] font-medium transition-colors cursor-pointer"
+                            style={{
+                              color: isActive ? "var(--color-text)" : "var(--color-text-muted)",
+                              fontStyle: tab.preview ? "italic" : "normal",
+                            }}
+                            title={tab.title}
+                          >
+                            <span className="shrink-0" style={{ opacity: isActive ? 1 : 0.8 }}>
+                              <TabIcon tab={tab} />
+                            </span>
+                            <span>{tab.title.length > 24 ? tab.title.slice(0, 22) + "…" : tab.title}</span>
+                          </button>
+                          <button
+                            type="button"
+                            onClick={(e) => { e.stopPropagation(); handleContentTabClose(tab.id); }}
+                            className="p-0.5 rounded-md mr-0.5 cursor-pointer"
+                            style={{ color: "var(--color-text-muted)" }}
+                            title="Close tab"
+                            onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = "var(--color-border)"; }}
+                            onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = "transparent"; }}
+                          >
+                            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                              <path d="M18 6 6 18" /><path d="m6 6 12 12" />
+                            </svg>
+                          </button>
+                        </div>
+                      );
+                    })}
+                    <div className="flex-1" />
+                    <button
+                      type="button"
+                      onClick={() => setRightPanelCollapsed(true)}
+                      className="p-1.5 rounded-md cursor-pointer shrink-0"
+                      style={{ color: "var(--color-text-muted)" }}
+                      title="Hide right panel (⌘⇧B)"
+                      onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)"; }}
+                      onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = "transparent"; }}
+                    >
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                        <rect width="18" height="18" x="3" y="3" rx="2" />
+                        <path d="M15 3v18" />
+                      </svg>
+                    </button>
+                  </div>
+
+                  {entryModal ? (
+                    <div className="flex-1 min-h-0 overflow-hidden">
+                      <EntryDetailPanel
+                        objectName={entryModal.objectName}
+                        entryId={entryModal.entryId}
+                        members={context?.members}
+                        tree={tree}
+                        searchFn={searchIndex}
+                        onClose={handleCloseEntry}
+                        onNavigateEntry={(objName, eid) => handleOpenEntry(objName, eid)}
+                        onNavigateObject={(objName) => {
+                          handleCloseEntry();
+                          handleNavigateToObject(objName);
+                        }}
+                        onRefresh={refreshCurrentObject}
+                        onNavigate={handleEditorNavigate}
+                      />
+                    </div>
+                  ) : activePath && content.kind !== "none" ? (
+                    <>
+                      {!activePath.startsWith("~") && (
                         <div
                           className="px-4 border-b flex-shrink-0 flex items-center h-10"
                           style={{ borderColor: "var(--color-border)" }}
                         >
-                          <Breadcrumbs path={activePath} onNavigate={handleBreadcrumbNavigate} />
+                          <Breadcrumbs path={activePath} onNavigate={handleBreadcrumbNavigate} formatSegment={formatBreadcrumbSegment} />
                         </div>
+                      )}
+                      <div className="flex-1 overflow-y-auto">
+                        <ContentRenderer
+                          content={content}
+                          workspaceExists={workspaceExists}
+                          expectedPath={workspaceRoot}
+                          tree={tree}
+                          activePath={activePath}
+                          browseDir={browseDir}
+                          treeLoading={treeLoading}
+                          members={context?.members}
+                          onNodeSelect={handleNodeSelect}
+                          onNavigateToObject={handleNavigateToObject}
+                          onRefreshObject={refreshCurrentObject}
+                          onRefreshTree={refreshTree}
+                          onNavigate={handleEditorNavigate}
+                          onOpenEntry={handleOpenEntry}
+                          activeEntryId={undefined}
+                          searchFn={searchIndex}
+                          onSelectCronJob={handleSelectCronJob}
+                          onBackToCronDashboard={handleBackToCronDashboard}
+                          cronView={cronView}
+                          onCronViewChange={setCronView}
+                          cronCalMode={cronCalMode}
+                          onCronCalModeChange={setCronCalMode}
+                          cronDate={cronDate}
+                          onCronDateChange={setCronDate}
+                          cronRunFilter={cronRunFilter}
+                          onCronRunFilterChange={setCronRunFilter}
+                          cronRun={cronRun}
+                          onCronRunChange={setCronRun}
+                          onSendCommand={handleCronSendCommand}
+                          onMakeTabPermanent={promoteTabByPath}
+                        />
+                      </div>
+                    </>
+                  ) : (
+                    <div className="flex-1 flex items-center justify-center">
+                      <p className="text-sm text-center px-6" style={{ color: "var(--color-text-muted)" }}>
+                        Select a file or open a page from the sidebar
+                      </p>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </RightPanel>
+          </div>
+        </aside>
+      )}
+
+      {/* Mobile right panel drawer */}
+      {isMobile && mobileRightPanelOpen && (
+        <div className="drawer-backdrop" onClick={() => setMobileRightPanelOpen(false)}>
+          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+          <div onClick={(e) => e.stopPropagation()} className="fixed inset-y-0 right-0 z-50 drawer-right" style={{ width: "min(90vw, 400px)", background: "var(--color-bg)" }}>
+            <div className="flex flex-col h-full">
+              <RightPanel>
+                <div className="flex h-full min-h-0 overflow-hidden">
+                  {/* On mobile the file tree shares horizontal space with content; respect the same toggle. */}
+                  {!fileTreeCollapsed && (
+                    <div
+                      className="flex flex-col min-h-0 shrink-0 border-r overflow-hidden"
+                      style={{ width: 200, minWidth: 200, borderColor: "var(--color-border)" }}
+                    >
+                      <div className="px-2 pt-2 pb-1 shrink-0 flex items-center gap-1">
+                        <span className="flex-1 text-[12px] font-medium px-1" style={{ color: "var(--color-text-muted)" }}>
+                          Files
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => setFileTreeCollapsed(true)}
+                          className="p-1 rounded-md cursor-pointer shrink-0"
+                          style={{ color: "var(--color-text-muted)" }}
+                          title="Hide files"
+                        >
+                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                            <polyline points="11 17 6 12 11 7" />
+                            <polyline points="18 17 13 12 18 7" />
+                          </svg>
+                        </button>
+                      </div>
+                      <div className="flex-1 overflow-y-auto px-1 py-2">
+                        <FileManagerTree
+                          tree={enhancedTree}
+                          activePath={activePath}
+                          onSelect={(node) => { handleNodeSelect(node); }}
+                          onRefresh={refreshTree}
+                          parentDir={effectiveParentDir}
+                          onNavigateUp={handleNavigateUp}
+                          browseDir={browseDir}
+                          workspaceRoot={workspaceRoot}
+                        />
+                      </div>
+                    </div>
+                  )}
+
+                  <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+                    <div
+                      className="flex items-center gap-1 px-2 h-10 shrink-0 border-b overflow-x-auto"
+                      style={{ borderColor: "var(--color-border)" }}
+                    >
+                      {fileTreeCollapsed && (
+                        <button
+                          type="button"
+                          onClick={() => setFileTreeCollapsed(false)}
+                          className="p-1 rounded-md cursor-pointer shrink-0"
+                          style={{ color: "var(--color-text-muted)" }}
+                          title="Show files"
+                        >
+                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                            <polyline points="13 17 18 12 13 7" />
+                            <polyline points="6 17 11 12 6 7" />
+                          </svg>
+                        </button>
+                      )}
+                      {contentTabs.map((tab) => {
+                        const isActive = tab.id === activeContentTabId;
+                        return (
+                          <div
+                            key={tab.id}
+                            className="flex items-center rounded-md shrink-0"
+                            style={{ background: isActive ? "var(--color-surface-hover)" : "transparent" }}
+                          >
+                            <button
+                              type="button"
+                              onClick={() => handleContentTabActivate(tab.id)}
+                              className="flex items-center gap-1.5 pl-2 pr-1 py-1 text-[12px] font-medium transition-colors cursor-pointer"
+                              style={{
+                                color: isActive ? "var(--color-text)" : "var(--color-text-muted)",
+                                fontStyle: tab.preview ? "italic" : "normal",
+                              }}
+                              title={tab.title}
+                            >
+                              <span className="shrink-0" style={{ opacity: isActive ? 1 : 0.8 }}>
+                                <TabIcon tab={tab} />
+                              </span>
+                              <span>{tab.title.length > 20 ? tab.title.slice(0, 18) + "…" : tab.title}</span>
+                            </button>
+                            <button
+                              type="button"
+                              onClick={(e) => { e.stopPropagation(); handleContentTabClose(tab.id); }}
+                              className="p-0.5 rounded-md mr-0.5 cursor-pointer"
+                              style={{ color: "var(--color-text-muted)" }}
+                              title="Close tab"
+                            >
+                              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                <path d="M18 6 6 18" /><path d="m6 6 12 12" />
+                              </svg>
+                            </button>
+                          </div>
+                        );
+                      })}
+                      <div className="flex-1" />
+                      <button
+                        type="button"
+                        onClick={() => setMobileRightPanelOpen(false)}
+                        className="p-1.5 rounded-md cursor-pointer shrink-0"
+                        style={{ color: "var(--color-text-muted)" }}
+                        title="Close"
+                      >
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                          <path d="M18 6 6 18" /><path d="m6 6 12 12" />
+                        </svg>
+                      </button>
+                    </div>
+
+                    {entryModal ? (
+                      <div className="flex-1 min-h-0 overflow-hidden">
+                        <EntryDetailPanel
+                          objectName={entryModal.objectName}
+                          entryId={entryModal.entryId}
+                          members={context?.members}
+                          tree={tree}
+                          searchFn={searchIndex}
+                          onClose={handleCloseEntry}
+                          onNavigateEntry={(objName, eid) => handleOpenEntry(objName, eid)}
+                          onNavigateObject={(objName) => {
+                            handleCloseEntry();
+                            handleNavigateToObject(objName);
+                          }}
+                          onRefresh={refreshCurrentObject}
+                          onNavigate={handleEditorNavigate}
+                        />
+                      </div>
+                    ) : activePath && content.kind !== "none" ? (
+                      <>
+                        {!activePath.startsWith("~") && (
+                          <div
+                            className="px-4 border-b flex-shrink-0 flex items-center h-10"
+                            style={{ borderColor: "var(--color-border)" }}
+                          >
+                            <Breadcrumbs path={activePath} onNavigate={handleBreadcrumbNavigate} formatSegment={formatBreadcrumbSegment} />
+                          </div>
+                        )}
                         <div className="flex-1 overflow-y-auto">
                           <ContentRenderer
                             content={content}
@@ -2912,154 +3362,13 @@ function WorkspacePageInner() {
                       </>
                     ) : (
                       <div className="flex-1 flex items-center justify-center">
-                        <p className="text-sm" style={{ color: "var(--color-text-muted)" }}>
-                          Select a file to view
+                        <p className="text-sm text-center px-6" style={{ color: "var(--color-text-muted)" }}>
+                          Select a file or open a page from the sidebar
                         </p>
                       </div>
                     )}
                   </div>
                 </div>
-              ) : (
-                <div className="flex flex-col h-full min-h-0 overflow-hidden">
-                  {activePath && content.kind !== "none" && (
-                    <div
-                      className="px-4 border-b flex-shrink-0 flex items-center h-10"
-                      style={{ borderColor: "var(--color-border)" }}
-                    >
-                      <Breadcrumbs path={activePath} onNavigate={handleBreadcrumbNavigate} />
-                    </div>
-                  )}
-                  <div className="flex-1 overflow-y-auto">
-                    <ContentRenderer
-                      content={content}
-                      workspaceExists={workspaceExists}
-                      expectedPath={workspaceRoot}
-                      tree={tree}
-                      activePath={activePath}
-                      browseDir={browseDir}
-                      treeLoading={treeLoading}
-                      members={context?.members}
-                      onNodeSelect={handleNodeSelect}
-                      onNavigateToObject={handleNavigateToObject}
-                      onRefreshObject={refreshCurrentObject}
-                      onRefreshTree={refreshTree}
-                      onNavigate={handleEditorNavigate}
-                      onOpenEntry={handleOpenEntry}
-                      activeEntryId={undefined}
-                      searchFn={searchIndex}
-                      onSelectCronJob={handleSelectCronJob}
-                      onBackToCronDashboard={handleBackToCronDashboard}
-                      cronView={cronView}
-                      onCronViewChange={setCronView}
-                      cronCalMode={cronCalMode}
-                      onCronCalModeChange={setCronCalMode}
-                      cronDate={cronDate}
-                      onCronDateChange={setCronDate}
-                      cronRunFilter={cronRunFilter}
-                      onCronRunFilterChange={setCronRunFilter}
-                      cronRun={cronRun}
-                      onCronRunChange={setCronRun}
-                      onSendCommand={handleCronSendCommand}
-                      onMakeTabPermanent={promoteTabByPath}
-                    />
-                  </div>
-                </div>
-              )}
-            </RightPanel>
-          </div>
-        </aside>
-      )}
-
-      {/* Mobile right panel drawer */}
-      {isMobile && mobileRightPanelOpen && (
-        <div className="drawer-backdrop" onClick={() => setMobileRightPanelOpen(false)}>
-          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-          <div onClick={(e) => e.stopPropagation()} className="fixed inset-y-0 right-0 z-50 drawer-right" style={{ width: "min(90vw, 400px)", background: "var(--color-bg)" }}>
-            <div className="flex flex-col h-full">
-              <RightPanel
-                tabs={pageContentTabs}
-                activeTabId={activeContentTabId}
-                onActivate={(id) => { handleContentTabActivate(id); }}
-                onClose={handleContentTabClose}
-                onCloseOthers={handleTabCloseOthers}
-                onCloseToRight={handleTabCloseToRight}
-                onCloseAll={handleTabCloseAll}
-                onReorder={handleTabReorder}
-                onTogglePin={handleTabTogglePin}
-                onMakePermanent={promoteTabById}
-                onCollapse={() => setMobileRightPanelOpen(false)}
-                filesTabActive={activeContentTabId === null}
-                onActivateFilesTab={() => {
-                  setActiveContentTabId(null);
-                  setActivePath(null);
-                  setContent({ kind: "none" });
-                }}
-              >
-                {activeContentTabId === null ? (
-                  <div className="flex-1 overflow-y-auto px-1 py-2">
-                    <FileManagerTree
-                      tree={enhancedTree}
-                      activePath={null}
-                      onSelect={(node) => { handleNodeSelect(node); }}
-                      onRefresh={refreshTree}
-                      parentDir={effectiveParentDir}
-                      onNavigateUp={handleNavigateUp}
-                      browseDir={browseDir}
-                      workspaceRoot={workspaceRoot}
-                    />
-                  </div>
-                ) : entryModal ? (
-                  <EntryDetailPanel
-                    objectName={entryModal.objectName}
-                    entryId={entryModal.entryId}
-                    members={context?.members}
-                    tree={tree}
-                    searchFn={searchIndex}
-                    onClose={handleCloseEntry}
-                    onNavigateEntry={(objName, eid) => handleOpenEntry(objName, eid)}
-                    onNavigateObject={(objName) => {
-                      handleCloseEntry();
-                      handleNavigateToObject(objName);
-                    }}
-                    onRefresh={refreshCurrentObject}
-                    onNavigate={handleEditorNavigate}
-                  />
-                ) : (
-                  <div className="flex-1 overflow-y-auto">
-                    <ContentRenderer
-                      content={content}
-                      workspaceExists={workspaceExists}
-                      expectedPath={workspaceRoot}
-                      tree={tree}
-                      activePath={activePath}
-                      browseDir={browseDir}
-                      treeLoading={treeLoading}
-                      members={context?.members}
-                      onNodeSelect={handleNodeSelect}
-                      onNavigateToObject={handleNavigateToObject}
-                      onRefreshObject={refreshCurrentObject}
-                      onRefreshTree={refreshTree}
-                      onNavigate={handleEditorNavigate}
-                      onOpenEntry={handleOpenEntry}
-                      activeEntryId={undefined}
-                      searchFn={searchIndex}
-                      onSelectCronJob={handleSelectCronJob}
-                      onBackToCronDashboard={handleBackToCronDashboard}
-                      cronView={cronView}
-                      onCronViewChange={setCronView}
-                      cronCalMode={cronCalMode}
-                      onCronCalModeChange={setCronCalMode}
-                      cronDate={cronDate}
-                      onCronDateChange={setCronDate}
-                      cronRunFilter={cronRunFilter}
-                      onCronRunFilterChange={setCronRunFilter}
-                      cronRun={cronRun}
-                      onCronRunChange={setCronRun}
-                      onSendCommand={handleCronSendCommand}
-                      onMakeTabPermanent={promoteTabByPath}
-                    />
-                  </div>
-                )}
               </RightPanel>
             </div>
           </div>
@@ -3358,7 +3667,12 @@ function ContentRenderer({
       return <InboxView onOpenPerson={(id) => onOpenEntry("people", id)} />;
 
     case "crm-calendar":
-      return <CalendarView onOpenPerson={(id) => onOpenEntry("people", id)} />;
+      return (
+        <CalendarView
+          onOpenPerson={(id) => onOpenEntry("people", id)}
+          onOpenCompany={(id) => onOpenEntry("company", id)}
+        />
+      );
 
     case "crm-person":
       return (
@@ -3926,11 +4240,11 @@ function ObjectView({
         {/* Left: title + count (shrinks first when space is tight) */}
         <div className="flex items-center gap-2 min-w-0 flex-shrink">
           <h1
-            className="text-sm font-semibold capitalize truncate"
+            className="text-sm font-semibold truncate"
             style={{ color: "var(--color-text)" }}
-            title={data.object.description || data.object.name}
+            title={data.object.description || displayObjectName(data.object.name)}
           >
-            {data.object.name}
+            {displayObjectName(data.object.name)}
           </h1>
           <span
             className="text-[11px] tabular-nums px-1.5 py-0.5 rounded-full flex-shrink-0"
@@ -3980,7 +4294,7 @@ function ObjectView({
               type="text"
               value={globalFilter}
               onChange={(e) => handleGlobalFilterChange(e.target.value)}
-              placeholder={`Search ${data.object.name}...`}
+              placeholder={`Search ${displayObjectName(data.object.name)}...`}
               className="w-full h-full text-[12px] bg-transparent outline-none border-0 p-0"
               style={{ color: "var(--color-text)" }}
             />
@@ -4057,7 +4371,7 @@ function ObjectView({
               background: "var(--color-accent)",
               color: "#fff",
             }}
-            title={`Add ${data.object.name}`}
+            title={`Add ${displayObjectNameSingular(data.object.name)}`}
           >
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
               <path d="M12 5v14" />
@@ -4204,13 +4518,15 @@ function DirectoryListing({
 }) {
   const children = node.children ?? [];
 
+  const titleText = node.type === "object" ? displayObjectName(node.name) : node.name;
+
   return (
     <div className="p-6 max-w-4xl mx-auto">
       <h1
-        className="font-instrument text-3xl tracking-tight mb-1 capitalize"
+        className={`font-instrument text-3xl tracking-tight mb-1${node.type === "object" ? "" : " capitalize"}`}
         style={{ color: "var(--color-text)" }}
       >
-        {node.name}
+        {titleText}
       </h1>
       <p className="text-sm mb-6" style={{ color: "var(--color-text-muted)" }}>
         {children.length} items
@@ -4276,7 +4592,9 @@ function DirectoryListing({
                   className="text-sm font-medium truncate"
                   style={{ color: "var(--color-text)" }}
                 >
-                  {child.name.replace(/\.md$/, "")}
+                  {child.type === "object"
+                    ? displayObjectName(child.name)
+                    : child.name.replace(/\.md$/, "")}
                 </div>
                 <div
                   className="text-xs capitalize"
@@ -4367,10 +4685,10 @@ function WelcomeView({
                 </span>
                 <div className="min-w-0">
                   <div
-                    className="text-sm font-medium capitalize truncate"
+                    className="text-sm font-medium truncate"
                     style={{ color: "var(--color-text)" }}
                   >
-                    {obj.name}
+                    {displayObjectName(obj.name)}
                   </div>
                   <div className="text-xs" style={{ color: "var(--color-text-muted)" }}>
                     {obj.defaultView === "kanban" ? "Kanban board" : "Table view"}


### PR DESCRIPTION
Large workspace orchestration and presentation update. Local debug ingest instrumentation was stripped before shipping.

Verification: `pnpm web:build`, `pnpm build`, `pnpm test`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to a sizable workspace UI/layout refactor (sidebar sizing modes, unified right-panel tabs, and file-tree toggling) that can affect navigation state and persistence, though changes are client-side/presentation-focused.
> 
> **Overview**
> **Workspace shell UI refactor:** the right panel now uses a *single unified tab strip* for all content (files + CRM/pages) while keeping the file tree as an independently toggleable column (persisted via `localStorage` and a new ⌘E shortcut); closing active content tabs now also resets right-panel content state to a placeholder.
> 
> **Sidebar updates:** the left sidebar gains a *compact icon-only mode* with snap-aware resizing and a toggle button, and the chat sessions list is simplified into a single recency-grouped list that merges native + gateway sessions (dropping channel status/heartbeat/crons/file-scoped session UI).
> 
> **CRM chrome consistency:** introduces `CrmObjectIcon` (lazy-loaded lucide icons) and applies `displayObjectName`/`displayObjectNameSingular` across breadcrumbs, tree labels, tables, filters, relation pickers, slash-command suggestions, and entry detail headers/titles for human-friendly object labels; calendar view wiring is extended to support opening companies as well as people.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1386cb007720a16789bc2fb8e2b3b726c3f3a25e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->