### PR TITLE
feat(web): close entry-detail panel on navigation and drive ?entry= from state

### DIFF
--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -1392,6 +1392,9 @@ function WorkspacePageInner() {
     async (node: TreeNode) => {
       setActivePath(node.path);
       setContent({ kind: "loading" });
+      // Any navigation into a file/object/folder replaces the right-panel
+      // view, so a stale entry-detail-panel must not float on top of it.
+      setEntryModal(null);
 
       try {
         if (node.type === "object") {
@@ -1592,6 +1595,7 @@ function WorkspacePageInner() {
       openTabForNode({ path: config.path, name: config.name, type: "folder" }, { preview: false });
       setActivePath(config.path);
       setContent({ kind: config.kind });
+      setEntryModal(null);
     },
     [openTabForNode, tree, loadContent, ensureRightPanelOpenWide],
   );
@@ -1639,6 +1643,7 @@ function WorkspacePageInner() {
           openTabForNode(node);
           setActivePath(node.path);
           setContent({ kind: "directory", node: { name: node.name, path: node.path, type: "folder" } });
+          setEntryModal(null);
           return;
         }
       }
@@ -1663,6 +1668,7 @@ function WorkspacePageInner() {
           openTabForNode(node);
           setActivePath(node.path);
           setContent({ kind: "cron-job", jobId, job });
+          setEntryModal(null);
           return;
         }
       }
@@ -1671,6 +1677,7 @@ function WorkspacePageInner() {
         openTabForNode(node);
         setActivePath(node.path);
         setContent({ kind: "cron-dashboard" });
+        setEntryModal(null);
         return;
       }
       if (node.path === "~skills") {
@@ -1711,6 +1718,9 @@ function WorkspacePageInner() {
     if (tab.path) {
       const node = resolveNode(tree, tab.path);
       setActivePath(tab.path);
+      // Activating a non-chat tab swaps the right-panel view; close any
+      // entry-detail panel that was open against the previously-active tab.
+      setEntryModal(null);
       if (node) {
         setContent({ kind: "loading" });
         void loadContent(node);
@@ -1812,6 +1822,7 @@ function WorkspacePageInner() {
       setContent({ kind: "none" });
       setActiveSessionId(null);
       setActiveSubagentKey(null);
+      setEntryModal(null);
       return openTab(closed, createBlankChatTab());
     });
   }, []);
@@ -1996,6 +2007,7 @@ function WorkspacePageInner() {
         openTabForNode(node);
         setActivePath(itemPath);
         setContent({ kind: "directory", node: { name: item.name, path: itemPath, type: "folder" } });
+        setEntryModal(null);
       } else {
         if (browseDir != null) {
           const parentOfFile = item.path.split("/").slice(0, -1).join("/") || "/";
@@ -2034,6 +2046,7 @@ function WorkspacePageInner() {
       activeSessionId,
       activeSubagentKey,
       fileChatSessionId: null,
+      entryModal,
       browseDir,
       showHidden,
       previewPath: null,
@@ -2054,7 +2067,7 @@ function WorkspacePageInner() {
       router.push(url, { scroll: false });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally excludes searchParams to avoid infinite loop; hydrationPhase is a ref gate
-  }, [activePath, activeSessionId, activeSubagentKey, browseDir, showHidden, router, cronView, cronCalMode, cronDate, cronRunFilter, cronRun]);
+  }, [activePath, activeSessionId, activeSubagentKey, entryModal, browseDir, showHidden, router, cronView, cronCalMode, cronDate, cronRunFilter, cronRun]);
 
   // Terminal URL sync — independent of workspace hydration so it works app-wide.
   useEffect(() => {

--- a/apps/web/lib/workspace-links.ts
+++ b/apps/web/lib/workspace-links.ts
@@ -215,6 +215,13 @@ export interface WorkspaceSyncState {
   activeSessionId: string | null;
   activeSubagentKey: string | null;
   fileChatSessionId: string | null;
+  /**
+   * The entry currently shown in the side-panel modal (or `null` when no
+   * modal is open). Drives the `?entry=<object>:<id>` URL param so the
+   * modal closes whenever app state clears it (e.g. on navigation), rather
+   * than being passively preserved from the previous URL.
+   */
+  entryModal: { objectName: string; entryId: string } | null;
   browseDir: string | null;
   showHidden: boolean;
   previewPath: string | null;
@@ -230,8 +237,11 @@ export interface WorkspaceSyncState {
  * Build the URL params that the workspace URL sync effect should push.
  *
  * Pure function: takes app state + the current URL params (for preserving
- * object-view and entry params managed by other effects) and returns the
- * complete URLSearchParams to write.
+ * object-view params managed by ObjectView's own effect) and returns the
+ * complete URLSearchParams to write. The `entry` param is driven by
+ * `state.entryModal`, not by the previous URL — that way navigating away
+ * from an open entry modal removes the param and the modal stays closed
+ * on refresh.
  */
 export function buildWorkspaceSyncParams(
   state: WorkspaceSyncState,
@@ -241,8 +251,12 @@ export function buildWorkspaceSyncParams(
 
   if (state.activePath) {
     params.set("path", state.activePath);
-    const entry = currentParams.get("entry");
-    if (entry) params.set("entry", entry);
+    if (state.entryModal) {
+      params.set(
+        "entry",
+        `${state.entryModal.objectName}:${state.entryModal.entryId}`,
+      );
+    }
     if (state.fileChatSessionId) params.set("fileChat", state.fileChatSessionId);
 
     if (state.activePath === "~cron") {

--- a/apps/web/lib/workspace-sync-params.test.ts
+++ b/apps/web/lib/workspace-sync-params.test.ts
@@ -16,6 +16,7 @@ function defaultState(overrides: Partial<WorkspaceSyncState> = {}): WorkspaceSyn
     activeSessionId: null,
     activeSubagentKey: null,
     fileChatSessionId: null,
+    entryModal: null,
     browseDir: null,
     showHidden: false,
     previewPath: null,
@@ -137,17 +138,42 @@ describe("buildWorkspaceSyncParams core behavior", () => {
     expect(params.has("chat")).toBe(false);
   });
 
-  it("preserves entry param from current URL when path is set (entry modal is independent)", () => {
+  it("includes entry param when entryModal state is set alongside an active path", () => {
     const params = buildWorkspaceSyncParams(
-      defaultState({ activePath: "leads" }),
-      new URLSearchParams("entry=leads:abc"),
+      defaultState({
+        activePath: "leads",
+        entryModal: { objectName: "leads", entryId: "abc" },
+      }),
+      new URLSearchParams(),
     );
     expect(params.get("entry")).toBe("leads:abc");
   });
 
+  it("strips a stale entry param from the URL when entryModal is null (modal closed by navigation)", () => {
+    const params = buildWorkspaceSyncParams(
+      defaultState({ activePath: "leads" }),
+      new URLSearchParams("entry=leads:abc"),
+    );
+    expect(params.has("entry")).toBe(false);
+  });
+
+  it("replaces a stale entry param when navigating to a different entry modal", () => {
+    const params = buildWorkspaceSyncParams(
+      defaultState({
+        activePath: "leads",
+        entryModal: { objectName: "leads", entryId: "new-id" },
+      }),
+      new URLSearchParams("entry=leads:old-id"),
+    );
+    expect(params.get("entry")).toBe("leads:new-id");
+  });
+
   it("does not carry entry param when in chat mode (entry only meaningful with path)", () => {
     const params = buildWorkspaceSyncParams(
-      defaultState({ activeSessionId: "sess-1" }),
+      defaultState({
+        activeSessionId: "sess-1",
+        entryModal: { objectName: "leads", entryId: "abc" },
+      }),
       new URLSearchParams("entry=leads:abc"),
     );
     expect(params.has("entry")).toBe(false);


### PR DESCRIPTION
## Summary

The floating entry-detail side panel used to stay open across most navigation events — clicking a file in the tree, switching tabs, selecting a sidebar item, or opening a blank chat tab would all change the main content area but leave the entry panel hovering on top of the new view. The URL `?entry=…` param was also passively preserved from the previous URL, so refreshing the page sometimes restored a panel the user had already dismissed.

This PR makes the panel state authoritative:

- Add `entryModal` to `WorkspaceSyncState` and drive the `?entry=` URL param off it in `buildWorkspaceSyncParams`. The param is set when `entryModal` is non-null, replaced when it points to a different entry, and stripped when it goes to null. This way, navigating away from an open panel removes the param, and the panel stays closed on refresh.
- Call `setEntryModal(null)` in every navigation handler that changes the right-panel view: `handleNodeSelect`, `handleNavigate` (CRM tabs), the cron-job / cron-dashboard / directory branches, `handleSelectTab`, the close-tab flow, and the file-browser item click.

### Files

- **`apps/web/lib/workspace-links.ts`** — `entryModal` field on `WorkspaceSyncState`; URL builder reads from state instead of carrying over the previous URL's `entry`.
- **`apps/web/lib/workspace-sync-params.test.ts`** — 3 new test cases covering open / close / replace and the chat-mode strip.
- **`apps/web/app/workspace/workspace-content.tsx`** — 8 `setEntryModal(null)` calls in nav handlers + state pass-through into `buildWorkspaceSyncParams` + `entryModal` added to the URL-sync effect's deps.

## Test plan

- [x] `pnpm --dir apps/web build` — passes
- [x] `pnpm --dir apps/web test` — 1551 passed | 5 skipped (added 2 new cases)
- [ ] Manual: open an entry detail panel, then click a file in the tree → panel closes
- [ ] Manual: open an entry detail panel, then switch tabs → panel closes
- [ ] Manual: open entry detail panel → URL has `?entry=obj:id`; close → URL drops it; refresh → panel stays closed
- [ ] Manual: navigate to a CRM tab → URL drops `?entry=`

## Out of scope

- Relation chip routing to PersonProfile/CompanyProfile (separate PR).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workspace navigation and URL-sync behavior across many code paths; risk is mainly UI state/URL regressions (e.g., entry modal unexpectedly closing/opening or incorrect query params), but no security- or data-critical logic changes.
> 
> **Overview**
> Makes the floating entry-detail panel *state-driven* and ensures it closes on any navigation that changes the right-panel view (file/object/folder opens, sidebar page navigations, tab switches, cron/directory selections, and close-all-tabs).
> 
> Updates workspace URL syncing so `?entry=` is written from `entryModal` state (set/replace/strip) instead of being preserved from the prior URL, with added tests to cover open/close/replace behavior and to ensure `entry` is not carried in chat mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6da10d8d6f23bb001edbfc4c7672ab442b6fd507. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->