### PR TITLE
fix(web): unblock v3.0.0 CI — TS narrowing in web-sessions + execFile mocks

### DIFF
--- a/apps/web/app/api/web-sessions/[id]/messages/route.ts
+++ b/apps/web/app/api/web-sessions/[id]/messages/route.ts
@@ -126,14 +126,15 @@ function deriveTitleFromMessages(lines: string[]): string | null {
         text = parsed.content;
       } else if (Array.isArray(parsed.parts)) {
         // ai-sdk UIMessage shape — concat all text parts.
-        text = parsed.parts
-          .filter((p: unknown): p is { type: string; text: string } =>
+        type UITextPart = { type: string; text: string };
+        text = (parsed.parts as unknown[])
+          .filter((p): p is UITextPart =>
             typeof p === "object" &&
             p !== null &&
             (p as { type?: string }).type === "text" &&
             typeof (p as { text?: string }).text === "string",
           )
-          .map((p) => p.text)
+          .map((p: UITextPart) => p.text)
           .join(" ");
       }
       const cleaned = text

--- a/apps/web/app/api/web-sessions/shared.ts
+++ b/apps/web/app/api/web-sessions/shared.ts
@@ -128,14 +128,15 @@ function summarizeSessionFile(fp: string): { title: string; messageCount: number
         if (typeof parsed.content === "string") {
           text = parsed.content;
         } else if (Array.isArray(parsed.parts)) {
-          text = parsed.parts
-            .filter((p: unknown): p is { type: string; text: string } =>
+          type UITextPart = { type: string; text: string };
+          text = (parsed.parts as unknown[])
+            .filter((p): p is UITextPart =>
               typeof p === "object" &&
               p !== null &&
               (p as { type?: string }).type === "text" &&
               typeof (p as { text?: string }).text === "string",
             )
-            .map((p) => p.text)
+            .map((p: UITextPart) => p.text)
             .join(" ");
         }
         const cleaned = text

--- a/apps/web/lib/subagent-runs.test.ts
+++ b/apps/web/lib/subagent-runs.test.ts
@@ -31,6 +31,16 @@ vi.mock("node:child_process", () => ({
       cb(null, { stdout: "" });
     },
   ),
+  execFile: vi.fn(
+    (
+      _cmd: string,
+      _args: string[],
+      _opts: unknown,
+      cb: (err: Error | null, result: { stdout: string }) => void,
+    ) => {
+      cb(null, { stdout: "" });
+    },
+  ),
 }));
 
 vi.mock("node:os", () => ({
@@ -158,6 +168,16 @@ describe("subagent runs", () => {
       exec: vi.fn(
         (
           _cmd: string,
+          _opts: unknown,
+          cb: (err: Error | null, result: { stdout: string }) => void,
+        ) => {
+          cb(null, { stdout: "" });
+        },
+      ),
+      execFile: vi.fn(
+        (
+          _cmd: string,
+          _args: string[],
           _opts: unknown,
           cb: (err: Error | null, result: { stdout: string }) => void,
         ) => {

--- a/apps/web/lib/workspace-chat-isolation.test.ts
+++ b/apps/web/lib/workspace-chat-isolation.test.ts
@@ -40,6 +40,21 @@ vi.mock("node:child_process", () => ({
       cb(null, { stdout: "" });
     },
   ),
+  execFile: vi.fn(
+    (
+      _cmd: string,
+      _args: string[],
+      _opts: unknown,
+      cb: (err: Error | null, result: { stdout: string }) => void,
+    ) => {
+      cb(null, { stdout: "" });
+    },
+  ),
+  spawn: vi.fn(() => ({
+    on: vi.fn(),
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+  })),
 }));
 
 vi.mock("node:os", () => ({
@@ -122,6 +137,21 @@ describe("workspace-scoped chat session isolation", () => {
           cb(null, { stdout: "" });
         },
       ),
+      execFile: vi.fn(
+        (
+          _cmd: string,
+          _args: string[],
+          _opts: unknown,
+          cb: (err: Error | null, result: { stdout: string }) => void,
+        ) => {
+          cb(null, { stdout: "" });
+        },
+      ),
+      spawn: vi.fn(() => ({
+        on: vi.fn(),
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+      })),
     }));
     vi.mock("node:os", () => ({
       homedir: vi.fn(() => "/home/testuser"),

--- a/apps/web/lib/workspace-profiles.test.ts
+++ b/apps/web/lib/workspace-profiles.test.ts
@@ -40,6 +40,21 @@ vi.mock("node:child_process", () => ({
       cb(null, { stdout: "" });
     },
   ),
+  execFile: vi.fn(
+    (
+      _cmd: string,
+      _args: string[],
+      _opts: unknown,
+      cb: (err: Error | null, result: { stdout: string }) => void,
+    ) => {
+      cb(null, { stdout: "" });
+    },
+  ),
+  spawn: vi.fn(() => ({
+    on: vi.fn(),
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+  })),
 }));
 
 vi.mock("node:os", () => ({
@@ -115,6 +130,21 @@ describe("workspace (flat workspace model)", () => {
           cb(null, { stdout: "" });
         },
       ),
+      execFile: vi.fn(
+        (
+          _cmd: string,
+          _args: string[],
+          _opts: unknown,
+          cb: (err: Error | null, result: { stdout: string }) => void,
+        ) => {
+          cb(null, { stdout: "" });
+        },
+      ),
+      spawn: vi.fn(() => ({
+        on: vi.fn(),
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+      })),
     }));
     vi.mock("node:os", () => ({
       homedir: vi.fn(() => "/home/testuser"),

--- a/apps/web/lib/workspace.test.ts
+++ b/apps/web/lib/workspace.test.ts
@@ -23,6 +23,14 @@ vi.mock("node:child_process", () => ({
   exec: vi.fn((_cmd: string, _opts: unknown, cb: (err: Error | null, result: { stdout: string }) => void) => {
     cb(null, { stdout: "" });
   }),
+  execFile: vi.fn((_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null, result: { stdout: string }) => void) => {
+    cb(null, { stdout: "" });
+  }),
+  spawn: vi.fn(() => ({
+    on: vi.fn(),
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+  })),
 }));
 
 // Mock node:os
@@ -83,6 +91,14 @@ describe("workspace utilities", () => {
       exec: vi.fn((_cmd: string, _opts: unknown, cb: (err: Error | null, result: { stdout: string }) => void) => {
         cb(null, { stdout: "" });
       }),
+      execFile: vi.fn((_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null, result: { stdout: string }) => void) => {
+        cb(null, { stdout: "" });
+      }),
+      spawn: vi.fn(() => ({
+        on: vi.fn(),
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+      })),
     }));
     vi.mock("node:os", () => ({
       homedir: vi.fn(() => "/home/testuser"),


### PR DESCRIPTION
## Summary

Two regressions on `v3.0.0` were blocking `pnpm web:build` and `pnpm test:web`. Both are pre-existing on the branch and unrelated to any specific feature work — they're just casualties of recent v3 commits that landed without a clean CI gate. Splitting them out as a "PR 0" so the four follow-up feature PRs from yesterday's work can each be reviewed against a green base.

### 1. TS narrowing in `web-sessions` title extraction

`apps/web/app/api/web-sessions/[id]/messages/route.ts` and the matching helper in `apps/web/app/api/web-sessions/shared.ts` both have:

```ts
text = parsed.parts
  .filter((p: unknown): p is { type: string; text: string } => …)
  .map((p) => p.text)
  .join(" ");
```

`parsed` comes from `JSON.parse` so `parsed.parts` is `any[]`; on `any[]`, the type predicate on `.filter` doesn't propagate to `.map`, and `noImplicitAny` rejects `(p) => p.text`. Fix: cast the array to `unknown[]` upfront and type the `.map` callback parameter explicitly via a local `UITextPart` alias. Same shape applied to both files.

Introduced in `d99205258 fix(web): chat titles, calendar UI, inbox avatars, tree refresh noise`.

### 2. Missing `execFile`/`spawn` in `node:child_process` test mocks

`apps/web/lib/workspace.ts` now imports `execFile` and `spawn` from `node:child_process`:

```ts
import { execSync, exec, execFile, spawn } from "node:child_process";
```

But the test mocks in `lib/workspace.test.ts`, `lib/workspace-profiles.test.ts`, `lib/workspace-chat-isolation.test.ts`, and `lib/subagent-runs.test.ts` only expose `execSync` / `exec`. Vitest fails import-time with:

```
Error: [vitest] No "execFile" export is defined on the "node:child_process" mock.
```

Fix: add `execFile` (and `spawn` where missing) to every `vi.mock("node:child_process", …)` call — both at the module-top level and inside the `beforeEach` re-mocks. 178 failing tests across 4 files were all the same root cause.

Introduced in `6e4b9f095 feat(web): polish v3 workspace layout, chat UX, and dev speed`.

## Test plan

- [x] `pnpm --dir apps/web build` — passes (was failing on the TS error)
- [x] `pnpm --dir apps/web test` — 1549 passed | 5 skipped | 0 failed (was 178 failed | 1371 passed)

## Out of scope

- The 349 dependabot alerts. Those are a separate problem.
- Any product changes — this PR is exclusively CI hygiene so the four follow-up PRs (chat-history popover, relation-link routing, entry-modal close-on-nav, gateway-driven sync) can land against a green base.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to TypeScript typing/narrowing in web-session title extraction and to Vitest mocks for `node:child_process`, with no functional behavior changes intended beyond unblocking builds/tests.
> 
> **Overview**
> Fixes TypeScript `noImplicitAny` failures in web-session auto-title extraction by explicitly narrowing `parsed.parts` to `unknown[]` and typing the filtered/mapped text parts.
> 
> Unblocks Vitest by extending `node:child_process` mocks in workspace/subagent-related tests to include `execFile` (and `spawn` where needed), matching new imports used by `workspace.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b482d21ac17a5325b3f5993de1801fda18739320. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->