### PR TITLE
feat(web): route relation chips to PersonProfile/CompanyProfile via stable seed IDs

### DIFF
--- a/apps/web/app/components/workspace/entry-detail-modal.tsx
+++ b/apps/web/app/components/workspace/entry-detail-modal.tsx
@@ -63,8 +63,16 @@ type EntryDetailModalProps = {
   entryId: string;
   members?: Array<{ id: string; name: string; email: string; role: string }>;
   onClose: () => void;
-  /** Navigate to another entry (opens new modal). */
-  onNavigateEntry?: (objectName: string, entryId: string) => void;
+  /**
+   * Navigate to another entry. The optional `relatedObjectId` lets the
+   * parent route precisely (CRM seed people/company → dedicated profile,
+   * everything else → side-panel modal).
+   */
+  onNavigateEntry?: (
+    objectName: string,
+    entryId: string,
+    relatedObjectId?: string,
+  ) => void;
   /** Navigate to an object table view. */
   onNavigateObject?: (objectName: string) => void;
   /** Called after an edit or delete to refresh parent data. */
@@ -176,10 +184,14 @@ function RelationChips({
   value: unknown;
   field: Field;
   relationLabels?: Record<string, Record<string, string>>;
-  onNavigateEntry?: (objectName: string, entryId: string) => void;
+  onNavigateEntry?: (
+    objectName: string,
+    entryId: string,
+    relatedObjectId?: string,
+  ) => void;
 }) {
   const fieldLabels = relationLabels?.[field.name];
-  const ids = parseRelationValue(String(value));
+  const ids = value == null ? [] : parseRelationValue(String(value));
   if (ids.length === 0) {return <EmptyValue />;}
 
   return (
@@ -189,7 +201,11 @@ function RelationChips({
         const handleClick = field.related_object_name && onNavigateEntry
           ? (e: React.MouseEvent<HTMLButtonElement>) => {
             e.stopPropagation();
-            onNavigateEntry(field.related_object_name!, id);
+            onNavigateEntry(
+              field.related_object_name!,
+              id,
+              field.related_object_id,
+            );
           }
           : undefined;
         return (
@@ -347,7 +363,11 @@ function ReverseRelationSection({
   onNavigateEntry,
 }: {
   relation: ReverseRelation;
-  onNavigateEntry?: (objectName: string, entryId: string) => void;
+  onNavigateEntry?: (
+    objectName: string,
+    entryId: string,
+    relatedObjectId?: string,
+  ) => void;
 }) {
   const displayLinks = relation.links.slice(0, 10);
   const overflow = relation.links.length - displayLinks.length;
@@ -371,7 +391,7 @@ function ReverseRelationSection({
           <button
             type="button"
             key={link.id}
-            onClick={() => onNavigateEntry?.(relation.sourceObjectName, link.id)}
+            onClick={() => onNavigateEntry?.(relation.sourceObjectName, link.id, relation.sourceObjectId)}
             className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium cursor-pointer hover:opacity-80"
             style={{
               background: "rgba(192, 132, 252, 0.1)",
@@ -407,7 +427,11 @@ function FieldValue({
   field: Field;
   members?: Array<{ id: string; name: string }>;
   relationLabels?: Record<string, Record<string, string>>;
-  onNavigateEntry?: (objectName: string, entryId: string) => void;
+  onNavigateEntry?: (
+    objectName: string,
+    entryId: string,
+    relatedObjectId?: string,
+  ) => void;
 }) {
   if (value === null || value === undefined || value === "") {return <EmptyValue />;}
 

--- a/apps/web/app/components/workspace/entry-detail-panel.tsx
+++ b/apps/web/app/components/workspace/entry-detail-panel.tsx
@@ -64,7 +64,16 @@ export type EntryDetailPanelProps = {
   tree: TreeNode[];
   searchFn?: MentionSearchFn;
   onClose: () => void;
-  onNavigateEntry?: (objectName: string, entryId: string) => void;
+  /**
+   * Open the entry's detail view. The optional `relatedObjectId` lets the
+   * parent route precisely (CRM seed people/company → dedicated profile,
+   * everything else → generic side-panel modal).
+   */
+  onNavigateEntry?: (
+    objectName: string,
+    entryId: string,
+    relatedObjectId?: string,
+  ) => void;
   onNavigateObject?: (objectName: string) => void;
   onRefresh?: () => void;
   onNavigate?: (path: string) => void;
@@ -163,17 +172,28 @@ function RelationChips({
 }: {
   value: unknown; field: Field;
   relationLabels?: Record<string, Record<string, string>>;
-  onNavigateEntry?: (objectName: string, entryId: string) => void;
+  onNavigateEntry?: (
+    objectName: string,
+    entryId: string,
+    relatedObjectId?: string,
+  ) => void;
 }) {
   const fieldLabels = relationLabels?.[field.name];
-  const ids = parseRelationValue(String(value));
+  const ids = value == null ? [] : parseRelationValue(String(value));
   if (ids.length === 0) return <EmptyValue />;
   return (
     <span className="flex items-center gap-1 flex-wrap">
       {ids.map((id) => {
         const label = fieldLabels?.[id] ?? id;
         const handleClick = field.related_object_name && onNavigateEntry
-          ? (e: React.MouseEvent<HTMLButtonElement>) => { e.stopPropagation(); onNavigateEntry(field.related_object_name!, id); }
+          ? (e: React.MouseEvent<HTMLButtonElement>) => {
+              e.stopPropagation();
+              onNavigateEntry(
+                field.related_object_name!,
+                id,
+                field.related_object_id,
+              );
+            }
           : undefined;
         return (
           <button type="button" key={id} onClick={handleClick}
@@ -287,7 +307,11 @@ function FieldValue({
   value: unknown; field: Field;
   members?: Array<{ id: string; name: string }>;
   relationLabels?: Record<string, Record<string, string>>;
-  onNavigateEntry?: (objectName: string, entryId: string) => void;
+  onNavigateEntry?: (
+    objectName: string,
+    entryId: string,
+    relatedObjectId?: string,
+  ) => void;
 }) {
   if (value === null || value === undefined || value === "") return <EmptyValue />;
   switch (field.type) {
@@ -303,7 +327,14 @@ function FieldValue({
   }
 }
 
-function ReverseRelationSection({ relation, onNavigateEntry }: { relation: ReverseRelation; onNavigateEntry?: (objectName: string, entryId: string) => void }) {
+function ReverseRelationSection({ relation, onNavigateEntry }: {
+  relation: ReverseRelation;
+  onNavigateEntry?: (
+    objectName: string,
+    entryId: string,
+    relatedObjectId?: string,
+  ) => void;
+}) {
   const displayLinks = relation.links.slice(0, 10);
   const overflow = relation.links.length - displayLinks.length;
   return (
@@ -315,7 +346,7 @@ function ReverseRelationSection({ relation, onNavigateEntry }: { relation: Rever
       </label>
       <div className="flex items-center gap-1 flex-wrap text-sm min-h-[1.5rem]">
         {displayLinks.map((link) => (
-          <button type="button" key={link.id} onClick={() => onNavigateEntry?.(relation.sourceObjectName, link.id)}
+          <button type="button" key={link.id} onClick={() => onNavigateEntry?.(relation.sourceObjectName, link.id, relation.sourceObjectId)}
             className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-medium cursor-pointer hover:opacity-80"
             style={{ background: "rgba(192, 132, 252, 0.1)", color: "#c084fc", border: "1px solid rgba(192, 132, 252, 0.2)" }}
             title={`Open ${link.label} in ${displayObjectName(relation.sourceObjectName)}`}

--- a/apps/web/app/components/workspace/object-table.tsx
+++ b/apps/web/app/components/workspace/object-table.tsx
@@ -57,7 +57,17 @@ type ObjectTableProps = {
 	relationLabels?: Record<string, Record<string, string>>;
 	reverseRelations?: ReverseRelation[];
 	onNavigateToObject?: (objectName: string) => void;
-	onNavigateToEntry?: (objectName: string, entryId: string) => void;
+	/**
+	 * Open the entry's detail view. The optional `relatedObjectId` lets the
+	 * parent route precisely (e.g. CRM seed people/company → dedicated profile,
+	 * everything else → generic side-panel modal) instead of guessing from the
+	 * raw object name, which collides with custom user objects.
+	 */
+	onNavigateToEntry?: (
+		objectName: string,
+		entryId: string,
+		relatedObjectId?: string,
+	) => void;
 	onEntryClick?: (entryId: string) => void;
 	onRefresh?: () => void;
 	activeEntryId?: string;
@@ -229,7 +239,11 @@ function RelationCell({
 	value: unknown; field: Field;
 	relationLabels?: Record<string, Record<string, string>>;
 	onNavigateObject?: (objectName: string) => void;
-	onNavigateEntry?: (objectName: string, entryId: string) => void;
+	onNavigateEntry?: (
+		objectName: string,
+		entryId: string,
+		relatedObjectId?: string,
+	) => void;
 }) {
 	const fieldLabels = relationLabels?.[field.name];
 	const ids = value == null ? [] : parseRelationValue(String(value));
@@ -244,7 +258,11 @@ function RelationCell({
 						if (!onNavigateEntry && !onNavigateObject) {return;}
 						e.stopPropagation();
 						if (onNavigateEntry) {
-							onNavigateEntry(field.related_object_name, id);
+							onNavigateEntry(
+								field.related_object_name,
+								id,
+								field.related_object_id,
+							);
 							return;
 						}
 						onNavigateObject?.(field.related_object_name);
@@ -382,11 +400,16 @@ function TagsInput({
 	);
 }
 
-function ReverseRelationCell({ links, sourceObjectName, onNavigateObject, onNavigateEntry }: {
+function ReverseRelationCell({ links, sourceObjectName, sourceObjectId, onNavigateObject, onNavigateEntry }: {
 	links: Array<{ id: string; label: string }>;
 	sourceObjectName: string;
+	sourceObjectId?: string;
 	onNavigateObject?: (objectName: string) => void;
-	onNavigateEntry?: (objectName: string, entryId: string) => void;
+	onNavigateEntry?: (
+		objectName: string,
+		entryId: string,
+		relatedObjectId?: string,
+	) => void;
 }) {
 	if (!links || links.length === 0) {return <span style={{ color: "var(--color-text-muted)", opacity: 0.5 }}>--</span>;}
 	const display = links.slice(0, 5);
@@ -400,7 +423,7 @@ function ReverseRelationCell({ links, sourceObjectName, onNavigateObject, onNavi
 						if (!onNavigateEntry && !onNavigateObject) {return;}
 						e.stopPropagation();
 						if (onNavigateEntry) {
-							onNavigateEntry(sourceObjectName, link.id);
+							onNavigateEntry(sourceObjectName, link.id, sourceObjectId);
 							return;
 						}
 						onNavigateObject?.(sourceObjectName);
@@ -440,7 +463,11 @@ function EditableCell({
 	members?: Array<{ id: string; name: string }>;
 	relationLabels?: Record<string, Record<string, string>>;
 	onNavigateObject?: (objectName: string) => void;
-	onNavigateEntry?: (objectName: string, entryId: string) => void;
+	onNavigateEntry?: (
+		objectName: string,
+		entryId: string,
+		relatedObjectId?: string,
+	) => void;
 	onLocalValueChange?: (value: string) => void;
 	onSaved?: () => void;
 	showUrlFavicon?: boolean;
@@ -941,6 +968,7 @@ export function ObjectTable({
 						<ReverseRelationCell
 							links={links}
 							sourceObjectName={rr.sourceObjectName}
+							sourceObjectId={rr.sourceObjectId}
 							onNavigateObject={onNavigateToObject}
 							onNavigateEntry={onNavigateToEntry}
 						/>

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -36,6 +36,7 @@ import { useSearchIndex } from "@/lib/search-index";
 import { parseWorkspaceLink, isWorkspaceLink, parseUrlState, buildUrl, buildWorkspaceSyncParams, type WorkspaceUrlState } from "@/lib/workspace-links";
 import { isCodeFile } from "@/lib/report-utils";
 import { displayObjectName, displayObjectNameSingular } from "@/lib/object-display-name";
+import { isSeedPeopleObjectId, isSeedCompanyObjectId } from "@/lib/seed-object-ids";
 import { CronDashboard } from "../components/cron/cron-dashboard";
 import { SkillStorePanel } from "../components/skill-store/skill-store-panel";
 import { IntegrationsPanel } from "../components/integrations/integrations-panel";
@@ -2072,21 +2073,34 @@ function WorkspacePageInner() {
 
   // Open entry modal handler
   const handleOpenEntry = useCallback(
-    (objectName: string, entryId: string) => {
+    (objectName: string, entryId: string, relatedObjectId?: string) => {
       // People + Company entries swap the MAIN panel for an Attio-style
       // profile (mirroring dench-2025's base-object-vs-generic-object
       // pattern). All other objects keep the existing side-panel modal.
       // The parent tab points at the resolved workspace object so the
       // back-to-list affordance lands on the unified ObjectView.
-      const isPersonProfile = objectName === "people";
-      const isCompanyProfile = objectName === "company" || objectName === "companies";
-      if (isPersonProfile) {
+      //
+      // Routing precedence:
+      //   1. `relatedObjectId` (when provided by a relation chip) is the
+      //      authoritative signal — comparing against the seed CRM object
+      //      IDs avoids false positives where a custom user object happens
+      //      to be named "company" / "companies" / "people".
+      //   2. Fallback to raw `objectName` matching for direct nav (URL
+      //      hydration, sidebar Companies/People entries) where no
+      //      relation field id is available.
+      const isSeedPerson = relatedObjectId
+        ? isSeedPeopleObjectId(relatedObjectId)
+        : objectName === "people";
+      const isSeedCompany = relatedObjectId
+        ? isSeedCompanyObjectId(relatedObjectId)
+        : objectName === "company" || objectName === "companies";
+      if (isSeedPerson) {
         const node = resolveCrmObjectNode(tree, "people");
         openTabForNode(node);
         setActivePath(node.path);
         setContent({ kind: "crm-person", entryId });
         setEntryModal(null);
-      } else if (isCompanyProfile) {
+      } else if (isSeedCompany) {
         const node = resolveCrmObjectNode(tree, "company");
         openTabForNode(node);
         setActivePath(node.path);
@@ -3328,7 +3342,9 @@ function WorkspacePageInner() {
                         tree={tree}
                         searchFn={searchIndex}
                         onClose={handleCloseEntry}
-                        onNavigateEntry={(objName, eid) => handleOpenEntry(objName, eid)}
+                        onNavigateEntry={(objName, eid, relatedObjectId) =>
+                          handleOpenEntry(objName, eid, relatedObjectId)
+                        }
                         onNavigateObject={(objName) => {
                           handleCloseEntry();
                           handleNavigateToObject(objName);
@@ -3530,7 +3546,9 @@ function WorkspacePageInner() {
                           tree={tree}
                           searchFn={searchIndex}
                           onClose={handleCloseEntry}
-                          onNavigateEntry={(objName, eid) => handleOpenEntry(objName, eid)}
+                          onNavigateEntry={(objName, eid, relatedObjectId) =>
+                            handleOpenEntry(objName, eid, relatedObjectId)
+                          }
                           onNavigateObject={(objName) => {
                             handleCloseEntry();
                             handleNavigateToObject(objName);
@@ -3652,7 +3670,11 @@ function ContentRenderer({
   onRefreshObject: () => void;
   onRefreshTree: () => void;
   onNavigate: (href: string) => void;
-  onOpenEntry: (objectName: string, entryId: string) => void;
+  onOpenEntry: (
+    objectName: string,
+    entryId: string,
+    relatedObjectId?: string,
+  ) => void;
   activeEntryId?: string;
   searchFn: (query: string, limit?: number) => import("@/lib/search-index").SearchIndexItem[];
   onSelectCronJob: (jobId: string) => void;
@@ -3938,7 +3960,11 @@ function ObjectView({
   onNavigateToObject: (objectName: string) => void;
   onRefreshObject: () => void;
   onRefreshTree?: () => void;
-  onOpenEntry?: (objectName: string, entryId: string) => void;
+  onOpenEntry?: (
+    objectName: string,
+    entryId: string,
+    relatedObjectId?: string,
+  ) => void;
   activeEntryId?: string;
 }) {
   const searchParams = useSearchParams();

--- a/apps/web/lib/seed-object-ids.ts
+++ b/apps/web/lib/seed-object-ids.ts
@@ -1,0 +1,32 @@
+/**
+ * Stable IDs for the CRM seed objects (people, company, email_thread, ...).
+ *
+ * Defined in a client-safe module — no DuckDB / fs imports — so React
+ * components can compare a relation's `related_object_id` against these
+ * constants to decide whether to route to a dedicated CRM profile
+ * (`PersonProfile` / `CompanyProfile`) or fall back to the generic
+ * entry-detail modal.
+ *
+ * The server-side migration code in `workspace-schema-migrations.ts`
+ * re-exports these via `ONBOARDING_OBJECT_IDS`.
+ */
+
+export const SEED_OBJECT_IDS = {
+	people: "seed_obj_people_00000000000000",
+	company: "seed_obj_company_0000000000000",
+	email_thread: "seed_obj_email_thread_000000000",
+	email_message: "seed_obj_email_message_00000000",
+	calendar_event: "seed_obj_calendar_event_0000000",
+	interaction: "seed_obj_interaction_00000000000",
+} as const;
+
+export type SeedObjectKey = keyof typeof SEED_OBJECT_IDS;
+
+/** Convenience predicates used by the workspace UI for relation routing. */
+export function isSeedPeopleObjectId(id: string | null | undefined): boolean {
+	return !!id && id === SEED_OBJECT_IDS.people;
+}
+
+export function isSeedCompanyObjectId(id: string | null | undefined): boolean {
+	return !!id && id === SEED_OBJECT_IDS.company;
+}

--- a/apps/web/lib/workspace-schema-migrations.ts
+++ b/apps/web/lib/workspace-schema-migrations.ts
@@ -20,17 +20,20 @@ import {
   readObjectYaml,
   writeObjectYaml,
 } from "./workspace";
+import { SEED_OBJECT_IDS } from "./seed-object-ids";
 
 // ---------------------------------------------------------------------------
 // Object IDs (seed_*) — must stay stable so re-runs are idempotent.
+// Single source of truth lives in `./seed-object-ids` so client components
+// can compare relation `related_object_id`s without pulling in server deps.
 // ---------------------------------------------------------------------------
 
-const PEOPLE_OBJECT_ID = "seed_obj_people_00000000000000";
-const COMPANY_OBJECT_ID = "seed_obj_company_0000000000000";
-const EMAIL_THREAD_OBJECT_ID = "seed_obj_email_thread_000000000";
-const EMAIL_MESSAGE_OBJECT_ID = "seed_obj_email_message_00000000";
-const CALENDAR_EVENT_OBJECT_ID = "seed_obj_calendar_event_0000000";
-const INTERACTION_OBJECT_ID = "seed_obj_interaction_00000000000";
+const PEOPLE_OBJECT_ID = SEED_OBJECT_IDS.people;
+const COMPANY_OBJECT_ID = SEED_OBJECT_IDS.company;
+const EMAIL_THREAD_OBJECT_ID = SEED_OBJECT_IDS.email_thread;
+const EMAIL_MESSAGE_OBJECT_ID = SEED_OBJECT_IDS.email_message;
+const CALENDAR_EVENT_OBJECT_ID = SEED_OBJECT_IDS.calendar_event;
+const INTERACTION_OBJECT_ID = SEED_OBJECT_IDS.interaction;
 
 const SOURCE_ENUM_VALUES = '["Manual","Gmail","Calendar"]';
 const SOURCE_ENUM_COLORS = '["#94a3b8","#ef4444","#3b82f6"]';


### PR DESCRIPTION
## Summary

When a row in the generic `ObjectTable` carries a relation field that points to a CRM seed object (people / company), clicking the foreign-link chip should land on the dedicated `PersonProfile` / `CompanyProfile` view — same affordance as clicking a Person directly from the sidebar — instead of the generic side-panel modal.

The previous routing in `handleOpenEntry` decided this by string-comparing the raw `objectName` against `\"people\"` / `\"company\"` / `\"companies\"`, which collides with custom user objects of the same name in any workspace where someone has created e.g. their own \"company\" object. This PR plumbs each relation's `related_object_id` through the navigation callbacks and routes by the stable seed ID instead, falling back to the old name match only for direct nav (URL hydration, sidebar Companies/People entries) where no relation field id is available.

### Changes

- **`apps/web/lib/seed-object-ids.ts`** *(NEW)* — single client-safe source of truth for the `seed_obj_*` IDs. Lives in its own module rather than `workspace-schema-migrations.ts` so React components can import the constants without pulling DuckDB / fs server deps into their bundle. Exposes `isSeedPeopleObjectId` / `isSeedCompanyObjectId` predicates.
- **`apps/web/lib/workspace-schema-migrations.ts`** — re-uses the constants from the new module so seed IDs stay consistent across server + client. No behavior change.
- **`apps/web/app/components/workspace/{object-table,entry-detail-modal,entry-detail-panel}.tsx`** — extend `onNavigateEntry` / `onNavigateToEntry` with an optional third `relatedObjectId?: string`. Relation chips and reverse-relation chips now pass `field.related_object_id` / `relation.sourceObjectId` through.
- **`apps/web/app/workspace/workspace-content.tsx`** — `handleOpenEntry` accepts the new arg and prefers it over `objectName` when deciding whether to swap into `PersonProfile` / `CompanyProfile`. JSX adapters and `ContentRenderer` / `ObjectView` prop signatures propagate the third arg. Also adds a small `value == null` guard on relation parsing.

## Test plan

- [x] `pnpm --dir apps/web build` — passes
- [x] `pnpm --dir apps/web test` — 1549 passed | 5 skipped
- [ ] Manual: in a custom CRM object with a relation pointing at the seed `people` table, click the chip → lands on PersonProfile (not generic modal)
- [ ] Manual: same for relation pointing at seed `company` → CompanyProfile
- [ ] Manual: in a workspace with a custom user object literally named \"company\", clicking a relation chip pointing at THAT object opens the generic side-panel modal (not CompanyProfile)
- [ ] Manual: sidebar People/Companies entries still go to PersonProfile/CompanyProfile (fallback path)

## Out of scope

- The entry-modal close-on-navigation behavior — that's a separate PR.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI routing change that only affects how relation/reverse-relation clicks decide between CRM profiles vs the generic entry panel; main risk is incorrect ID propagation causing links to open the wrong view.
> 
> **Overview**
> Improves entry navigation from relation and reverse-relation chips by plumbing an optional `relatedObjectId` through `onNavigateEntry`/`onNavigateToEntry` callbacks and using it to route reliably.
> 
> Adds a client-safe `seed-object-ids.ts` with stable CRM seed object IDs and helpers, reuses these IDs in `workspace-schema-migrations.ts`, and updates `handleOpenEntry` in `workspace-content.tsx` to prefer seed-ID checks (with object-name fallback) so custom objects named `people`/`company` no longer incorrectly open `PersonProfile`/`CompanyProfile`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1a8bee13ed2a85bbaaa81d7b4904c666edf3516. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->