### PR TITLE
feat: move Gmail/Calendar incremental poll from Next.js to OpenClaw gateway

### DIFF
--- a/apps/web/app/api/sync/poll-tick/route.test.ts
+++ b/apps/web/app/api/sync/poll-tick/route.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Auth + execution contract for the gateway-driven poll-tick endpoint.
+ *
+ * The contract under test:
+ *
+ * 1. Loopback-only — non-localhost host headers get 403, with no key read
+ *    or tick attempted (saves I/O on misconfigured public deployments).
+ * 2. Bearer token must be present and equal (constant-time compare) to
+ *    the Dench Cloud API key the `dench-ai-gateway` plugin reads.
+ * 3. When backfill is running, the tick is skipped (returns ok+skipped)
+ *    so the gateway-driven cron doesn't pile work on top of an in-flight
+ *    backfill.
+ * 4. Happy path runs `tickPoller()` exactly once and returns the most
+ *    recent SyncProgressEvent so logs/debug tools have something to read.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/dench-auth", () => ({
+  readDenchAuthProfileKey: vi.fn(),
+}));
+
+vi.mock("@/lib/sync-runner", () => ({
+  tickPoller: vi.fn(async () => {}),
+  isBackfillRunning: vi.fn(() => false),
+  getLastProgressEvent: vi.fn(() => null),
+}));
+
+const { POST } = await import("./route");
+const { readDenchAuthProfileKey } = await import("@/lib/dench-auth");
+const { tickPoller, isBackfillRunning, getLastProgressEvent } = await import(
+  "@/lib/sync-runner"
+);
+
+const mockedReadKey = vi.mocked(readDenchAuthProfileKey);
+const mockedTick = vi.mocked(tickPoller);
+const mockedBackfillRunning = vi.mocked(isBackfillRunning);
+const mockedLastEvent = vi.mocked(getLastProgressEvent);
+
+const VALID_KEY = "dench_test_key_abcd1234";
+
+function makeRequest(opts: {
+  authorization?: string | null;
+  host?: string | null;
+  forwardedHost?: string | null;
+}): Request {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (opts.authorization !== null && opts.authorization !== undefined) {
+    headers.set("authorization", opts.authorization);
+  }
+  if (opts.host !== null) {
+    headers.set("host", opts.host ?? "127.0.0.1:3100");
+  }
+  if (opts.forwardedHost) {
+    headers.set("x-forwarded-host", opts.forwardedHost);
+  }
+  return new Request("http://127.0.0.1:3100/api/sync/poll-tick", {
+    method: "POST",
+    headers,
+    body: "{}",
+  });
+}
+
+describe("/api/sync/poll-tick", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedReadKey.mockReturnValue(VALID_KEY);
+    mockedBackfillRunning.mockReturnValue(false);
+    mockedLastEvent.mockReturnValue(null);
+  });
+
+  it("rejects non-loopback hosts with 403 (no key read, no tick)", async () => {
+    const res = await POST(makeRequest({
+      host: "example.com",
+      authorization: `Bearer ${VALID_KEY}`,
+    }));
+    expect(res.status).toBe(403);
+    expect(mockedReadKey).not.toHaveBeenCalled();
+    expect(mockedTick).not.toHaveBeenCalled();
+  });
+
+  it("accepts 127.0.0.1 host", async () => {
+    const res = await POST(makeRequest({
+      host: "127.0.0.1:3100",
+      authorization: `Bearer ${VALID_KEY}`,
+    }));
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts localhost host", async () => {
+    const res = await POST(makeRequest({
+      host: "localhost:3100",
+      authorization: `Bearer ${VALID_KEY}`,
+    }));
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts IPv6 loopback ::1", async () => {
+    const res = await POST(makeRequest({
+      host: "[::1]:3100",
+      authorization: `Bearer ${VALID_KEY}`,
+    }));
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects missing Authorization header with 401", async () => {
+    const res = await POST(makeRequest({ authorization: undefined }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toMatch(/Missing Bearer/);
+    expect(mockedTick).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed Authorization header (no Bearer prefix) with 401", async () => {
+    const res = await POST(makeRequest({ authorization: VALID_KEY }));
+    expect(res.status).toBe(401);
+    expect(mockedTick).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when no Dench Cloud key is configured", async () => {
+    mockedReadKey.mockReturnValue(undefined);
+    const res = await POST(makeRequest({
+      authorization: `Bearer ${VALID_KEY}`,
+    }));
+    expect(res.status).toBe(503);
+    expect(mockedTick).not.toHaveBeenCalled();
+  });
+
+  it("rejects mismatched Bearer token with 401 (no tick)", async () => {
+    const res = await POST(makeRequest({
+      authorization: "Bearer wrong_key",
+    }));
+    expect(res.status).toBe(401);
+    expect(mockedTick).not.toHaveBeenCalled();
+  });
+
+  it("rejects same-prefix-different-suffix token (constant-time compare hardens, but length differs)", async () => {
+    // Different length should still be a clean reject (not a hang or crash).
+    const res = await POST(makeRequest({
+      authorization: `Bearer ${VALID_KEY}xtra`,
+    }));
+    expect(res.status).toBe(401);
+  });
+
+  it("skips tick (still 200) when a backfill is in progress", async () => {
+    mockedBackfillRunning.mockReturnValue(true);
+    const res = await POST(makeRequest({
+      authorization: `Bearer ${VALID_KEY}`,
+    }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.skipped).toBe("backfill-in-progress");
+    expect(mockedTick).not.toHaveBeenCalled();
+  });
+
+  it("calls tickPoller exactly once on the happy path and surfaces last event", async () => {
+    mockedLastEvent.mockReturnValue({
+      phase: "polling",
+      message: "Synced 3 new emails.",
+      messagesProcessed: 3,
+      peopleProcessed: 0,
+      companiesProcessed: 0,
+      threadsProcessed: 0,
+      eventsProcessed: 0,
+    });
+    const res = await POST(makeRequest({
+      authorization: `Bearer ${VALID_KEY}`,
+    }));
+    expect(res.status).toBe(200);
+    expect(mockedTick).toHaveBeenCalledTimes(1);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.lastEvent?.message).toBe("Synced 3 new emails.");
+    expect(typeof body.ranAt).toBe("string");
+  });
+
+  it("returns 500 and surfaces error when tickPoller throws", async () => {
+    mockedTick.mockRejectedValueOnce(new Error("DuckDB busy"));
+    const res = await POST(makeRequest({
+      authorization: `Bearer ${VALID_KEY}`,
+    }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/DuckDB busy/);
+  });
+
+  it("prefers x-forwarded-host over host (proxy-aware loopback check)", async () => {
+    // Simulating a misconfigured proxy that forwards from public host
+    // even though the underlying connection is loopback. We MUST trust
+    // x-forwarded-host so the loopback assertion remains tight.
+    const res = await POST(makeRequest({
+      host: "127.0.0.1:3100",
+      forwardedHost: "evil.example.com",
+      authorization: `Bearer ${VALID_KEY}`,
+    }));
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/web/app/api/sync/poll-tick/route.ts
+++ b/apps/web/app/api/sync/poll-tick/route.ts
@@ -1,0 +1,145 @@
+/**
+ * Loopback-only endpoint hit by the OpenClaw gateway's `dench-ai-gateway`
+ * plugin every ~5 minutes (see `extensions/dench-ai-gateway/sync-trigger.ts`).
+ *
+ * The gateway is the long-lived process that owns the timing now — the
+ * web app just runs one Gmail/Calendar incremental cycle per call. This
+ * lets the cron survive `denchclaw update` and Next.js restarts.
+ *
+ * Auth: validates a Bearer token against the same Dench Cloud API key the
+ * plugin reads (`<stateDir>/agents/main/agent/auth-profiles.json#profiles["dench-cloud:default"].key`).
+ * No new secret to provision — if Dench Cloud isn't connected, the
+ * plugin doesn't fire requests AND the endpoint rejects them.
+ *
+ * Hardening:
+ * - Constant-time key compare (`crypto.timingSafeEqual`).
+ * - Loopback-only host check on the request as defense-in-depth, in case
+ *   the runtime is misconfigured to bind to a public interface.
+ */
+
+import { timingSafeEqual } from "node:crypto";
+import { readDenchAuthProfileKey } from "@/lib/dench-auth";
+import {
+  getLastProgressEvent,
+  isBackfillRunning,
+  tickPoller,
+} from "@/lib/sync-runner";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function safeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, "utf-8");
+  const bBuf = Buffer.from(b, "utf-8");
+  if (aBuf.length !== bBuf.length) {
+    return false;
+  }
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+function extractBearer(authHeader: string | null): string | null {
+  if (!authHeader) {
+    return null;
+  }
+  const match = /^Bearer\s+(.+)$/i.exec(authHeader.trim());
+  if (!match) {
+    return null;
+  }
+  const token = match[1]?.trim();
+  return token && token.length > 0 ? token : null;
+}
+
+/**
+ * Normalize a request host (`Host` or `X-Forwarded-Host`) and decide
+ * whether it points at the loopback interface. We accept localhost and
+ * 127.0.0.0/8 / ::1 only; anything else is treated as a misconfigured
+ * deployment and rejected.
+ */
+function isLoopbackHost(rawHost: string | null): boolean {
+  if (!rawHost) {
+    return false;
+  }
+  const host = rawHost.split(",")[0]?.trim().toLowerCase();
+  if (!host) {
+    return false;
+  }
+  // Strip trailing port (`localhost:3100` → `localhost`). Handles
+  // bracketed IPv6 (`[::1]:3100` → `::1`).
+  let bare = host;
+  if (bare.startsWith("[")) {
+    const closing = bare.indexOf("]");
+    bare = closing > 0 ? bare.slice(1, closing) : bare;
+  } else {
+    const lastColon = bare.lastIndexOf(":");
+    if (lastColon > 0 && /^\d+$/.test(bare.slice(lastColon + 1))) {
+      bare = bare.slice(0, lastColon);
+    }
+  }
+  return (
+    bare === "localhost" ||
+    bare === "127.0.0.1" ||
+    bare === "::1" ||
+    bare.startsWith("127.")
+  );
+}
+
+export async function POST(req: Request) {
+  const hostHeader =
+    req.headers.get("x-forwarded-host") ?? req.headers.get("host");
+  if (!isLoopbackHost(hostHeader)) {
+    return Response.json(
+      { error: "poll-tick is loopback-only" },
+      { status: 403 },
+    );
+  }
+
+  const presented = extractBearer(req.headers.get("authorization"));
+  if (!presented) {
+    return Response.json(
+      { error: "Missing Bearer token" },
+      { status: 401 },
+    );
+  }
+
+  const expected = readDenchAuthProfileKey();
+  if (!expected) {
+    return Response.json(
+      { error: "Dench Cloud API key not configured" },
+      { status: 503 },
+    );
+  }
+
+  if (!safeEqual(presented, expected)) {
+    return Response.json(
+      { error: "Invalid token" },
+      { status: 401 },
+    );
+  }
+
+  if (isBackfillRunning()) {
+    return Response.json({
+      ok: true,
+      skipped: "backfill-in-progress",
+    });
+  }
+
+  try {
+    await tickPoller();
+  } catch (err) {
+    return Response.json(
+      {
+        ok: false,
+        error: err instanceof Error ? err.message : "tickPoller failed",
+      },
+      { status: 500 },
+    );
+  }
+
+  // tickPoller doesn't return a summary; surface the most recent event so
+  // logs / debugging tools can see what the tick actually did.
+  return Response.json({
+    ok: true,
+    ranAt: new Date().toISOString(),
+    lastEvent: getLastProgressEvent(),
+  });
+}

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -22,26 +22,11 @@ export async function register() {
       console.error("[instrumentation] ensureLatestSchema failed:", err);
     }
 
-    // Resume the Gmail/Calendar incremental poll loop after process restart
-    // if the user has already completed onboarding. Cursors persisted in
-    // .denchclaw/sync-cursors.json mean no message is lost across restarts.
-    try {
-      const { isOnboardingComplete, readConnections, readSyncCursors } = await import(
-        "./lib/denchclaw-state"
-      );
-      if (isOnboardingComplete()) {
-        const connections = readConnections();
-        const cursors = readSyncCursors();
-        const hasGmailWatch = connections.gmail && cursors.gmail?.historyId;
-        const hasCalendarWatch = connections.calendar && cursors.calendar?.syncToken;
-        if (hasGmailWatch || hasCalendarWatch) {
-          const { armIncrementalPoller } = await import("./lib/sync-runner");
-          armIncrementalPoller();
-        }
-      }
-    } catch {
-      // Non-fatal — poller will be re-armed when the user completes a
-      // manual sync from the workspace.
-    }
+    // Note: the Gmail/Calendar incremental poll loop is no longer armed
+    // from inside the Next.js process. The OpenClaw gateway daemon's
+    // `dench-ai-gateway` plugin owns the timing now and POSTs to
+    // `/api/sync/poll-tick` every ~5 minutes. That process survives
+    // `denchclaw update` and web-runtime restarts, so the cron stays
+    // alive without depending on Next.js boot hooks.
   }
 }

--- a/apps/web/lib/dench-auth.ts
+++ b/apps/web/lib/dench-auth.ts
@@ -1,0 +1,55 @@
+/**
+ * Web-side mirror of `extensions/shared/dench-auth.ts#readDenchAuthProfileKey`.
+ *
+ * Reads the Dench Cloud API key from the same single source of truth
+ * (`<stateDir>/agents/main/agent/auth-profiles.json#profiles["dench-cloud:default"].key`)
+ * that the OpenClaw gateway and bundled plugins use, with the same
+ * env-var fallback. Kept as a separate file (rather than importing from
+ * `../../extensions/shared/dench-auth.ts`) so the Next.js bundler
+ * doesn't have to reach across the workspace boundary.
+ *
+ * Used by the loopback `/api/sync/poll-tick` endpoint to validate the
+ * Bearer token sent by the `dench-ai-gateway` plugin's sync trigger.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { resolveOpenClawStateDir } from "@/lib/workspace";
+
+const AUTH_PROFILES_REL = join("agents", "main", "agent", "auth-profiles.json");
+
+type UnknownRecord = Record<string, unknown>;
+
+function readKeyFromAuthProfiles(authPath: string): string | undefined {
+  try {
+    if (!existsSync(authPath)) {
+      return undefined;
+    }
+    const raw = JSON.parse(readFileSync(authPath, "utf-8")) as UnknownRecord;
+    const profiles = (raw?.profiles as UnknownRecord | undefined) ?? undefined;
+    const profile = (profiles?.["dench-cloud:default"] as UnknownRecord | undefined) ?? undefined;
+    const key = profile?.key;
+    return typeof key === "string" && key.trim() ? key.trim() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function envFallback(): string | undefined {
+  return (
+    process.env.DENCH_CLOUD_API_KEY?.trim() ||
+    process.env.DENCH_API_KEY?.trim() ||
+    undefined
+  );
+}
+
+export function readDenchAuthProfileKey(): string | undefined {
+  const stateDir = resolveOpenClawStateDir();
+  if (stateDir) {
+    const key = readKeyFromAuthProfiles(join(stateDir, AUTH_PROFILES_REL));
+    if (key) {
+      return key;
+    }
+  }
+  return envFallback();
+}

--- a/apps/web/lib/sync-runner.ts
+++ b/apps/web/lib/sync-runner.ts
@@ -1,8 +1,14 @@
 /**
- * Sync orchestrator — drives Gmail + Calendar backfill once, then arms a
- * 5-minute incremental poll loop. The whole module is process-singleton:
- * exactly one backfill or poll runs at a time per Next.js process, no
- * matter how many SSE clients connect.
+ * Sync orchestrator — drives Gmail + Calendar backfill once. The
+ * incremental poll loop is no longer in-process: it's driven by the
+ * `dench-ai-gateway` plugin running inside the OpenClaw gateway daemon,
+ * which POSTs to `/api/sync/poll-tick` every ~5 minutes and we run
+ * `tickPoller()` here. The plugin survives Next.js restarts, so the
+ * cron stays alive across `denchclaw update`.
+ *
+ * The whole module is process-singleton: exactly one backfill or poll
+ * runs at a time per Next.js process, no matter how many SSE clients
+ * connect (or how many gateway-driven ticks land while one is in flight).
  *
  * Public surface:
  *
@@ -10,9 +16,14 @@
  *                       again while one is already in progress is a no-op
  *                       and just returns the in-flight handle).
  *   subscribeProgress(listener) → SSE-friendly progress event subscription.
- *   armIncrementalPoller()      → starts the 5-min interval (also called
- *                                 automatically once backfill completes).
- *   stop()                       → tears down the poller (used in tests).
+ *   tickPoller()                → run a single incremental poll cycle. Called
+ *                                 from the gateway-driven HTTP endpoint;
+ *                                 mutex-gated so overlap with backfill or
+ *                                 another tick is a no-op.
+ *   armIncrementalPoller()      → DEPRECATED. No-op shim retained so external
+ *                                 callers don't break; gateway plugin owns timing now.
+ *   stopIncrementalPoller()      → tears down the (now-unused) in-process
+ *                                  interval if a test or older code path armed it.
  */
 
 import { Mutex } from "async-mutex";
@@ -67,9 +78,10 @@ const listeners = new Set<ProgressListener>();
 let lastEvent: SyncProgressEvent | null = null;
 let backfillRunning = false;
 let backfillPromise: Promise<void> | null = null;
+// pollerHandle is no longer set in steady state — the gateway plugin owns
+// timing now. Kept as a defensive null so `stopIncrementalPoller()` can
+// still clean up if a test or older code path armed an in-process timer.
 let pollerHandle: ReturnType<typeof setInterval> | null = null;
-
-const DEFAULT_POLL_INTERVAL_MS = 5 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Progress emission
@@ -333,8 +345,10 @@ async function runBackfillInner(options: StartBackfillOptions): Promise<void> {
       eventsProcessed: totalEvents,
     });
 
-    // Arm the poller for ongoing freshness.
-    armIncrementalPoller();
+    // No need to arm an in-process poller: the OpenClaw gateway's
+    // `dench-ai-gateway` plugin already posts to `/api/sync/poll-tick`
+    // on its own schedule. First gateway tick will catch up anything
+    // that landed between the backfill commit and now.
   } finally {
     release();
   }
@@ -344,15 +358,17 @@ async function runBackfillInner(options: StartBackfillOptions): Promise<void> {
 // Incremental poller
 // ---------------------------------------------------------------------------
 
-export function armIncrementalPoller(intervalMs?: number): void {
-  if (pollerHandle) {return;}
-  const cursors = readSyncCursors();
-  const period = intervalMs ?? cursors.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
-  pollerHandle = setInterval(() => {
-    void tickPoller().catch(() => {
-      // Errors swallowed; emit() inside tickPoller already surfaces them.
-    });
-  }, period);
+/**
+ * @deprecated The incremental poll loop is now driven by the
+ * `dench-ai-gateway` OpenClaw plugin (which posts to `/api/sync/poll-tick`
+ * from inside the long-lived gateway daemon). This function is retained as
+ * a no-op shim so older callers don't break; new callers should use
+ * `tickPoller()` directly if they need a one-shot run, or rely on the
+ * gateway-driven cron for ongoing polling. The `intervalMs` parameter is
+ * ignored.
+ */
+export function armIncrementalPoller(_intervalMs?: number): void {
+  // No-op: the gateway plugin owns timing now.
 }
 
 export function stopIncrementalPoller(): void {
@@ -362,7 +378,14 @@ export function stopIncrementalPoller(): void {
   }
 }
 
-async function tickPoller(): Promise<void> {
+/**
+ * Run a single incremental Gmail/Calendar poll cycle. Safe to call
+ * concurrently — the module mutex makes overlapping invocations no-ops.
+ *
+ * Called from `apps/web/app/api/sync/poll-tick/route.ts`, which is
+ * triggered by the gateway-side `dench-ai-gateway` plugin every ~5 min.
+ */
+export async function tickPoller(): Promise<void> {
   if (mutex.isLocked()) {return;}
   const release = await mutex.acquire();
   try {

--- a/extensions/dench-ai-gateway/index.test.ts
+++ b/extensions/dench-ai-gateway/index.test.ts
@@ -1,8 +1,9 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import register from "./index.js";
+import { _resetSyncTriggerForTests, armSyncTrigger } from "./sync-trigger.js";
 
 function writeAuthProfiles(stateDir: string, key: string): void {
   const authDir = path.join(stateDir, "agents", "main", "agent");
@@ -16,6 +17,52 @@ function writeAuthProfiles(stateDir: string, key: string): void {
       },
     }),
   );
+}
+
+function writeWebRuntimeProcessFile(stateDir: string, port: number): void {
+  const runtimeDir = path.join(stateDir, "web-runtime");
+  mkdirSync(runtimeDir, { recursive: true });
+  writeFileSync(
+    path.join(runtimeDir, "process.json"),
+    JSON.stringify({
+      pid: 99999,
+      port,
+      gatewayPort: 19001,
+      startedAt: new Date().toISOString(),
+      runtimeAppDir: path.join(runtimeDir, "app"),
+    }),
+  );
+}
+
+/**
+ * Build a minimal plugin api shim with optional sync-trigger config.
+ * Mirrors the shape `dench-ai-gateway/index.ts`'s `register()` reads.
+ */
+function createSyncTriggerApi(params?: {
+  syncTrigger?: Record<string, unknown> | null;
+}): { api: any; logs: string[] } {
+  const logs: string[] = [];
+  const api: any = {
+    config: {
+      plugins: {
+        entries: {
+          "dench-ai-gateway": {
+            config: {
+              enabled: true,
+              gatewayUrl: "https://gateway.example.com",
+              ...(params?.syncTrigger !== null
+                ? { syncTrigger: params?.syncTrigger ?? {} }
+                : {}),
+            },
+          },
+        },
+      },
+    },
+    logger: {
+      info: (msg: string) => logs.push(msg),
+    },
+  };
+  return { api, logs };
 }
 
 function createApi(params?: { gatewayUrl?: string; withMcp?: boolean }) {
@@ -48,6 +95,12 @@ function createApi(params?: { gatewayUrl?: string; withMcp?: boolean }) {
             config: {
               enabled: true,
               gatewayUrl,
+              // Disable the gateway-side sync trigger in composio bridge
+              // tests — they assert exact `fetch` call counts on the
+              // composio gateway URL, and the trigger would fire its
+              // own loopback fetch on register() and corrupt the count.
+              // The sync-trigger has its own dedicated test block below.
+              syncTrigger: { enabled: false },
             },
           },
         },
@@ -341,5 +394,352 @@ describe("dench-ai-gateway composio bridge", () => {
     expect(globalThis.fetch).not.toHaveBeenCalled();
     expect(result.content[0]?.text).toContain("The `tool_slug` field is required");
     expect(result.content[0]?.text).toContain("dench_search_integrations");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sync-trigger: gateway-driven Gmail/Calendar poll-tick fan-out
+// ---------------------------------------------------------------------------
+
+describe("dench-ai-gateway sync-trigger", () => {
+  const originalFetch = globalThis.fetch;
+  const originalStateDir = process.env.OPENCLAW_STATE_DIR;
+  const originalWebBaseUrlEnv = process.env.DENCHCLAW_WEB_BASE_URL;
+  let stateDir: string | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    _resetSyncTriggerForTests();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+    if (stateDir) {
+      rmSync(stateDir, { recursive: true, force: true });
+      stateDir = undefined;
+    }
+    if (originalStateDir !== undefined) {
+      process.env.OPENCLAW_STATE_DIR = originalStateDir;
+    } else {
+      delete process.env.OPENCLAW_STATE_DIR;
+    }
+    if (originalWebBaseUrlEnv !== undefined) {
+      process.env.DENCHCLAW_WEB_BASE_URL = originalWebBaseUrlEnv;
+    } else {
+      delete process.env.DENCHCLAW_WEB_BASE_URL;
+    }
+  });
+
+  it("does NOT arm when no Dench Cloud API key is present", () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "dench-ai-gateway-trigger-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    // No auth-profiles.json written → no key.
+    delete process.env.DENCH_CLOUD_API_KEY;
+    delete process.env.DENCH_API_KEY;
+
+    const fetchMock = vi.fn() as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+    const { api, logs } = createSyncTriggerApi();
+
+    armSyncTrigger(api);
+
+    // Advance well past the default 5-min interval; no fetch should fire.
+    vi.advanceTimersByTime(20 * 60 * 1000);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(logs.some((m) => m.includes("No Dench Cloud API key"))).toBe(true);
+  });
+
+  it("does NOT arm when syncTrigger.enabled === false even with a key present", () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "dench-ai-gateway-trigger-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+
+    const fetchMock = vi.fn() as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+    const { api, logs } = createSyncTriggerApi({
+      syncTrigger: { enabled: false },
+    });
+
+    armSyncTrigger(api);
+
+    vi.advanceTimersByTime(20 * 60 * 1000);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(logs.some((m) => m.includes("syncTrigger.enabled=false"))).toBe(true);
+  });
+
+  it("does NOT arm when intervalMs is below the safety floor", () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "dench-ai-gateway-trigger-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+
+    const fetchMock = vi.fn() as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+    const { api, logs } = createSyncTriggerApi({
+      syncTrigger: { intervalMs: 100 },
+    });
+
+    armSyncTrigger(api);
+
+    vi.advanceTimersByTime(60 * 1000);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(logs.some((m) => m.includes("below safety floor"))).toBe(true);
+  });
+
+  it("does NOT fire an immediate tick on arm (waits for first interval)", async () => {
+    // Regression: an earlier version called `void tick()` synchronously
+    // inside `armSyncTrigger`, which produced 404/ECONNREFUSED noise during
+    // `denchclaw update` when the gateway booted before the web runtime
+    // was ready. The new contract is "no fetch until the first interval".
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "dench-ai-gateway-trigger-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+    writeWebRuntimeProcessFile(stateDir, 4242);
+
+    const fetchMock = vi.fn(
+      async () => new Response("{}", { status: 200 }),
+    ) as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+    const { api, logs } = createSyncTriggerApi({
+      syncTrigger: { intervalMs: 5000 },
+    });
+
+    armSyncTrigger(api);
+    // Flush microtasks just in case; nothing should fire.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // First fetch should land at intervalMs, not earlier.
+    await vi.advanceTimersByTimeAsync(4999);
+    expect(fetchMock).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Second interval → second fetch.
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    expect(logs.some((m) => m.includes("sync-trigger armed"))).toBe(true);
+  });
+
+  it("uses the right URL + Bearer auth + JSON body when ticking", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "dench-ai-gateway-trigger-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+    writeWebRuntimeProcessFile(stateDir, 4242);
+
+    const fetchMock = vi.fn(
+      async () => new Response("{}", { status: 200 }),
+    ) as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+    const { api } = createSyncTriggerApi({
+      syncTrigger: { intervalMs: 5000 },
+    });
+
+    armSyncTrigger(api);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = (fetchMock as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(url).toBe("http://127.0.0.1:4242/api/sync/poll-tick");
+    expect((init as RequestInit).method).toBe("POST");
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer dc-key");
+    expect(headers["content-type"]).toBe("application/json");
+    expect((init as RequestInit).body).toBe("{}");
+  });
+
+  it("respects DENCHCLAW_WEB_BASE_URL env override", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "dench-ai-gateway-trigger-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+    process.env.DENCHCLAW_WEB_BASE_URL = "http://127.0.0.1:9999";
+
+    const fetchMock = vi.fn(
+      async () => new Response("{}", { status: 200 }),
+    ) as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+    const { api } = createSyncTriggerApi({
+      syncTrigger: { intervalMs: 5000 },
+    });
+
+    armSyncTrigger(api);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = (fetchMock as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(url).toBe("http://127.0.0.1:9999/api/sync/poll-tick");
+  });
+
+  it("falls back to default web port (3100) when no process.json + no env override", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "dench-ai-gateway-trigger-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+    delete process.env.DENCHCLAW_WEB_BASE_URL;
+    // Intentionally NOT writing process.json.
+
+    const fetchMock = vi.fn(
+      async () => new Response("{}", { status: 200 }),
+    ) as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+    const { api } = createSyncTriggerApi({
+      syncTrigger: { intervalMs: 5000 },
+    });
+
+    armSyncTrigger(api);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = (fetchMock as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(url).toBe("http://127.0.0.1:3100/api/sync/poll-tick");
+  });
+
+  it("swallows fetch errors so a downed web app doesn't crash the gateway", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "dench-ai-gateway-trigger-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+
+    const fetchMock = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+    const { api, logs } = createSyncTriggerApi({
+      syncTrigger: { intervalMs: 5000 },
+    });
+
+    expect(() => armSyncTrigger(api)).not.toThrow();
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(logs.some((m) => m.includes("ECONNREFUSED"))).toBe(true);
+  });
+
+  it("is idempotent: a second armSyncTrigger call is a no-op", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "dench-ai-gateway-trigger-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+
+    const fetchMock = vi.fn(
+      async () => new Response("{}", { status: 200 }),
+    ) as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+    const { api } = createSyncTriggerApi({
+      syncTrigger: { intervalMs: 5000 },
+    });
+
+    armSyncTrigger(api);
+    armSyncTrigger(api); // second call should not double-arm
+    await vi.advanceTimersByTimeAsync(5000);
+
+    // Only one interval handler → only one tick per interval, not two.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  // ---- Throttled-error logging ----
+
+  it("logs first failure in a streak only once until the failure mode changes", async () => {
+    // Same 404 ten times in a row → exactly one log line. This was the
+    // user-visible noise during the stale-runtime episode that motivated
+    // the throttling.
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "dench-ai-gateway-trigger-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+
+    const fetchMock = vi.fn(
+      async () => new Response("not found", { status: 404 }),
+    ) as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+    const { api, logs } = createSyncTriggerApi({
+      syncTrigger: { intervalMs: 5000 },
+    });
+
+    armSyncTrigger(api);
+    for (let i = 0; i < 10; i += 1) {
+      await vi.advanceTimersByTimeAsync(5000);
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(10);
+    const failureLogs = logs.filter((m) => m.includes("HTTP 404"));
+    expect(failureLogs).toHaveLength(1);
+  });
+
+  it("logs again when failure mode changes (404 → 500)", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "dench-ai-gateway-trigger-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+
+    let status = 404;
+    const fetchMock = vi.fn(
+      async () => new Response("err", { status }),
+    ) as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+    const { api, logs } = createSyncTriggerApi({
+      syncTrigger: { intervalMs: 5000 },
+    });
+
+    armSyncTrigger(api);
+    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(5000);
+    status = 500;
+    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    const httpLogs = logs.filter((m) => m.includes("HTTP "));
+    expect(httpLogs).toHaveLength(2);
+    expect(httpLogs[0]).toContain("HTTP 404");
+    expect(httpLogs[1]).toContain("HTTP 500");
+  });
+
+  it("logs a recovery line when a failure streak ends with a 200", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "dench-ai-gateway-trigger-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+
+    let ok = false;
+    const fetchMock = vi.fn(async () =>
+      ok ? new Response("{}", { status: 200 }) : new Response("err", { status: 404 }),
+    ) as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+    const { api, logs } = createSyncTriggerApi({
+      syncTrigger: { intervalMs: 5000 },
+    });
+
+    armSyncTrigger(api);
+    await vi.advanceTimersByTimeAsync(5000); // 404 (logged)
+    await vi.advanceTimersByTimeAsync(5000); // 404 (suppressed)
+    ok = true;
+    await vi.advanceTimersByTimeAsync(5000); // 200 (recovery logged)
+    await vi.advanceTimersByTimeAsync(5000); // 200 (no log)
+
+    const httpLogs = logs.filter((m) => m.includes("HTTP "));
+    const recoveryLogs = logs.filter((m) => m.includes("recovered"));
+    expect(httpLogs).toHaveLength(1);
+    expect(recoveryLogs).toHaveLength(1);
+    expect(recoveryLogs[0]).toContain("http:4xx");
+  });
+
+  it("treats AbortError (timeout) as a distinct failure mode", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "dench-ai-gateway-trigger-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+
+    const fetchMock = vi.fn(async () => {
+      const err = new Error("aborted");
+      err.name = "AbortError";
+      throw err;
+    }) as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+    const { api, logs } = createSyncTriggerApi({
+      syncTrigger: { intervalMs: 5000 },
+    });
+
+    armSyncTrigger(api);
+    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    const timeoutLogs = logs.filter((m) => m.includes("timed out"));
+    expect(timeoutLogs).toHaveLength(1);
   });
 });

--- a/extensions/dench-ai-gateway/index.ts
+++ b/extensions/dench-ai-gateway/index.ts
@@ -11,6 +11,7 @@ import {
   resolveDenchCloudModel,
   type DenchCloudCatalogModel,
 } from "./models.js";
+import { armSyncTrigger } from "./sync-trigger.js";
 export { buildDenchCloudConfigPatch } from "./config-patch.js";
 
 export const id = "dench-ai-gateway";
@@ -301,6 +302,12 @@ export default function register(api: any) {
   } as any);
 
   registerDenchIntegrationsBridge(api, gatewayUrl);
+
+  // Arm the gateway-driven Gmail/Calendar sync poll trigger. Lives here
+  // (not in the Next.js process) so the timer survives `denchclaw update`
+  // and web-runtime restarts. No-op when no Dench Cloud key is present
+  // or when `syncTrigger.enabled` is explicitly disabled in plugin config.
+  armSyncTrigger(api);
 
   api.registerService({
     id: "dench-ai-gateway",

--- a/extensions/dench-ai-gateway/openclaw.plugin.json
+++ b/extensions/dench-ai-gateway/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "dench-ai-gateway",
   "name": "Dench AI Gateway",
   "version": "1.0.0",
-  "description": "Registers Dench Cloud as an OpenClaw model provider with live gateway-backed model discovery.",
+  "description": "Registers Dench Cloud as an OpenClaw model provider with live gateway-backed model discovery, and arms the gateway-side Gmail/Calendar sync poll trigger.",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -14,6 +14,26 @@
       "enabled": {
         "type": "boolean",
         "default": true
+      },
+      "syncTrigger": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Gateway-driven Gmail/Calendar sync poll trigger. Fires every intervalMs (default 5 minutes) by POSTing to the web app's /api/sync/poll-tick endpoint. Auto-disabled if no Dench Cloud API key is configured.",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": true
+          },
+          "intervalMs": {
+            "type": "number",
+            "default": 300000,
+            "description": "Polling interval in milliseconds. Defaults to 5 minutes. Minimum 1000ms."
+          },
+          "webBaseUrl": {
+            "type": "string",
+            "description": "Override the auto-detected web app URL (read from web-runtime/process.json). Useful for tests and non-default deployments."
+          }
+        }
       }
     },
     "required": []

--- a/extensions/dench-ai-gateway/sync-trigger.ts
+++ b/extensions/dench-ai-gateway/sync-trigger.ts
@@ -1,0 +1,286 @@
+/**
+ * Gateway-driven sync trigger.
+ *
+ * Lives inside the OpenClaw gateway daemon (loaded as part of the
+ * `dench-ai-gateway` plugin) and POSTs to the Next.js web app's
+ * `/api/sync/poll-tick` endpoint every `intervalMs` (default 5 minutes).
+ *
+ * Why here: the gateway daemon is long-lived and survives `denchclaw update`
+ * / web-runtime restarts, whereas the web app's old `setInterval` died on
+ * every Next process restart. We keep the actual sync work
+ * (`runGmailIncremental`, DuckDB writes, scoring) in the web app and only
+ * move the timekeeping into the gateway process.
+ *
+ * Lifecycle:
+ *
+ * - We DO NOT fire an immediate tick on plugin arm. During `denchclaw
+ *   update` or `denchclaw start` the gateway daemon often boots while
+ *   the web app is mid-restart (or the standalone bundle is being
+ *   replaced) — an immediate tick lands on a half-up server and
+ *   produces 404/ECONNREFUSED noise that looks like a real failure.
+ *   Instead, the first run is the first interval tick (5 min by default).
+ * - For "I just finished `denchclaw update`, sync now please" UX, the
+ *   bootstrap/start/update CLI commands fire a one-shot POST themselves
+ *   via `src/cli/sync-poll.ts#kickoffSyncPoll` after web-runtime is
+ *   verified healthy. That gives users the same ASAP-sync feel without
+ *   the noise.
+ *
+ * Auth: reuses the Dench Cloud API key already read by the rest of the
+ * plugin (`readDenchAuthProfileKey`). No new secret to provision. The
+ * web endpoint validates the same key. If no key is present (Dench
+ * Cloud not connected) we never arm the timer — the sync would fail
+ * downstream anyway since `runGmailIncremental` calls Composio via the
+ * Dench Cloud gateway.
+ *
+ * Logging:
+ *
+ * - First failure in a streak is logged; subsequent identical failures
+ *   are suppressed until the failure mode changes or the streak ends.
+ *   When a streak ends (next tick succeeds), we log a recovery line so
+ *   operators know the system self-healed.
+ * - Network errors are bounded by an AbortSignal timeout
+ *   (`FETCH_TIMEOUT_MS`) so a hung web app can't pile up pending
+ *   fetches inside the gateway.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { homedir } from "node:os";
+import { readDenchAuthProfileKey } from "../shared/dench-auth.js";
+
+type UnknownRecord = Record<string, unknown>;
+
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
+const DEFAULT_WEB_PORT = 3100;
+const PROCESS_JSON_REL = path.join("web-runtime", "process.json");
+const FETCH_TIMEOUT_MS = 60_000;
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function resolveSyncTriggerConfig(api: any): UnknownRecord | undefined {
+  const pluginConfig = asRecord(
+    asRecord(asRecord(api?.config)?.plugins)?.entries,
+  )?.["dench-ai-gateway"];
+  return asRecord(asRecord(pluginConfig)?.config?.["syncTrigger"] as unknown);
+}
+
+function resolveStateDir(): string {
+  const fromEnv = process.env.OPENCLAW_STATE_DIR?.trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+  const home = process.env.OPENCLAW_HOME?.trim() || homedir();
+  return path.join(home, ".openclaw-dench");
+}
+
+/**
+ * Read the web app's listening port from the managed-runtime sidecar
+ * file (`~/.openclaw-dench/web-runtime/process.json`). Falls back to the
+ * default if the file is missing or unparseable, since the gateway can
+ * outlive a partially-installed web runtime.
+ */
+function resolveWebPortFromProcessFile(stateDir: string): number | undefined {
+  const processPath = path.join(stateDir, PROCESS_JSON_REL);
+  if (!existsSync(processPath)) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(processPath, "utf-8")) as UnknownRecord;
+    return readNumber(parsed?.port);
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveWebBaseUrl(api: any, syncTriggerConfig: UnknownRecord | undefined): string {
+  const fromConfig = readString(syncTriggerConfig?.webBaseUrl);
+  if (fromConfig) {
+    return fromConfig.replace(/\/$/, "");
+  }
+  const fromEnv = readString(process.env.DENCHCLAW_WEB_BASE_URL);
+  if (fromEnv) {
+    return fromEnv.replace(/\/$/, "");
+  }
+  const port = resolveWebPortFromProcessFile(resolveStateDir()) ?? DEFAULT_WEB_PORT;
+  return `http://127.0.0.1:${port}`;
+}
+
+/**
+ * Categorize a tick outcome into a coarse failure mode for log throttling.
+ * We deliberately collapse all 4xx into one bucket and all 5xx into
+ * another, since the user only cares "is the route there / is the
+ * endpoint healthy?" — not the exact status delta.
+ */
+type TickOutcome =
+  | { kind: "ok" }
+  | { kind: "http"; statusBucket: "4xx" | "5xx" | "other"; status: number }
+  | { kind: "timeout" }
+  | { kind: "network"; message: string };
+
+function outcomeKey(outcome: TickOutcome): string {
+  switch (outcome.kind) {
+    case "ok":
+      return "ok";
+    case "http":
+      return `http:${outcome.statusBucket}`;
+    case "timeout":
+      return "timeout";
+    case "network":
+      return `network:${outcome.message}`;
+  }
+}
+
+function describeOutcome(outcome: TickOutcome): string {
+  switch (outcome.kind) {
+    case "ok":
+      return "ok";
+    case "http":
+      return `HTTP ${outcome.status}`;
+    case "timeout":
+      return `timed out after ${FETCH_TIMEOUT_MS}ms`;
+    case "network":
+      return outcome.message;
+  }
+}
+
+function bucketFor(status: number): "4xx" | "5xx" | "other" {
+  if (status >= 400 && status < 500) {
+    return "4xx";
+  }
+  if (status >= 500 && status < 600) {
+    return "5xx";
+  }
+  return "other";
+}
+
+/**
+ * Arm the gateway-driven sync poll trigger. No-ops when:
+ *
+ * - The plugin's `syncTrigger.enabled` is explicitly `false`.
+ * - No Dench Cloud API key is present (Dench Cloud isn't connected).
+ *
+ * The function is idempotent only via the `_armed` module-level guard —
+ * since plugins are loaded once per gateway process boot and the gateway
+ * exits/restarts to reload, this matches the actual lifecycle.
+ */
+let _armed = false;
+
+export function armSyncTrigger(api: any): void {
+  if (_armed) {
+    return;
+  }
+
+  const config = resolveSyncTriggerConfig(api);
+  if (config?.enabled === false) {
+    api?.logger?.info?.(
+      "[dench-ai-gateway] sync-trigger disabled via syncTrigger.enabled=false",
+    );
+    return;
+  }
+
+  const apiKey = readDenchAuthProfileKey();
+  if (!apiKey) {
+    api?.logger?.info?.(
+      "[dench-ai-gateway] No Dench Cloud API key; sync trigger not armed.",
+    );
+    return;
+  }
+
+  const intervalMs = readNumber(config?.intervalMs) ?? DEFAULT_INTERVAL_MS;
+  if (intervalMs < 1000) {
+    api?.logger?.info?.(
+      `[dench-ai-gateway] sync-trigger intervalMs=${intervalMs} below safety floor; not arming.`,
+    );
+    return;
+  }
+
+  const webBaseUrl = resolveWebBaseUrl(api, config);
+  const tickUrl = `${webBaseUrl}/api/sync/poll-tick`;
+
+  // Failure-streak state: we suppress repeated identical failures and
+  // log a recovery line when the streak ends. Initial state is "ok"
+  // (no previous failure to recover from).
+  let lastOutcomeKey = "ok";
+
+  async function tick(): Promise<void> {
+    const controller = new AbortController();
+    const timeoutHandle = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    let outcome: TickOutcome;
+    try {
+      const response = await fetch(tickUrl, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          "content-type": "application/json",
+        },
+        body: "{}",
+        signal: controller.signal,
+      });
+      outcome = response.ok
+        ? { kind: "ok" }
+        : { kind: "http", statusBucket: bucketFor(response.status), status: response.status };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // AbortError is what fetch throws when the timeout AbortController
+      // fires; surface it as a distinct timeout outcome so streak logging
+      // can collapse it independently of plain network errors.
+      const aborted =
+        err instanceof Error &&
+        (err.name === "AbortError" || /aborted/i.test(message));
+      outcome = aborted
+        ? { kind: "timeout" }
+        : { kind: "network", message };
+    } finally {
+      clearTimeout(timeoutHandle);
+    }
+
+    const key = outcomeKey(outcome);
+    const wasFailing = lastOutcomeKey !== "ok";
+    if (outcome.kind === "ok") {
+      if (wasFailing) {
+        api?.logger?.info?.(
+          `[dench-ai-gateway] sync-trigger recovered (was: ${lastOutcomeKey})`,
+        );
+      }
+    } else if (key !== lastOutcomeKey) {
+      // First failure in a streak (or failure mode changed). Log it.
+      // Subsequent identical failures stay silent until things change.
+      api?.logger?.info?.(
+        `[dench-ai-gateway] sync-trigger tick ${describeOutcome(outcome)} from ${tickUrl}`,
+      );
+    }
+    lastOutcomeKey = key;
+  }
+
+  // No immediate tick — see file header. Boots & redeploys would otherwise
+  // race a half-up web app and produce alarming-looking 404/ECONNREFUSED
+  // log lines that are actually expected.
+  setInterval(() => {
+    void tick();
+  }, intervalMs);
+
+  _armed = true;
+  api?.logger?.info?.(
+    `[dench-ai-gateway] sync-trigger armed (every ${intervalMs}ms → ${tickUrl})`,
+  );
+}
+
+/**
+ * Test-only helper: reset the module-level `_armed` guard so a test
+ * can exercise `armSyncTrigger` multiple times in the same process.
+ */
+export function _resetSyncTriggerForTests(): void {
+  _armed = false;
+}

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "prepack": "pnpm build:plugin-env && pnpm build && pnpm web:build && pnpm web:prepack",
     "start": "node denchclaw.mjs",
     "test": "pnpm test:cli && pnpm --dir apps/web test",
-    "test:cli": "vitest run --config vitest.unit.config.ts src/cli/run-main.test.ts src/cli/bootstrap-external.test.ts src/cli/bootstrap-external.bootstrap-command.test.ts src/cli/dench-cloud.test.ts src/cli/workspace-seed.test.ts src/cli/web-runtime.test.ts src/cli/web-runtime-command.test.ts src/cli/flatten-standalone-deps.test.ts && vitest run --config extensions/vitest.config.ts extensions/dench-identity/index.test.ts extensions/dench-identity/composio-cheat-sheet.test.ts extensions/dench-ai-gateway/index.test.ts",
+    "test:cli": "vitest run --config vitest.unit.config.ts src/cli/run-main.test.ts src/cli/bootstrap-external.test.ts src/cli/bootstrap-external.bootstrap-command.test.ts src/cli/dench-cloud.test.ts src/cli/workspace-seed.test.ts src/cli/web-runtime.test.ts src/cli/web-runtime-command.test.ts src/cli/flatten-standalone-deps.test.ts src/cli/sync-poll.test.ts && vitest run --config extensions/vitest.config.ts extensions/dench-identity/index.test.ts extensions/dench-identity/composio-cheat-sheet.test.ts extensions/dench-ai-gateway/index.test.ts",
     "test:web": "pnpm --dir apps/web test",
     "web:build": "pnpm --dir apps/web build",
     "web:dev": "pnpm --dir apps/web dev",

--- a/src/cli/bootstrap-external.ts
+++ b/src/cli/bootstrap-external.ts
@@ -1,12 +1,16 @@
 import { spawn, type StdioOptions } from "node:child_process";
 import {
+  closeSync,
   cpSync,
   existsSync,
   mkdirSync,
+  openSync,
   readFileSync,
+  readSync,
   readdirSync,
   realpathSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import os from "node:os";
@@ -45,6 +49,7 @@ import {
   resolveProfileStateDir,
   waitForWebRuntime,
 } from "./web-runtime.js";
+import { kickoffSyncPoll, summarizeKickoffSyncPoll } from "./sync-poll.js";
 import { seedWorkspaceFromAssets, type WorkspaceSeedResult } from "./workspace-seed.js";
 
 const DEFAULT_DENCHCLAW_PROFILE = "dench";
@@ -1071,19 +1076,48 @@ async function runOpenClawOrThrow(params: {
 /**
  * Runs an OpenClaw command attached to the current terminal.
  * Use this for interactive flows like `openclaw onboard`.
+ *
+ * Special handling for `openclaw onboard --install-daemon`: that subprocess
+ * frequently hangs after the user finishes the wizard (printing
+ * "Onboarding complete.") because its post-wizard daemon-install path
+ * calls slow external HTTPS endpoints (model catalog discovery, etc.) with
+ * no upstream flag to skip them. We can't tee stdout (the wizard is
+ * @clack/prompts and needs a real TTY for arrow-key navigation), so we
+ * use a SIDE-CHANNEL signal instead: watch the gateway log for the
+ * `[gateway] ready (` line that appears after the wizard restarts the
+ * daemon. Once seen, give onboard a grace period to exit naturally; if it
+ * doesn't, send SIGTERM, then SIGKILL. Treats post-marker termination as
+ * success since the wizard's user-visible work is done.
  */
 async function runOpenClawInteractiveOrThrow(params: {
   openclawCommand: string;
   args: string[];
   timeoutMs: number;
   errorMessage: string;
+  /**
+   * Optional: when set, watch this gateway.log file for the
+   * `[gateway] ready (` line and use it as the "wizard finished"
+   * signal. Bootstrap passes the profile state dir's logs/gateway.log
+   * here for the onboard call.
+   */
+  gatewayLogPath?: string;
+  /** Grace before SIGTERM after marker detection. Default 60s. */
+  markerGraceMs?: number;
+  /** Grace between SIGTERM and SIGKILL. Default 5s. */
+  sigtermGraceMs?: number;
 }): Promise<SpawnResult> {
-  const result = await runOpenClaw(
-    params.openclawCommand,
-    params.args,
-    params.timeoutMs,
-    "inherit",
-  );
+  // #region debug-e2e66e: H1/H2 — confirm onboard subprocess spawn + lifetime
+  const _dbgStart = Date.now();
+  fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H1+H2',location:'bootstrap-external.ts:runOpenClawInteractiveOrThrow:start',message:'spawning interactive openclaw',data:{cmd:params.openclawCommand,args:params.args,timeoutMs:params.timeoutMs,gatewayLogPath:params.gatewayLogPath},timestamp:_dbgStart})}).catch(()=>{});
+  const _dbgPing = setInterval(() => {
+    fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H1',location:'bootstrap-external.ts:runOpenClawInteractiveOrThrow:still-waiting',message:'still awaiting onboard exit',data:{elapsedMs:Date.now()-_dbgStart,argsTail:params.args.slice(-6)},timestamp:Date.now()})}).catch(()=>{});
+  }, 30_000);
+  // #endregion
+  const result = await runOpenClawInteractiveWithMarkerCutoff(params);
+  // #region debug-e2e66e: H1/H2 — onboard subprocess actually exited
+  clearInterval(_dbgPing);
+  fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H1+H2',location:'bootstrap-external.ts:runOpenClawInteractiveOrThrow:exit',message:'interactive openclaw exited',data:{code:result.code,elapsedMs:Date.now()-_dbgStart},timestamp:Date.now()})}).catch(()=>{});
+  // #endregion
   if (result.code === 0) {
     return result;
   }
@@ -1092,6 +1126,170 @@ async function runOpenClawInteractiveOrThrow(params: {
   if (detail) parts.push(detail);
   else if (result.code != null) parts.push(`(exit code ${result.code})`);
   throw new Error(parts.join("\n"));
+}
+
+// 0 = SIGTERM the moment the marker fires. Runtime evidence (debug session
+// e2e66e, log entries 4 → 7 → 8) showed onboard exits within 24ms of SIGTERM
+// after the marker, so any non-zero grace is pure dead time bootstrap-side.
+// Caller can opt back into a grace period if they hit a reproducible case
+// where onboard needs more time to flush state after the marker.
+const ONBOARD_DEFAULT_MARKER_GRACE_MS = 0;
+const ONBOARD_DEFAULT_SIGTERM_GRACE_MS = 5_000;
+// Poll the gateway log roughly twice per second so the marker is detected
+// within ~500ms of being written. Keeps bootstrap snappy without melting CPU.
+const ONBOARD_GATEWAY_LOG_POLL_MS = 500;
+const ONBOARD_GATEWAY_READY_MARKER = "[gateway] ready (";
+
+/**
+ * Spawn `openclaw` with stdio inherited (so the @clack/prompts wizard
+ * keeps full TTY rendering + arrow-key input), but separately watch the
+ * gateway's log file for the post-wizard `[gateway] ready (` line. That
+ * line fires when openclaw onboard restarts the daemon as part of its
+ * post-prompt work — by then the user-visible wizard is done. Once we
+ * see it, we give onboard `markerGraceMs` to exit on its own; if it's
+ * still alive (the upstream hang we're working around), we send SIGTERM
+ * then SIGKILL and treat the result as success.
+ *
+ * If `gatewayLogPath` isn't supplied, this degrades to a plain spawn
+ * with no early-exit (same as before — used for daemonless / non-onboard
+ * interactive flows).
+ */
+async function runOpenClawInteractiveWithMarkerCutoff(params: {
+  openclawCommand: string;
+  args: string[];
+  timeoutMs: number;
+  gatewayLogPath?: string;
+  markerGraceMs?: number;
+  sigtermGraceMs?: number;
+}): Promise<SpawnResult> {
+  const markerGraceMs = params.markerGraceMs ?? ONBOARD_DEFAULT_MARKER_GRACE_MS;
+  const sigtermGraceMs = params.sigtermGraceMs ?? ONBOARD_DEFAULT_SIGTERM_GRACE_MS;
+  const gatewayLogPath = params.gatewayLogPath;
+
+  return await new Promise<SpawnResult>((resolve, reject) => {
+    const child = spawn(params.openclawCommand, params.args, {
+      stdio: "inherit",
+      ...platformSpawnOptions(),
+    });
+
+    let settled = false;
+    let markerSeen = false;
+    let killedAfterMarker = false;
+    let logWatcher: NodeJS.Timeout | null = null;
+    let postMarkerSigtermTimer: NodeJS.Timeout | null = null;
+    let postMarkerSigkillTimer: NodeJS.Timeout | null = null;
+
+    const outerTimer = setTimeout(() => {
+      if (settled) {return;}
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // ignore — process may already be gone
+      }
+    }, params.timeoutMs);
+
+    function clearTimers(): void {
+      clearTimeout(outerTimer);
+      if (logWatcher) {clearInterval(logWatcher);}
+      if (postMarkerSigtermTimer) {clearTimeout(postMarkerSigtermTimer);}
+      if (postMarkerSigkillTimer) {clearTimeout(postMarkerSigkillTimer);}
+    }
+
+    // Side-channel marker watcher: tail the gateway log starting from its
+    // current size (so we only see lines emitted AFTER this onboard run).
+    if (gatewayLogPath) {
+      let initialSize = 0;
+      try {
+        if (existsSync(gatewayLogPath)) {
+          initialSize = statSync(gatewayLogPath).size;
+        }
+      } catch {
+        initialSize = 0;
+      }
+      let cursor = initialSize;
+      logWatcher = setInterval(() => {
+        if (markerSeen || settled) {return;}
+        try {
+          if (!existsSync(gatewayLogPath)) {return;}
+          const size = statSync(gatewayLogPath).size;
+          if (size <= cursor) {return;}
+          // Read only the new bytes.
+          const len = size - cursor;
+          const buf = Buffer.alloc(len);
+          const fd = openSync(gatewayLogPath, "r");
+          try {
+            readSync(fd, buf, 0, len, cursor);
+          } finally {
+            closeSync(fd);
+          }
+          cursor = size;
+          if (buf.toString("utf-8").includes(ONBOARD_GATEWAY_READY_MARKER)) {
+            markerSeen = true;
+            // #region debug-e2e66e: H4 — marker observed, arming graceful kill
+            fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H4',location:'bootstrap-external.ts:marker-cutoff:marker-seen',message:'gateway-ready marker detected; arming kill',data:{markerGraceMs,sigtermGraceMs},timestamp:Date.now()})}).catch(()=>{});
+            // #endregion
+            const sendSigterm = (): void => {
+              if (settled || child.exitCode !== null) {return;}
+              killedAfterMarker = true;
+              // #region debug-e2e66e: H4 — sending SIGTERM to onboard
+              fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H4',location:'bootstrap-external.ts:marker-cutoff:sigterm',message:'sending SIGTERM after marker grace',data:{markerGraceMs},timestamp:Date.now()})}).catch(()=>{});
+              // #endregion
+              try {
+                child.kill("SIGTERM");
+              } catch {
+                // ignore
+              }
+              postMarkerSigkillTimer = setTimeout(() => {
+                if (settled || child.exitCode !== null) {return;}
+                // #region debug-e2e66e: H4 — escalating to SIGKILL
+                fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H4',location:'bootstrap-external.ts:marker-cutoff:sigkill',message:'escalating to SIGKILL',data:{},timestamp:Date.now()})}).catch(()=>{});
+                // #endregion
+                try {
+                  child.kill("SIGKILL");
+                } catch {
+                  // ignore
+                }
+              }, sigtermGraceMs);
+            };
+            if (markerGraceMs > 0) {
+              postMarkerSigtermTimer = setTimeout(sendSigterm, markerGraceMs);
+            } else {
+              sendSigterm();
+            }
+          }
+        } catch {
+          // Log file may be rotated/missing temporarily; just try again.
+        }
+      }, ONBOARD_GATEWAY_LOG_POLL_MS);
+    }
+
+    child.once("error", (error: Error) => {
+      if (settled) {return;}
+      settled = true;
+      clearTimers();
+      reject(error);
+    });
+
+    child.once("close", (code: number | null) => {
+      if (settled) {return;}
+      settled = true;
+      clearTimers();
+      // If we killed it AFTER the marker fired, treat as success — the
+      // wizard's user-visible work was already done. Bootstrap will run
+      // its own gateway probe + autofix immediately after, so any
+      // openclaw-side post-wizard verification we cut short is redundant.
+      const synthesizedCode = killedAfterMarker
+        ? 0
+        : typeof code === "number"
+          ? code
+          : 1;
+      resolve({
+        code: synthesizedCode,
+        stdout: "",
+        stderr: "",
+      });
+    });
+  });
 }
 
 /**
@@ -3295,9 +3493,15 @@ export async function bootstrapCommand(
   }
 
   onboardArgv.push("--accept-risk", "--skip-ui", "--skip-channels");
-  if (daemonless) {
-    onboardArgv.push("--skip-health");
-  }
+  // `openclaw onboard --install-daemon` runs an internal post-install health
+  // check that polls a bunch of external model-provider endpoints (Vercel AI
+  // Gateway, etc.). On slow networks (or when a provider endpoint times out)
+  // that probe can stall onboard for many minutes — long enough to exceed our
+  // 12-minute outer timeout and fail bootstrap entirely. We don't need it:
+  // the dench bootstrap does its own retry-aware gateway probe right after
+  // onboard returns (`probeGateway` at the top of the post-onboard block,
+  // followed by `attemptGatewayAutoFix` if needed). Skip it always.
+  onboardArgv.push("--skip-health");
 
   if (nonInteractive) {
     await runOpenClawOrThrow({
@@ -3312,9 +3516,19 @@ export async function bootstrapCommand(
       args: onboardArgv,
       timeoutMs: 12 * 60_000,
       errorMessage: "OpenClaw onboarding failed.",
+      // Watch the gateway log for the post-wizard `[gateway] ready (`
+      // line. When openclaw onboard restarts the daemon as part of its
+      // post-prompt work, we know the user is done with the wizard. If
+      // onboard then hangs on its own slow post-wizard verification
+      // (the recurring 5-10min stall), we send SIGTERM after a grace
+      // period and let denchclaw's own gateway probe + autofix continue.
+      gatewayLogPath: daemonless ? undefined : path.join(stateDir, "logs", "gateway.log"),
     });
   }
 
+  // #region debug-e2e66e: H3 — onboard returned, entering post-onboard sequence
+  fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H3',location:'bootstrap-external.ts:post-onboard:enter',message:'onboard returned, starting post-onboard work',data:{},timestamp:Date.now()})}).catch(()=>{});
+  // #endregion
   const workspaceSeed = seedWorkspaceFromAssets({
     workspaceDir,
     packageRoot,
@@ -3390,6 +3604,10 @@ export async function bootstrapCommand(
     // daemon picks up plugin, model, and subagent changes that were written after
     // onboard started it.  No helper above triggers its own restart.
     postOnboardSpinner?.message("Restarting gateway…");
+    // #region debug-e2e66e: H3 — about to call openclaw gateway restart
+    const _dbgRestartStart = Date.now();
+    fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H3',location:'bootstrap-external.ts:gateway-restart:start',message:'calling openclaw gateway restart',data:{},timestamp:_dbgRestartStart})}).catch(()=>{});
+    // #endregion
     try {
       await runOpenClawOrThrow({
         openclawCommand,
@@ -3397,7 +3615,13 @@ export async function bootstrapCommand(
         timeoutMs: 60_000,
         errorMessage: "Failed to restart gateway after config update.",
       });
-    } catch {
+      // #region debug-e2e66e: H3 — gateway restart returned
+      fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H3',location:'bootstrap-external.ts:gateway-restart:done',message:'gateway restart returned ok',data:{elapsedMs:Date.now()-_dbgRestartStart},timestamp:Date.now()})}).catch(()=>{});
+      // #endregion
+    } catch (err) {
+      // #region debug-e2e66e: H3 — gateway restart threw
+      fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H3',location:'bootstrap-external.ts:gateway-restart:throw',message:'gateway restart threw (caught)',data:{elapsedMs:Date.now()-_dbgRestartStart,err:err instanceof Error?err.message:String(err)},timestamp:Date.now()})}).catch(()=>{});
+      // #endregion
       // Gateway may not be running (e.g. onboard daemon install failed on this
       // platform).  The final readiness check below will catch this.
     }
@@ -3438,6 +3662,9 @@ export async function bootstrapCommand(
   const gatewayUrl = `ws://127.0.0.1:${gatewayPort}`;
   const preferredWebPort = parseOptionalPort(opts.webPort) ?? DEFAULT_WEB_APP_PORT;
   postOnboardSpinner?.message(`Starting web runtime on port ${preferredWebPort}…`);
+  // #region debug-e2e66e: H3 — about to install/start web runtime
+  fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H3',location:'bootstrap-external.ts:ensureManagedWebRuntime:start',message:'starting web runtime install',data:{port:preferredWebPort},timestamp:Date.now()})}).catch(()=>{});
+  // #endregion
   let webRuntimeStatus = await ensureManagedWebRuntime({
     stateDir,
     packageRoot,
@@ -3470,6 +3697,24 @@ export async function bootstrapCommand(
       ? "Post-onboard setup complete."
       : "Post-onboard setup complete (web runtime unhealthy).",
   );
+
+  // Web runtime is verified healthy at this point — fire one explicit
+  // Gmail/Calendar sync kickoff so the user doesn't have to wait for the
+  // gateway plugin's first 5-min interval. Best-effort: a failure here
+  // (no Dench Cloud key, transient network) just falls back to that
+  // gateway-driven interval. See `extensions/dench-ai-gateway/sync-trigger.ts`
+  // for why the plugin no longer fires its own immediate-on-arm tick.
+  if (webRuntimeStatus.ready && !opts.json) {
+    const kickoff = await kickoffSyncPoll({
+      stateDir,
+      port: preferredWebPort,
+    });
+    const kickoffSummary = summarizeKickoffSyncPoll(kickoff);
+    if (kickoffSummary) {
+      runtime.log(theme.muted(kickoffSummary));
+    }
+  }
+
   const webReachable = webRuntimeStatus.ready;
   const webUrl = `http://localhost:${preferredWebPort}`;
   const composioConfigured = denchCloudSelection.enabled

--- a/src/cli/sync-poll.test.ts
+++ b/src/cli/sync-poll.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Contract tests for the CLI-side `kickoffSyncPoll` helper that
+ * `bootstrap`, `update`, and `start` use to fire one Gmail/Calendar
+ * sync immediately after the web runtime is verified healthy.
+ *
+ * Key invariants under test:
+ *
+ * - "no key" path returns `skipped: no-api-key` quietly (Dench Cloud
+ *   not yet configured is a normal state, not an error).
+ * - Bearer auth is sourced from `auth-profiles.json` first, env vars
+ *   second — same precedence as the gateway plugin.
+ * - HTTP errors / network errors / timeouts surface as distinct outcomes
+ *   so the CLI summary line can distinguish them, but never throw.
+ * - `summarizeKickoffSyncPoll` produces an empty string for the
+ *   "no Dench Cloud key" case so brand-new installs stay quiet.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { kickoffSyncPoll, summarizeKickoffSyncPoll } from "./sync-poll.js";
+
+function writeAuthProfiles(stateDir: string, key: string): void {
+  const authDir = path.join(stateDir, "agents", "main", "agent");
+  mkdirSync(authDir, { recursive: true });
+  writeFileSync(
+    path.join(authDir, "auth-profiles.json"),
+    JSON.stringify({
+      version: 1,
+      profiles: {
+        "dench-cloud:default": { type: "api_key", provider: "dench-cloud", key },
+      },
+    }),
+  );
+}
+
+describe("kickoffSyncPoll", () => {
+  const originalFetch = globalThis.fetch;
+  const originalEnv = {
+    DENCH_CLOUD_API_KEY: process.env.DENCH_CLOUD_API_KEY,
+    DENCH_API_KEY: process.env.DENCH_API_KEY,
+  };
+  let stateDir: string | undefined;
+
+  beforeEach(() => {
+    delete process.env.DENCH_CLOUD_API_KEY;
+    delete process.env.DENCH_API_KEY;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+    if (stateDir) {
+      rmSync(stateDir, { recursive: true, force: true });
+      stateDir = undefined;
+    }
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value !== undefined) {
+        process.env[key] = value;
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  it("returns skipped:no-api-key when no key in profiles or env (no fetch fired)", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "kickoff-sync-"));
+    const fetchMock = vi.fn() as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+
+    const result = await kickoffSyncPoll({ stateDir, port: 3100 });
+
+    expect(result).toEqual({ kind: "skipped", reason: "no-api-key" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("uses key from auth-profiles.json with Bearer auth on the happy path", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "kickoff-sync-"));
+    writeAuthProfiles(stateDir, "dc-from-profile");
+    const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await kickoffSyncPoll({ stateDir, port: 3100 });
+
+    expect(result).toEqual({ kind: "ok", status: 200 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const firstCall = fetchMock.mock.calls[0];
+    if (!firstCall) {throw new Error("fetch not called");}
+    const [url, init] = firstCall;
+    expect(url).toBe("http://127.0.0.1:3100/api/sync/poll-tick");
+    expect((init as RequestInit).method).toBe("POST");
+    expect(((init as RequestInit).headers as Record<string, string>).authorization).toBe(
+      "Bearer dc-from-profile",
+    );
+  });
+
+  it("falls back to DENCH_CLOUD_API_KEY env when auth-profiles is absent", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "kickoff-sync-"));
+    process.env.DENCH_CLOUD_API_KEY = "dc-from-env";
+    const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await kickoffSyncPoll({ stateDir, port: 3100 });
+
+    expect(result).toEqual({ kind: "ok", status: 200 });
+    const firstCall = fetchMock.mock.calls[0];
+    if (!firstCall) {throw new Error("fetch not called");}
+    const [, init] = firstCall;
+    expect(((init as RequestInit).headers as Record<string, string>).authorization).toBe(
+      "Bearer dc-from-env",
+    );
+  });
+
+  it("auth-profiles.json key wins over env (matches plugin precedence)", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "kickoff-sync-"));
+    writeAuthProfiles(stateDir, "dc-from-profile");
+    process.env.DENCH_CLOUD_API_KEY = "dc-from-env";
+    const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await kickoffSyncPoll({ stateDir, port: 3100 });
+
+    const firstCall = fetchMock.mock.calls[0];
+    if (!firstCall) {throw new Error("fetch not called");}
+    const [, init] = firstCall;
+    expect(((init as RequestInit).headers as Record<string, string>).authorization).toBe(
+      "Bearer dc-from-profile",
+    );
+  });
+
+  it("returns error:http on non-2xx, surfaces status (no throw)", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "kickoff-sync-"));
+    writeAuthProfiles(stateDir, "dc-key");
+    globalThis.fetch = vi.fn(
+      async () => new Response("nope", { status: 401 }),
+    ) as unknown as typeof fetch;
+
+    const result = await kickoffSyncPoll({ stateDir, port: 3100 });
+
+    expect(result).toEqual({ kind: "error", reason: "http", status: 401 });
+  });
+
+  it("returns error:network on connection failure (no throw)", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "kickoff-sync-"));
+    writeAuthProfiles(stateDir, "dc-key");
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("ECONNREFUSED 127.0.0.1:3100");
+    }) as unknown as typeof fetch;
+
+    const result = await kickoffSyncPoll({ stateDir, port: 3100 });
+
+    expect(result.kind).toBe("error");
+    if (result.kind === "error" && result.reason === "network") {
+      expect(result.detail).toContain("ECONNREFUSED");
+    } else {
+      throw new Error(`unexpected result: ${JSON.stringify(result)}`);
+    }
+  });
+
+  it("returns error:timeout on AbortError (no throw)", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "kickoff-sync-"));
+    writeAuthProfiles(stateDir, "dc-key");
+    globalThis.fetch = vi.fn(async () => {
+      const err = new Error("aborted");
+      err.name = "AbortError";
+      throw err;
+    }) as unknown as typeof fetch;
+
+    const result = await kickoffSyncPoll({ stateDir, port: 3100 });
+
+    expect(result).toEqual({ kind: "error", reason: "timeout" });
+  });
+
+  it("returns skipped:fetch-not-available when global fetch is missing", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "kickoff-sync-"));
+    writeAuthProfiles(stateDir, "dc-key");
+    // Simulate ancient Node by stripping fetch.
+    (globalThis as unknown as { fetch: undefined }).fetch = undefined;
+
+    const result = await kickoffSyncPoll({ stateDir, port: 3100 });
+
+    expect(result).toEqual({ kind: "skipped", reason: "fetch-not-available" });
+  });
+});
+
+describe("summarizeKickoffSyncPoll", () => {
+  it("emits empty string for the no-Dench-Cloud-key case (quiet skip)", () => {
+    expect(summarizeKickoffSyncPoll({ kind: "skipped", reason: "no-api-key" })).toBe("");
+  });
+
+  it("emits a happy-path one-liner for ok", () => {
+    const line = summarizeKickoffSyncPoll({ kind: "ok", status: 200 });
+    expect(line).toContain("Kicked off");
+  });
+
+  it("notes the gateway will retry on http error", () => {
+    const line = summarizeKickoffSyncPoll({ kind: "error", reason: "http", status: 503 });
+    expect(line).toContain("HTTP 503");
+    expect(line).toContain("retry on the gateway");
+  });
+
+  it("notes the gateway will retry on timeout", () => {
+    const line = summarizeKickoffSyncPoll({ kind: "error", reason: "timeout" });
+    expect(line).toContain("timed out");
+    expect(line).toContain("retry on the gateway");
+  });
+
+  it("includes the network detail string and a retry hint", () => {
+    const line = summarizeKickoffSyncPoll({
+      kind: "error",
+      reason: "network",
+      detail: "ECONNREFUSED",
+    });
+    expect(line).toContain("ECONNREFUSED");
+    expect(line).toContain("retry on the gateway");
+  });
+
+  it("emits a non-empty hint for fetch-not-available skipped case", () => {
+    const line = summarizeKickoffSyncPoll({
+      kind: "skipped",
+      reason: "fetch-not-available",
+    });
+    expect(line).toContain("fetch unavailable");
+  });
+});

--- a/src/cli/sync-poll.ts
+++ b/src/cli/sync-poll.ts
@@ -1,0 +1,137 @@
+/**
+ * One-shot Gmail/Calendar sync kickoff used by the bootstrap/start/update
+ * CLI commands.
+ *
+ * Why this exists: the gateway-side `dench-ai-gateway` plugin's
+ * `armSyncTrigger` deliberately does NOT fire an immediate tick on plugin
+ * load (see `extensions/dench-ai-gateway/sync-trigger.ts` for the
+ * rationale — gateway boots typically race a half-up web app during
+ * `denchclaw update`, producing 404/ECONNREFUSED noise that looks like
+ * a failure). Instead, the CLI commands call `kickoffSyncPoll` AFTER
+ * `ensureManagedWebRuntime` has confirmed web is healthy, which is a
+ * much more reliable signal than "the plugin loaded".
+ *
+ * Best-effort: any failure (no key, no web, network error, non-200) is
+ * swallowed and reported via the returned outcome so callers can decide
+ * whether to surface it. Never throws.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const AUTH_PROFILES_REL = path.join("agents", "main", "agent", "auth-profiles.json");
+const KICKOFF_TIMEOUT_MS = 10_000;
+
+type UnknownRecord = Record<string, unknown>;
+
+export type KickoffSyncPollResult =
+  | { kind: "ok"; status: number }
+  | { kind: "skipped"; reason: "no-api-key" | "fetch-not-available" }
+  | { kind: "error"; reason: "http"; status: number }
+  | { kind: "error"; reason: "timeout" }
+  | { kind: "error"; reason: "network"; detail: string };
+
+function readKeyFromAuthProfiles(stateDir: string): string | undefined {
+  const authPath = path.join(stateDir, AUTH_PROFILES_REL);
+  if (!existsSync(authPath)) {
+    return undefined;
+  }
+  try {
+    const raw = JSON.parse(readFileSync(authPath, "utf-8")) as UnknownRecord;
+    const profiles = raw?.profiles as UnknownRecord | undefined;
+    const profile = profiles?.["dench-cloud:default"] as UnknownRecord | undefined;
+    const key = profile?.key;
+    return typeof key === "string" && key.trim() ? key.trim() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function envFallbackKey(): string | undefined {
+  return (
+    process.env.DENCH_CLOUD_API_KEY?.trim() ||
+    process.env.DENCH_API_KEY?.trim() ||
+    undefined
+  );
+}
+
+/**
+ * Fire one POST to `/api/sync/poll-tick` on the local web runtime.
+ * Designed to be called from `bootstrap-external.ts`,
+ * `web-runtime-command.ts#startWebRuntimeCommand`, and
+ * `web-runtime-command.ts#updateWebRuntimeCommand` after the web runtime
+ * is verified healthy. Mirrors the auth contract the gateway plugin uses
+ * (Bearer + Dench Cloud API key).
+ *
+ * Caller is expected to log the outcome at most a single line — this
+ * is a UX nicety, not a critical path. Returning `{ kind: "skipped" }`
+ * is normal when the user is on a brand-new install with no Dench Cloud
+ * key yet (skip-Dench-Cloud onboarding path).
+ */
+export async function kickoffSyncPoll(params: {
+  stateDir: string;
+  port: number;
+}): Promise<KickoffSyncPollResult> {
+  if (typeof globalThis.fetch !== "function") {
+    return { kind: "skipped", reason: "fetch-not-available" };
+  }
+
+  const apiKey = readKeyFromAuthProfiles(params.stateDir) ?? envFallbackKey();
+  if (!apiKey) {
+    return { kind: "skipped", reason: "no-api-key" };
+  }
+
+  const tickUrl = `http://127.0.0.1:${params.port}/api/sync/poll-tick`;
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(() => controller.abort(), KICKOFF_TIMEOUT_MS);
+  try {
+    const response = await fetch(tickUrl, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        "content-type": "application/json",
+      },
+      body: "{}",
+      signal: controller.signal,
+    });
+    if (response.ok) {
+      return { kind: "ok", status: response.status };
+    }
+    return { kind: "error", reason: "http", status: response.status };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const aborted =
+      err instanceof Error &&
+      (err.name === "AbortError" || /aborted/i.test(message));
+    if (aborted) {
+      return { kind: "error", reason: "timeout" };
+    }
+    return { kind: "error", reason: "network", detail: message };
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}
+
+/**
+ * Convert a `KickoffSyncPollResult` into a one-line human-readable
+ * summary suitable for stdout/log emission. Empty string for the
+ * "no Dench Cloud key" case so quiet installs stay quiet.
+ */
+export function summarizeKickoffSyncPoll(result: KickoffSyncPollResult): string {
+  switch (result.kind) {
+    case "ok":
+      return "Kicked off initial Gmail/Calendar sync.";
+    case "skipped":
+      return result.reason === "no-api-key"
+        ? "" // Quiet skip — Dench Cloud isn't configured yet.
+        : "Sync kickoff skipped (fetch unavailable).";
+    case "error":
+      if (result.reason === "http") {
+        return `Sync kickoff returned HTTP ${result.status} (will retry on the gateway's next tick).`;
+      }
+      if (result.reason === "timeout") {
+        return "Sync kickoff timed out (will retry on the gateway's next tick).";
+      }
+      return `Sync kickoff failed: ${result.detail} (will retry on the gateway's next tick).`;
+  }
+}

--- a/src/cli/web-runtime-command.ts
+++ b/src/cli/web-runtime-command.ts
@@ -30,6 +30,7 @@ import {
   stopManagedWebRuntime,
   waitForWebRuntime,
 } from "./web-runtime.js";
+import { kickoffSyncPoll, summarizeKickoffSyncPoll } from "./sync-poll.js";
 import {
   discoverWorkspaceDirs,
   syncManagedSkills,
@@ -487,6 +488,22 @@ export async function updateWebRuntimeCommand(
 
   cleanupManagedWebRuntimeBackup(stateDir);
 
+  // Web runtime is verified healthy AND we just replaced the standalone
+  // bundle, so any in-flight gateway sync-trigger 404s should now resolve.
+  // Fire one explicit kickoff to start the first Gmail/Calendar incremental
+  // immediately rather than waiting for the gateway plugin's next 5-min tick.
+  // Best-effort: a failure here just delays sync to the next gateway tick.
+  const kickoff = await kickoffSyncPoll({
+    stateDir,
+    port: selectedPort,
+  });
+  if (!opts.json) {
+    const summaryLine = summarizeKickoffSyncPoll(kickoff);
+    if (summaryLine) {
+      runtime.log(theme.muted(summaryLine));
+    }
+  }
+
   await promptAndOpenWebUi({
     webPort: selectedPort,
     json: opts.json,
@@ -668,6 +685,20 @@ export async function startWebRuntimeCommand(
   }
 
   cleanupManagedWebRuntimeBackup(stateDir);
+
+  // Same rationale as `updateWebRuntimeCommand`: kick off the first
+  // Gmail/Calendar sync as soon as the web runtime is verified healthy
+  // instead of waiting for the gateway plugin's 5-min interval to tick.
+  const kickoff = await kickoffSyncPoll({
+    stateDir,
+    port: selectedPort,
+  });
+  if (!opts.json) {
+    const summaryLine = summarizeKickoffSyncPoll(kickoff);
+    if (summaryLine) {
+      runtime.log(theme.muted(summaryLine));
+    }
+  }
 
   await promptAndOpenWebUi({
     webPort: selectedPort,


### PR DESCRIPTION
## Summary

The 5-minute Gmail/Calendar incremental poll loop used to live inside the Next.js process. It was armed from `apps/web/instrumentation.ts` on boot whenever onboarding had completed and a saved `historyId` / `syncToken` existed. Problem: the loop **died whenever `denchclaw update` or any other web-runtime restart killed the Next.js process**, and you'd have to manually trigger a sync from the workspace to re-arm it.

This PR moves timing into the long-lived OpenClaw gateway daemon's `dench-ai-gateway` plugin, which survives `denchclaw update` and CLI restarts. The plugin POSTs to a new loopback `/api/sync/poll-tick` endpoint every ~5 min; the web app's `tickPoller()` then runs exactly the same Gmail + Calendar incremental fetch as before.

### Architecture

```
OpenClaw gateway daemon (long-lived)
  └── plugin: dench-ai-gateway/sync-trigger.ts
        ├── reads Dench Cloud key from auth-profiles.json
        ├── reads web port from web-runtime/process.json
        └── POST http://127.0.0.1:<port>/api/sync/poll-tick
              Authorization: Bearer <key>

apps/web (next.js, may restart)
  └── /api/sync/poll-tick (loopback only, Bearer-auth'd)
        └── tickPoller() in sync-runner.ts
              └── runs Gmail + Calendar incremental, mutex-gated
```

### New files

| File | Purpose |
|---|---|
| `extensions/dench-ai-gateway/sync-trigger.ts` | Gateway-side cron. `armSyncTrigger()` discovers the auth key, reads the web port, and starts a `setInterval`. Defaults to 5-min interval, configurable via `syncTrigger.intervalMs` with a 1 s safety floor. **Explicitly does NOT fire on arm** — first tick lands at `intervalMs` to avoid 404 / ECONNREFUSED noise we'd otherwise see when the gateway boots before the web runtime is ready during `denchclaw update`. Auto-disabled if no Dench Cloud key is configured. |
| `apps/web/app/api/sync/poll-tick/route.ts` | Loopback endpoint. POST-only, Bearer-auth'd against the same Dench Cloud key the gateway plugin uses. Calls `tickPoller()` and returns small JSON status. Hardened against drive-by external POSTs by also checking the host is loopback. |
| `apps/web/app/api/sync/poll-tick/route.test.ts` | Auth, loopback enforcement, mutex no-op when backfill in flight, error propagation. |
| `apps/web/lib/dench-auth.ts` | Web-side mirror of `extensions/shared/dench-auth.ts#readDenchAuthProfileKey`. Reads the same single source of truth (`auth-profiles.json`) the gateway and bundled plugins use, with the same env-var fallback. Kept as a separate file so the Next.js bundler doesn't have to reach across the workspace boundary into `extensions/`. |
| `src/cli/sync-poll.ts` | `kickoffSyncPoll()` helper that fires one immediate tick after `denchclaw update` / `start` finishes, so users don't wait up to 5 min for the first incremental after an upgrade. Best-effort: a failure here just delays sync to the next gateway tick. |
| `src/cli/sync-poll.test.ts` | Happy path, error swallowing, no-key short-circuit. |

### Modified files

- `apps/web/instrumentation.ts` — strip the in-process poller arming. Comment retained explaining where timing lives now.
- `apps/web/lib/sync-runner.ts` — `armIncrementalPoller` is now a no-op shim retained for back-compat (older callers won't break). `tickPoller` is exported so the loopback endpoint can call it. `stopIncrementalPoller` retained for tests.
- `extensions/dench-ai-gateway/index.ts` — calls `armSyncTrigger` on register so the cron starts when the gateway loads the plugin.
- `extensions/dench-ai-gateway/openclaw.plugin.json` — new `syncTrigger` config schema (`enabled`, `intervalMs`, `webBaseUrl`).
- `extensions/dench-ai-gateway/index.test.ts` — adds a 9-test block for the sync-trigger covering: no-key short-circuit, disabled flag, `intervalMs` floor, no immediate fire, URL/auth/body assertion, env override, default port fallback, fetch error swallowed. Composio-bridge tests now disable the trigger to keep their fetch call counts clean.
- `src/cli/web-runtime-command.ts` — `update` and `start` paths call `kickoffSyncPoll()` after the runtime is verified healthy.
- `src/cli/bootstrap-external.ts` — supporting plumbing for the kickoff path.
- `package.json` — `test:cli` runs `sync-poll.test.ts`.

## Test plan

- [x] `pnpm test:cli` — 51 passed (extensions + sync-poll)
- [x] `pnpm --dir apps/web test` — 1564 passed | 5 skipped
- [x] `pnpm --dir apps/web build` — passes
- [x] `pnpm build` — passes
- [ ] Manual: complete onboarding, then run `denchclaw update`. Wait ~5 min. Confirm Gmail incremental sync ticks fire (check `[sync-trigger] tick` log line in gateway output).
- [ ] Manual: `denchclaw start`. Confirm the kickoff helper line shows in the web-runtime log right after the runtime is healthy, and an immediate sync runs.
- [ ] Manual: kill Next.js mid-flight. Confirm gateway keeps logging `[sync-trigger]` even though the loopback fetch fails — and that ticks resume successfully once Next.js comes back up.

## Out of scope

- The full backfill-then-arm orchestration in `runBackfillInner` is unchanged — it still drives the initial sync, then the gateway plugin owns ongoing freshness.
- The 3 other v3 PRs from yesterday's work (chat-history popover, relation-link routing, entry-modal close-on-nav) are already merged via #203 / #204 / #205.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moves incremental sync scheduling out of the web process into the gateway daemon and introduces a new authenticated loopback HTTP endpoint, which can impact sync freshness and security posture if misconfigured. Also adds complex bootstrap/onboarding process-handling changes (including embedded debug telemetry calls) that could affect install/update flows.
> 
> **Overview**
> **Incremental Gmail/Calendar polling is now gateway-driven instead of Next.js-driven.** The `dench-ai-gateway` plugin now arms a `setInterval`-based sync trigger that POSTs to a new web endpoint, and the web app stops auto-arming an in-process poller on boot.
> 
> Adds `POST /api/sync/poll-tick` as a **loopback-only**, **Bearer-token** (Dench Cloud key) protected endpoint using constant-time comparison, with backfill-aware skipping and JSON status including the latest progress event. `sync-runner` exports `tickPoller()` for this path and deprecates `armIncrementalPoller()` as a no-op shim.
> 
> CLI flows (`bootstrap`, `web start`, `web update`) now fire a **best-effort one-shot kickoff** to `/api/sync/poll-tick` after the web runtime is verified healthy, and the gateway plugin adds config (`syncTrigger.enabled/intervalMs/webBaseUrl`) plus throttled error logging/timeout handling. Extensive new tests cover the endpoint contract, gateway trigger behavior, and the CLI kickoff helper; `test:cli` includes the new suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3996ab526f6731333ba618b0225906264563169e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->