### PR TITLE
docs: align skill guides with v3 CRM and workspace behavior

### DIFF
--- a/skills/app-builder/data-builder/SKILL.md
+++ b/skills/app-builder/data-builder/SKILL.md
@@ -1006,10 +1006,10 @@ permissions:
       async function loadDashboard() {
         try {
           const result = await window.dench.db.query(`
-          SELECT o.name, o.description, o.icon, COUNT(e.id) as entry_count
+          SELECT o.name, o.description, COUNT(e.id) as entry_count
           FROM objects o
           LEFT JOIN entries e ON e.object_id = o.id
-          GROUP BY o.name, o.description, o.icon
+          GROUP BY o.name, o.description
           ORDER BY entry_count DESC
         `);
 

--- a/skills/crm/duckdb-operations/SKILL.md
+++ b/skills/crm/duckdb-operations/SKILL.md
@@ -24,11 +24,13 @@ CREATE OR REPLACE MACRO nanoid32() AS (
   FROM generate_series(1, 32)
 );
 
+-- NOTE: Object icons live ONLY in `<objectDir>/.object.yaml` under the
+-- `icon:` key. There is intentionally no `icon` column on `objects` —
+-- never include one in INSERT/UPDATE statements.
 CREATE TABLE IF NOT EXISTS objects (
   id VARCHAR PRIMARY KEY DEFAULT (gen_random_uuid()::VARCHAR),
   name VARCHAR NOT NULL,
   description VARCHAR,
-  icon VARCHAR,
   default_view VARCHAR DEFAULT 'table',
   parent_document_id VARCHAR,
   sort_order INTEGER DEFAULT 0,
@@ -249,9 +251,12 @@ All operations use `exec` with `duckdb {{WORKSPACE_PATH}}/workspace.duckdb`. Bat
 
 ### Create Object
 
+Icons are not part of the `objects` row — set `icon:` in `<objectDir>/.object.yaml`
+after the INSERT, or use the icon picker in the web UI.
+
 ```sql
-INSERT INTO objects (name, description, icon, default_view)
-VALUES ('lead', 'Sales leads tracking', 'user-plus', 'table')
+INSERT INTO objects (name, description, default_view)
+VALUES ('lead', 'Sales leads tracking', 'table')
 ON CONFLICT (name) DO NOTHING RETURNING *;
 ```
 

--- a/skills/crm/object-builder/SKILL.md
+++ b/skills/crm/object-builder/SKILL.md
@@ -10,6 +10,16 @@ This skill covers creating and modifying workspace objects end-to-end. For DuckD
 
 ---
 
+## Where icons live (READ THIS FIRST)
+
+Object icons live ONLY in `<objectDir>/.object.yaml` under the `icon:` key.
+**Never** include an `icon` column in any DuckDB SQL — the column has been retired.
+To change an existing object's icon, edit its `.object.yaml` directly OR call
+`PATCH /api/workspace/objects/<name>/icon` with `{ "icon": "lucide-name" }`.
+The web UI also exposes an icon picker in the object header.
+
+---
+
 ## Full Workflow: Create CRM Structure in One Shot
 
 EVERY object creation MUST complete ALL THREE steps below. Never stop after the SQL.
@@ -19,9 +29,9 @@ EVERY object creation MUST complete ALL THREE steps below. Never stop after the 
 ```sql
 BEGIN TRANSACTION;
 
--- 1a. Create object
-INSERT INTO objects (name, description, icon, default_view)
-VALUES ('lead', 'Sales leads tracking', 'user-plus', 'table')
+-- 1a. Create object (icon is NOT a DB column — it lives in .object.yaml only)
+INSERT INTO objects (name, description, default_view)
+VALUES ('lead', 'Sales leads tracking', 'table')
 ON CONFLICT (name) DO NOTHING;
 
 -- 1b. Create all fields
@@ -130,8 +140,8 @@ When creating task/board objects, use `default_view = 'kanban'` and auto-create 
 
 ```sql
 BEGIN TRANSACTION;
-INSERT INTO objects (name, description, icon, default_view)
-VALUES ('task', 'Task tracking board', 'check-square', 'kanban')
+INSERT INTO objects (name, description, default_view)
+VALUES ('task', 'Task tracking board', 'kanban')
 ON CONFLICT (name) DO NOTHING;
 
 -- Auto-create Status field with kanban-appropriate values
@@ -320,7 +330,7 @@ You MUST complete ALL steps below after ANY schema mutation (create/update/delet
 
 - [ ] `CREATE OR REPLACE VIEW v_{object_name}` — regenerate the PIVOT view
 - [ ] `mkdir -p {{WORKSPACE_PATH}}/{object_name}/` — create the object directory
-- [ ] Write `{{WORKSPACE_PATH}}/{object_name}/.object.yaml` — metadata projection with id, name, description, icon, default_view, entry_count, and full field list
+- [ ] Write `{{WORKSPACE_PATH}}/{object_name}/.object.yaml` — metadata projection with id, name, description, **icon** (yaml is the only place icons live), default_view, entry_count, and full field list
 - [ ] If object has a `parent_document_id`, place directory inside the parent document's directory
 - [ ] Update `WORKSPACE.md` if it exists
 

--- a/skills/crm/views-filters/SKILL.md
+++ b/skills/crm/views-filters/SKILL.md
@@ -261,9 +261,10 @@ filters:
 Generate by querying DuckDB then writing the file:
 
 ```bash
-# 1. Query object + fields from DuckDB
+# 1. Query object + fields from DuckDB (icon is NOT a DB column — read it
+#    from the existing .object.yaml if you need to preserve it across edits).
 duckdb {{WORKSPACE_PATH}}/workspace.duckdb -json "
-  SELECT o.id, o.name, o.description, o.icon, o.default_view,
+  SELECT o.id, o.name, o.description, o.default_view,
          (SELECT COUNT(*) FROM entries WHERE object_id = o.id) as entry_count
   FROM objects o WHERE o.name = 'lead'
 "


### PR DESCRIPTION
## Summary
Updates bundled agent skill markdown under `skills/` for app-builder and CRM (DuckDB operations, object builder, views/filters) to match v3 workspace and CRM behavior.

## Test plan
No code changes; optional spot-check of skill content.

## Merge order
Merge after [#199](https://github.com/DenchHQ/DenchClaw/pull/199) (or rebase onto `v3.0.0` after it lands) to avoid `skills/` merge noise.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes, but they affect canonical SQL/schema examples so mistakes could mislead users setting up DuckDB objects.
> 
> **Overview**
> **Aligns skill docs with v3 workspace icon behavior.** CRM DuckDB/object/view guides now explicitly state that object icons live only in `<objectDir>/.object.yaml`, remove the `icon` column from the `objects` table definition and all INSERT/query examples, and point to the icon API/UI for updates.
> 
> **Updates app-builder dashboard example SQL** to stop selecting/grouping by `o.icon`, matching the retired DB column.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b793d5cb943c3b4f652b0d4bef9c28b2e8a550ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->