### PR TITLE
feat(web): include file-scoped chats in unified chat history popover

### DIFF
--- a/apps/web/app/components/workspace/chat-history-popover.tsx
+++ b/apps/web/app/components/workspace/chat-history-popover.tsx
@@ -620,7 +620,10 @@ export function ChatHistoryPopover({
 	const groups = useMemo(() => {
 		const rows: UnifiedRow[] = [];
 		for (const s of sessions) {
-			if (s.id.includes(":subagent:") || s.filePath) continue;
+			// Hide subagent (child) sessions — they render nested under their parent.
+			// Keep file-scoped sessions (those with `filePath`) in the unified history;
+			// in v3 they're regular top-level chats.
+			if (s.id.includes(":subagent:")) continue;
 			rows.push({ kind: "native", ts: s.updatedAt, session: s });
 		}
 		if (gatewaySessions) {

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -1185,13 +1185,15 @@ function WorkspacePageInner() {
   }, [refreshContext]);
 
   // Fetch chat sessions
+  // v3: keep file-scoped sessions too — the per-file session strip is gone, so
+  // every non-subagent chat lives in the unified history dropdown now.
   const fetchSessions = useCallback(async () => {
     setSessionsLoading(true);
     try {
       const res = await fetch("/api/web-sessions?includeAll=true");
       const data = await res.json();
-      const all: Array<WebSession & { filePath?: string }> = data.sessions ?? [];
-      setSessions(all.filter((s) => !s.filePath));
+      const all: WebSession[] = data.sessions ?? [];
+      setSessions(all);
     } catch {
       // ignore
     } finally {


### PR DESCRIPTION
## Summary

In v3 the per-file chat session strip was removed from the workspace sidebar in favor of a single "Clock" popover (`ChatHistoryPopover`) that lists every chat — but the popover and the workspace-content session fetch both still filtered out sessions whose `filePath` was set, leaving those chats with nowhere to live in the UI.

This PR drops both filters so file-scoped chats show up in the unified history dropdown alongside non-file ones. Subagent (child) sessions are still hidden because they render nested under their parent in the popover.

### Changes

- `apps/web/app/components/workspace/chat-history-popover.tsx` — only filter out `:subagent:` sessions; keep `filePath`-bearing rows
- `apps/web/app/workspace/workspace-content.tsx` — drop the `all.filter((s) => !s.filePath)` in `fetchSessions`

## Test plan

- [x] `pnpm --dir apps/web build` — passes
- [ ] Manual: open a file, start a chat scoped to it, confirm it appears in the Clock popover at the top of the workspace
- [ ] Manual: confirm subagent runs still nest under their parent and don't appear as standalone rows

## Out of scope

- Per-file session strip is intentionally not coming back; the popover is the v3 home for chat history.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state change that only affects which sessions are fetched and displayed; main concern is potential extra rows/perf in the history list.
> 
> **Overview**
> File-scoped chat sessions (those with `filePath`) are now treated as normal top-level chats in the unified history UI.
> 
> `fetchSessions` in `workspace-content.tsx` no longer filters out `filePath` sessions, and `ChatHistoryPopover` now hides only `:subagent:` child sessions (still rendered nested under parents) while including file-scoped sessions in the grouped history list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a298f7da5be7b88d67ff03cecfe5d95d3dbd9cc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->