### PR TITLE
feat(web): TipTap file mentions use displayObjectName

### DIFF
--- a/apps/web/app/components/tiptap/file-mention-extension.ts
+++ b/apps/web/app/components/tiptap/file-mention-extension.ts
@@ -1,6 +1,7 @@
 import { Node, mergeAttributes } from "@tiptap/core";
 import { type SuggestionOptions } from "@tiptap/suggestion";
 import { PluginKey } from "@tiptap/pm/state";
+import { displayObjectName } from "@/lib/object-display-name";
 
 export const chatFileMentionPluginKey = new PluginKey("chatFileMention");
 
@@ -50,6 +51,7 @@ export const FileMentionNode = Node.create({
 		const mType = (HTMLAttributes.mentionType as string) || "file";
 		const dView = (HTMLAttributes.defaultView as string) || "";
 		const colors = mentionColors(label, mType);
+		const visibleLabel = mType === "object" ? displayObjectName(label) : label;
 		return [
 			"span",
 			mergeAttributes(
@@ -63,7 +65,7 @@ export const FileMentionNode = Node.create({
 				},
 				HTMLAttributes,
 			),
-			label,
+			visibleLabel,
 		];
 	},
 });

--- a/apps/web/app/components/tiptap/file-mention-list.tsx
+++ b/apps/web/app/components/tiptap/file-mention-list.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import type { SearchIndexItem } from "@/lib/search-index";
+import { displayObjectName, displayObjectNameSingular } from "@/lib/object-display-name";
 import {
 	IconFolderFilled,
 	IconFileFilled,
@@ -181,8 +182,11 @@ const FileMentionList = forwardRef<FileMentionListRef, FileMentionListProps>(
 			const category = getFileCategory(item.name, item.type);
 			const hasEmoji = item.icon && /\p{Emoji_Presentation}/u.test(item.icon);
 			const isDbItem = item.type === "object" || item.type === "entry";
+			const displayName = item.type === "object"
+				? displayObjectName(item.name)
+				: item.name;
 			const sublabel = item.type === "entry" && item.objectName
-				? item.objectName
+				? displayObjectNameSingular(item.objectName)
 				: isDbItem
 					? (item.defaultView === "kanban" ? "Board" : "Table")
 					: shortenPath(item.path);
@@ -205,7 +209,7 @@ const FileMentionList = forwardRef<FileMentionListRef, FileMentionListProps>(
 					</span>
 					<div className="min-w-0 flex-1">
 						<div className="text-sm font-medium truncate">
-							{item.name}
+							{displayName}
 						</div>
 						<div
 							className="text-xs truncate"


### PR DESCRIPTION
Small follow-up so rich editor file mentions match workspace object labels.

Verification: `pnpm web:build`, `pnpm build`, `pnpm test`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts how object and entry names are rendered in the mention pill and suggestion dropdown; no data fetching or persistence logic is altered.
> 
> **Overview**
> Updates TipTap chat @-mentions to display workspace *object* names using the shared `displayObjectName` formatting, so mention pills and the suggestion list match the rest of the UI.
> 
> Also formats entry mention sublabels (their `objectName`) via `displayObjectNameSingular` instead of showing the raw identifier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20ecc72d76137570dd0306ddf6d9464710c9557e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->