### PR TITLE
perf(web): fix workspace object table re-render storm on select/scroll

### DIFF
--- a/apps/web/app/components/workspace/data-table.tsx
+++ b/apps/web/app/components/workspace/data-table.tsx
@@ -341,13 +341,32 @@ export function DataTable<TData, TValue>({
 		[onColumnReorder],
 	);
 
-	// Scroll tracking for sticky column shadow
+	// Scroll tracking for sticky column shadow.
+	// Coalesces via rAF + ref comparison so a continuous scroll doesn't
+	// trigger a setState (and thus a tbody re-render) per pixel.
+	const isScrolledRef = useRef(false);
+	const scrollRafRef = useRef<number | null>(null);
 	const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
-		setIsScrolled(e.currentTarget.scrollLeft > 0);
+		const next = e.currentTarget.scrollLeft > 0;
+		if (next === isScrolledRef.current) {return;}
+		isScrolledRef.current = next;
+		if (scrollRafRef.current != null) {return;}
+		scrollRafRef.current = requestAnimationFrame(() => {
+			scrollRafRef.current = null;
+			setIsScrolled(isScrolledRef.current);
+		});
+	}, []);
+	useEffect(() => () => {
+		if (scrollRafRef.current != null) {cancelAnimationFrame(scrollRafRef.current);}
 	}, []);
 
-	// Build row number column — always first, non-sortable, non-hideable
-	const rownumColumn: ColumnDef<TData> = {
+	// Build row number column — always first, non-sortable, non-hideable.
+	// Memoized so the column definition has a stable identity across renders;
+	// otherwise `allColumns` (and therefore the entire TanStack table tree)
+	// would rebuild on every render — including a row-selection click.
+	const serverPaginationPage = serverPagination?.page;
+	const serverPaginationPageSize = serverPagination?.pageSize;
+	const rownumColumn = useMemo<ColumnDef<TData>>(() => ({
 		id: "__rownum",
 		header: () => (
 			<span
@@ -358,8 +377,8 @@ export function DataTable<TData, TValue>({
 			</span>
 		),
 		cell: ({ row }) => {
-			const baseIdx = serverPagination
-				? (serverPagination.page - 1) * serverPagination.pageSize
+			const baseIdx = serverPaginationPage != null && serverPaginationPageSize != null
+				? (serverPaginationPage - 1) * serverPaginationPageSize
 				: 0;
 			return (
 				<span
@@ -375,10 +394,10 @@ export function DataTable<TData, TValue>({
 		enableSorting: false,
 		enableHiding: false,
 		enableResizing: false,
-	};
+	}), [serverPaginationPage, serverPaginationPageSize]);
 
-	// Build selection column
-	const selectionColumn: ColumnDef<TData> | null = enableRowSelection
+	// Build selection column. Memoized for stable identity across renders.
+	const selectionColumn = useMemo<ColumnDef<TData> | null>(() => enableRowSelection
 		? {
 				id: "select",
 				header: ({ table }) => (
@@ -403,10 +422,10 @@ export function DataTable<TData, TValue>({
 				enableSorting: false,
 				enableHiding: false,
 			}
-		: null;
+		: null, [enableRowSelection]);
 
-	// Build actions column
-	const actionsColumn: ColumnDef<TData> | null = rowActions
+	// Build actions column. Memoized for stable identity across renders.
+	const actionsColumn = useMemo<ColumnDef<TData> | null>(() => rowActions
 		? {
 				id: "actions",
 				header: () => null,
@@ -421,7 +440,7 @@ export function DataTable<TData, TValue>({
 				enableSorting: false,
 				enableHiding: false,
 			}
-		: null;
+		: null, [rowActions]);
 
 	const allColumns = useMemo(() => {
 		const cols: ColumnDef<TData, TValue>[] = [];
@@ -432,10 +451,15 @@ export function DataTable<TData, TValue>({
 		return cols;
 	}, [columns, selectionColumn, actionsColumn, rownumColumn]);
 
-	// Server-side pagination state derived from props
-	const serverPaginationState = serverPagination
-		? { pageIndex: serverPagination.page - 1, pageSize: serverPagination.pageSize }
-		: undefined;
+	// Server-side pagination state derived from props. Memoized so the
+	// table state object identity is stable across renders that don't
+	// touch pagination.
+	const serverPaginationState = useMemo(
+		() => serverPagination
+			? { pageIndex: serverPagination.page - 1, pageSize: serverPagination.pageSize }
+			: undefined,
+		[serverPagination?.page, serverPagination?.pageSize], // eslint-disable-line react-hooks/exhaustive-deps
+	);
 
 	const resizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -502,9 +526,19 @@ export function DataTable<TData, TValue>({
 
 	const selectedCount = Object.keys(rowSelectionState).filter((k) => rowSelectionState[k]).length;
 	const visibleColumns = table.getVisibleFlatColumns().filter((c) => c.id !== "__rownum" && c.id !== "select" && c.id !== "actions" && c.id !== "__add_column");
+	// Stable items array for dnd-kit's SortableContext so the dnd
+	// context isn't reset on every render.
+	const sortableHeaderIds = useMemo(
+		() => columnOrder.filter((id) => !FIXED_COL_IDS.has(id)),
+		[columnOrder], // eslint-disable-line react-hooks/exhaustive-deps
+	);
 
 	// Column sizes as CSS variables for performant resize (TanStack recommended approach).
 	// Only th elements reference these vars; td widths are inherited via table-layout:fixed.
+	// Depend on `columnSizing` (the actual sizes) instead of `columnSizingInfo` (a fresh
+	// object on every state change) so this doesn't recompute on selection/sort/etc.
+	const columnSizingState = table.getState().columnSizing;
+	const isResizingColumn = !!table.getState().columnSizingInfo.isResizingColumn;
 	const columnSizeVars = useMemo(() => {
 		const headers = table.getFlatHeaders();
 		const vars: Record<string, number> = {};
@@ -513,7 +547,7 @@ export function DataTable<TData, TValue>({
 			vars[`--col-${header.column.id}-size`] = header.column.getSize();
 		}
 		return vars;
-	}, [table.getState().columnSizingInfo, table.getState().columnSizing]); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [columnSizingState, isResizingColumn, columnVisibility, columnOrder]); // eslint-disable-line react-hooks/exhaustive-deps
 
 	// ─── Render ───
 
@@ -690,7 +724,7 @@ export function DataTable<TData, TValue>({
 										style={{ borderColor: "var(--color-border)" }}
 										className="border-b-2 backdrop-blur-sm"
 									>
-										<SortableContext items={columnOrder.filter((id) => !FIXED_COL_IDS.has(id))} strategy={horizontalListSortingStrategy}>
+										<SortableContext items={sortableHeaderIds} strategy={horizontalListSortingStrategy}>
 											{headerGroup.headers.map((header, colIdx) => {
 												// Layout: [__rownum, select?, ...data, actions?]
 												const firstDataIdx = 1 + (enableRowSelection ? 1 : 0);
@@ -887,7 +921,166 @@ export function DataTable<TData, TValue>({
 	);
 }
 
-/* ─── Memoized Table Body (skips re-render during column resize) ─── */
+/* ─── Memoized Table Row & Body ───
+ *
+ * The big perf win lives here. Previously the entire <tbody> re-rendered on
+ * every parent state change (selection, scroll, hover, sort) because the only
+ * memo on `DataTableBody` skipped renders ONLY during column resize. We now
+ * memoize at the row level so a single checkbox click re-renders just the
+ * toggled row instead of all 100+ rows.
+ */
+
+// biome-ignore lint/suspicious/noExplicitAny: generic row component used with React.memo
+type TableRowProps = {
+	row: Row<any>;
+	rowIdx: number;
+	isSelected: boolean;
+	isActive: boolean;
+	enableRowSelection: boolean;
+	stickyFirstColumn: boolean;
+	isScrolled: boolean;
+	onRowClick?: (row: any, index: number) => void;
+	firstColumnFaviconUrl: string | null | undefined;
+	/** Stable string key encoding visible column IDs in order. When this
+	 * changes (column add/remove/reorder/visibility) the row re-renders. */
+	cellLayoutKey: string;
+};
+
+function TableRowInner({
+	row,
+	rowIdx,
+	isSelected,
+	isActive,
+	enableRowSelection,
+	stickyFirstColumn,
+	isScrolled,
+	onRowClick,
+	firstColumnFaviconUrl,
+}: TableRowProps) {
+	const visibleCells = row.getVisibleCells();
+	const firstDataIdx = 1 + (enableRowSelection ? 1 : 0);
+	const altBg = rowIdx % 2 === 0 ? "var(--color-surface)" : "var(--color-bg)";
+	const baseBg = isActive || isSelected ? "var(--color-accent-light)" : altBg;
+	const stickyBg = baseBg;
+
+	const handleClick = useCallback(() => {
+		onRowClick?.(row.original, rowIdx);
+	}, [onRowClick, row.original, rowIdx]);
+
+	const handleMouseEnter = useCallback((e: React.MouseEvent<HTMLTableRowElement>) => {
+		if (!isSelected && !isActive) {
+			(e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)";
+		}
+	}, [isSelected, isActive]);
+
+	const handleMouseLeave = useCallback((e: React.MouseEvent<HTMLTableRowElement>) => {
+		if (!isSelected && !isActive) {
+			(e.currentTarget as HTMLElement).style.background = altBg;
+		}
+	}, [isSelected, isActive, altBg]);
+
+	return (
+		<tr
+			data-state={isSelected ? "selected" : isActive ? "active" : undefined}
+			className={cn(
+				"border-b transition-colors duration-100 group/row",
+				onRowClick && "cursor-pointer",
+				isSelected && "data-[state=selected]:bg-(--color-accent-light)",
+			)}
+			style={{
+				borderColor: isActive ? "var(--color-accent)" : "var(--color-border)",
+				background: baseBg,
+			}}
+			onClick={handleClick}
+			onMouseEnter={handleMouseEnter}
+			onMouseLeave={handleMouseLeave}
+		>
+			{visibleCells.map((cell, colIdx) => {
+				const isRownumCol = cell.column.id === "__rownum";
+				const isFirstData = colIdx === firstDataIdx;
+				const isSticky = stickyFirstColumn && isFirstData;
+				const isSelectCol = cell.column.id === "select";
+				const isLastCol = colIdx === visibleCells.length - 1;
+				const cellFaviconUrl = isFirstData && !isSelectCol ? firstColumnFaviconUrl : undefined;
+
+				const cellStyle: React.CSSProperties = {
+					borderColor: "var(--color-border)",
+					...(isSticky
+						? {
+								position: "sticky" as const,
+								left: enableRowSelection ? 40 : 0,
+								zIndex: 2,
+								background: stickyBg,
+								boxShadow: isScrolled ? "4px 0 12px -2px rgba(0,0,0,0.12), 2px 0 4px -1px rgba(0,0,0,0.06)" : "none",
+							}
+						: {}),
+					...(isSelectCol
+						? {
+								position: "sticky" as const,
+								left: 0,
+								zIndex: 2,
+								background: stickyBg,
+								width: 40,
+							}
+						: {}),
+				};
+
+				return (
+					<td
+						key={cell.id}
+						className={cn(
+							"align-middle whitespace-nowrap text-[13px] border-b transition-colors box-border",
+							isRownumCol
+								? "px-3 py-3 text-right"
+								: isSelectCol
+									? "px-3 py-3"
+									: "px-4 py-3",
+							!isLastCol && "border-r",
+							isSticky && isScrolled && "border-r-2!",
+						)}
+						style={cellStyle}
+					>
+						<div className="overflow-hidden">
+							{cellFaviconUrl ? (
+								<div className="flex min-w-0 items-center gap-2">
+									<span className="pointer-events-none shrink-0">
+										<UrlFavicon src={cellFaviconUrl} />
+									</span>
+									<div className="min-w-0 flex-1 overflow-hidden">
+										{flexRender(cell.column.columnDef.cell, cell.getContext())}
+									</div>
+								</div>
+							) : (
+								flexRender(cell.column.columnDef.cell, cell.getContext())
+							)}
+						</div>
+						{isSticky && isScrolled && (
+							<div className="absolute top-0 right-0 bottom-0 w-4 translate-x-full pointer-events-none bg-linear-to-r from-black/4 to-transparent z-100" />
+						)}
+					</td>
+				);
+			})}
+		</tr>
+	);
+}
+
+/** Custom equality: skip re-render unless something the row actually
+ * displays changed. The `row` reference itself is fresh on every TanStack
+ * render so we explicitly ignore it and compare semantic primitives instead. */
+const TableRow = React.memo(TableRowInner, (prev, next) => {
+	return (
+		prev.row.original === next.row.original &&
+		prev.rowIdx === next.rowIdx &&
+		prev.isSelected === next.isSelected &&
+		prev.isActive === next.isActive &&
+		prev.enableRowSelection === next.enableRowSelection &&
+		prev.stickyFirstColumn === next.stickyFirstColumn &&
+		prev.isScrolled === next.isScrolled &&
+		prev.onRowClick === next.onRowClick &&
+		prev.firstColumnFaviconUrl === next.firstColumnFaviconUrl &&
+		prev.cellLayoutKey === next.cellLayoutKey
+	);
+});
 
 // biome-ignore lint/suspicious/noExplicitAny: generic body component used with React.memo
 type DataTableBodyProps = {
@@ -911,124 +1104,50 @@ function DataTableBodyInner({
 	onRowClick,
 	getFirstDataColumnFaviconUrl,
 }: DataTableBodyProps) {
-	// Layout: [__rownum, select?, ...data, actions?]
-	const firstDataIdx = 1 + (enableRowSelection ? 1 : 0);
+	// Encode visible column layout as a stable string. When columns are
+	// added/removed/reordered/hidden, this changes and rows re-render.
+	// Column SIZE changes don't need to invalidate rows — sizes are applied
+	// via CSS variables on <th> elements and <td> widths inherit via
+	// table-layout:fixed.
+	const cellLayoutKey = table.getVisibleLeafColumns().map((c) => c.id).join("|");
+
 	return (
 		<tbody className="[&_tr:last-child]:border-0">
 			{table.getRowModel().rows.map((row, rowIdx) => {
 				const isSelected = row.getIsSelected();
-				const visibleCells = row.getVisibleCells();
 				const isActive = activeRowId != null && getRowId != null && getRowId(row.original) === activeRowId;
-				// Subtle zebra: white (surface) for even rows, slightly off-white (bg) for odd rows.
-				const altBg = rowIdx % 2 === 0 ? "var(--color-surface)" : "var(--color-bg)";
-				const baseBg = isActive || isSelected ? "var(--color-accent-light)" : altBg;
+				const firstColumnFaviconUrl = getFirstDataColumnFaviconUrl?.(row, table) ?? undefined;
 				return (
-					<tr
+					<TableRow
 						key={row.id}
-						data-state={isSelected ? "selected" : isActive ? "active" : undefined}
-						className={cn(
-							"border-b transition-colors duration-100 group/row",
-							onRowClick && "cursor-pointer",
-							isSelected && "data-[state=selected]:bg-(--color-accent-light)",
-						)}
-						style={{
-							borderColor: isActive ? "var(--color-accent)" : "var(--color-border)",
-							background: baseBg,
-						}}
-						onClick={() => onRowClick?.(row.original, rowIdx)}
-						onMouseEnter={(e) => {
-							if (!isSelected && !isActive)
-								{(e.currentTarget as HTMLElement).style.background = "var(--color-surface-hover)";}
-						}}
-						onMouseLeave={(e) => {
-							if (!isSelected && !isActive)
-								{(e.currentTarget as HTMLElement).style.background = altBg;}
-						}}
-					>
-						{visibleCells.map((cell, colIdx) => {
-							const isRownumCol = cell.column.id === "__rownum";
-							const isFirstData = colIdx === firstDataIdx;
-							const isSticky = stickyFirstColumn && isFirstData;
-							const isSelectCol = cell.column.id === "select";
-							const isLastCol = colIdx === visibleCells.length - 1;
-							const firstDataColumnFaviconUrl = isFirstData && !isSelectCol
-								? getFirstDataColumnFaviconUrl?.(row, table)
-								: undefined;
-
-							// Sticky cells need an explicit background so content scrolling
-							// underneath them doesn't show through. Match the row's zebra shade.
-							const stickyBg = (isActive || isSelected)
-								? "var(--color-accent-light)"
-								: altBg;
-
-							const cellStyle: React.CSSProperties = {
-								borderColor: "var(--color-border)",
-								...(isSticky
-									? {
-											position: "sticky" as const,
-											left: enableRowSelection ? 40 : 0,
-											zIndex: 2,
-											background: stickyBg,
-											boxShadow: isScrolled ? "4px 0 12px -2px rgba(0,0,0,0.12), 2px 0 4px -1px rgba(0,0,0,0.06)" : "none",
-										}
-									: {}),
-								...(isSelectCol
-									? {
-											position: "sticky" as const,
-											left: 0,
-											zIndex: 2,
-											background: stickyBg,
-											width: 40,
-										}
-									: {}),
-							};
-
-							return (
-								<td
-									key={cell.id}
-									className={cn(
-										"align-middle whitespace-nowrap text-[13px] border-b transition-colors box-border",
-										isRownumCol
-											? "px-3 py-3 text-right"
-											: isSelectCol
-												? "px-3 py-3"
-												: "px-4 py-3",
-										!isLastCol && "border-r",
-										isSticky && isScrolled && "border-r-2!",
-									)}
-									style={cellStyle}
-								>
-									<div className="overflow-hidden">
-										{firstDataColumnFaviconUrl ? (
-											<div className="flex min-w-0 items-center gap-2">
-												<span className="pointer-events-none shrink-0">
-													<UrlFavicon src={firstDataColumnFaviconUrl} />
-												</span>
-												<div className="min-w-0 flex-1 overflow-hidden">
-													{flexRender(cell.column.columnDef.cell, cell.getContext())}
-												</div>
-											</div>
-										) : (
-											flexRender(cell.column.columnDef.cell, cell.getContext())
-										)}
-									</div>
-									{isSticky && isScrolled && (
-										<div className="absolute top-0 right-0 bottom-0 w-4 translate-x-full pointer-events-none bg-linear-to-r from-black/4 to-transparent z-100" />
-									)}
-								</td>
-							);
-						})}
-					</tr>
+						row={row}
+						rowIdx={rowIdx}
+						isSelected={isSelected}
+						isActive={isActive}
+						enableRowSelection={enableRowSelection}
+						stickyFirstColumn={stickyFirstColumn}
+						isScrolled={isScrolled}
+						onRowClick={onRowClick}
+						firstColumnFaviconUrl={firstColumnFaviconUrl}
+						cellLayoutKey={cellLayoutKey}
+					/>
 				);
 			})}
 		</tbody>
 	);
 }
 
-const DataTableBody = React.memo(DataTableBodyInner, (prev, next) =>
-	!!next.table.getState().columnSizingInfo.isResizingColumn
-	&& prev.table.options.data === next.table.options.data,
-);
+/** Skip re-rendering the body shell during column resize (sizes flow via
+ * CSS variables on <th>; rows don't need to react). For all other changes
+ * the body re-renders, but per-row memoization above prevents the
+ * expensive cell work from running for unchanged rows. */
+const DataTableBody = React.memo(DataTableBodyInner, (prev, next) => {
+	const isResizing = !!next.table.getState().columnSizingInfo.isResizingColumn;
+	if (isResizing && prev.table.options.data === next.table.options.data) {
+		return true;
+	}
+	return false;
+});
 
 /* ─── Sub-components ─── */
 

--- a/apps/web/app/components/workspace/object-table.tsx
+++ b/apps/web/app/components/workspace/object-table.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useMemo, useCallback, useRef, useEffect } from "react";
-import { type ColumnDef, type CellContext, type Row } from "@tanstack/react-table";
+import React, { useState, useMemo, useCallback, useRef, useEffect } from "react";
+import { type ColumnDef, type CellContext } from "@tanstack/react-table";
 import { DataTable, type RowAction, type ColumnSizingState } from "./data-table";
 import { RelationSelect } from "./relation-select";
 import { FormattedFieldValue } from "./formatted-field-value";
@@ -94,11 +94,9 @@ type ObjectTableProps = {
 };
 
 type EntryRow = Record<string, unknown> & { entry_id?: string };
-type EntryRowCell = ReturnType<Row<EntryRow>["getVisibleCells"]>[number];
 
 const CREATED_AT_KEYS = ["created_at", "Created", "createdAt", "created"] as const;
 const UPDATED_AT_KEYS = ["updated_at", "Updated", "updatedAt", "updated"] as const;
-const FIXED_TABLE_COLUMN_IDS = new Set(["__rownum", "select", "actions", "__add_column"]);
 
 /* ─── Helpers ─── */
 
@@ -159,41 +157,27 @@ function resolveEntryMetaValue(
 	return undefined;
 }
 
-function getColumnFieldType(meta: unknown): string | undefined {
-	if (!meta || typeof meta !== "object") {
-		return undefined;
-	}
-	const fieldType = (meta as { fieldType?: unknown }).fieldType;
-	return typeof fieldType === "string" ? fieldType : undefined;
-}
-
-function getCellFaviconUrl(cell: EntryRowCell): string | undefined {
-	const formatted = formatWorkspaceFieldValue(
-		cell.getValue(),
-		getColumnFieldType(cell.column.columnDef.meta),
-	);
-	return formatted.kind === "link" && formatted.linkType === "url"
-		? formatted.faviconUrl
-		: undefined;
-}
-
-function getFirstUrlColumnFaviconUrl(row: Row<EntryRow>): string | undefined {
-	const candidateCells = row.getVisibleCells().filter(
-		(cell) => !FIXED_TABLE_COLUMN_IDS.has(cell.column.id),
-	);
-	const urlTypedCells = candidateCells.filter(
-		(cell) => getColumnFieldType(cell.column.columnDef.meta) === "url",
-	);
-	const cellsToCheck = urlTypedCells.length > 0 ? urlTypedCells : candidateCells;
-
-	for (const cell of cellsToCheck) {
-		const faviconUrl = getCellFaviconUrl(cell);
-		if (faviconUrl) {
-			return faviconUrl;
+function computeEntryFaviconUrl(
+	entry: Record<string, unknown>,
+	candidateFields: Field[],
+): string | undefined {
+	for (const field of candidateFields) {
+		const value = entry[field.name];
+		if (value == null || value === "") {continue;}
+		const formatted = formatWorkspaceFieldValue(value, field.type);
+		if (formatted.kind === "link" && formatted.linkType === "url" && formatted.faviconUrl) {
+			return formatted.faviconUrl;
 		}
 	}
-
 	return undefined;
+}
+
+/** Stable getRowId: hoisted to module scope so its identity doesn't change
+ * across renders (avoids re-keying the TanStack row map). */
+function getRowIdFromEntry(row: EntryRow): string {
+	const eid = row.entry_id;
+	if (eid == null) {return "";}
+	return String(typeof eid === "object" ? JSON.stringify(eid) : eid);
 }
 
 /* ─── Cell Renderers (read-only display) ─── */
@@ -234,10 +218,11 @@ function UserCell({ value, members }: { value: unknown; members?: Array<{ id: st
 }
 
 function RelationCell({
-	value, field, relationLabels, onNavigateObject, onNavigateEntry,
+	value, field, fieldLabels, onNavigateObject, onNavigateEntry,
 }: {
 	value: unknown; field: Field;
-	relationLabels?: Record<string, Record<string, string>>;
+	/** Labels for THIS field only (already narrowed). */
+	fieldLabels?: Record<string, string>;
 	onNavigateObject?: (objectName: string) => void;
 	onNavigateEntry?: (
 		objectName: string,
@@ -245,7 +230,6 @@ function RelationCell({
 		relatedObjectId?: string,
 	) => void;
 }) {
-	const fieldLabels = relationLabels?.[field.name];
 	const ids = value == null ? [] : parseRelationValue(String(value));
 	if (ids.length === 0) {return <span style={{ color: "var(--color-text-muted)", opacity: 0.5 }}>--</span>;}
 	return (
@@ -441,37 +425,45 @@ function ReverseRelationCell({ links, sourceObjectName, sourceObjectId, onNaviga
 
 /* ─── Inline Edit Cell ─── */
 
-function EditableCell({
-	value: initialValue,
-	entryId,
-	fieldName,
-	objectName,
-	field,
-	members,
-	relationLabels,
-	onNavigateObject,
-	onNavigateEntry,
-	onLocalValueChange,
-	onSaved,
-	showUrlFavicon = false,
-}: {
+type EditableCellProps = {
 	value: unknown;
 	entryId: string;
 	fieldName: string;
 	objectName: string;
 	field: Field;
 	members?: Array<{ id: string; name: string }>;
-	relationLabels?: Record<string, Record<string, string>>;
+	/** Labels for THIS field only (relation fields). Pre-narrowed from the
+	 * parent's full relationLabels map so non-relation cells don't bust their
+	 * memo when the unrelated parts of the map change. */
+	fieldRelationLabels?: Record<string, string>;
 	onNavigateObject?: (objectName: string) => void;
 	onNavigateEntry?: (
 		objectName: string,
 		entryId: string,
 		relatedObjectId?: string,
 	) => void;
-	onLocalValueChange?: (value: string) => void;
+	/** Stable callback that receives the (entryId, fieldName, value) tuple
+	 * so each cell doesn't have to bind its own arrow (which would bust
+	 * the surrounding React.memo). */
+	onLocalValueChange?: (entryId: string, fieldName: string, value: string) => void;
 	onSaved?: () => void;
 	showUrlFavicon?: boolean;
-}) {
+};
+
+function EditableCellInner({
+	value: initialValue,
+	entryId,
+	fieldName,
+	objectName,
+	field,
+	members,
+	fieldRelationLabels,
+	onNavigateObject,
+	onNavigateEntry,
+	onLocalValueChange,
+	onSaved,
+	showUrlFavicon = false,
+}: EditableCellProps) {
 	const [editing, setEditing] = useState(false);
 	const [localValue, setLocalValue] = useState(safeString(initialValue));
 	const inputRef = useRef<HTMLInputElement | HTMLSelectElement>(null);
@@ -493,7 +485,7 @@ function EditableCell({
 	const isTags = field.type === "tags";
 
 	const save = useCallback(async (val: string) => {
-		onLocalValueChange?.(val);
+		onLocalValueChange?.(entryId, fieldName, val);
 		try {
 			await fetch(`/api/workspace/objects/${encodeURIComponent(objectName)}/entries/${encodeURIComponent(entryId)}`, {
 				method: "PATCH",
@@ -639,7 +631,7 @@ function EditableCell({
 				<RelationCell
 					value={initialValue}
 					field={field}
-					relationLabels={relationLabels}
+					fieldLabels={fieldRelationLabels}
 					onNavigateObject={onNavigateObject}
 					onNavigateEntry={onNavigateEntry}
 				/>
@@ -684,6 +676,40 @@ function EditableCell({
 		</div>
 	);
 }
+
+/** React.memo wrapper for the inline-edit cell. With stable parent props
+ * (Layer 3 fixes), this is the dominant per-cell perf win — cells whose
+ * value/field hasn't changed will skip rendering entirely on a row that
+ * does need to re-render (e.g. a sibling cell's value changed). */
+const EditableCell = React.memo(EditableCellInner);
+
+/* ─── First-column sticky bold link ─── */
+
+type FirstColumnCellProps = {
+	value: unknown;
+	entryId: string;
+	onEntryClick?: (entryId: string) => void;
+};
+
+function FirstColumnCellInner({ value, entryId, onEntryClick }: FirstColumnCellProps) {
+	const displayVal = value === null || value === undefined || value === "" ? "--" : safeString(value);
+	const isEmpty = displayVal === "--";
+	const handleClick = useCallback((e: React.MouseEvent) => {
+		e.stopPropagation();
+		if (entryId && !isEmpty && onEntryClick) {onEntryClick(entryId);}
+	}, [entryId, isEmpty, onEntryClick]);
+	return (
+		<span
+			className={`font-semibold truncate block max-w-[300px] ${isEmpty || !onEntryClick ? "" : "cursor-pointer hover:underline"}`}
+			style={{ color: isEmpty ? "var(--color-text-muted)" : "var(--color-accent)", opacity: isEmpty ? 0.5 : 1 }}
+			onClick={handleClick}
+		>
+			{displayVal}
+		</span>
+	);
+}
+
+const FirstColumnCell = React.memo(FirstColumnCellInner);
 
 /* ─── Main ObjectTable ─── */
 
@@ -769,6 +795,36 @@ export function ObjectTable({
 		return reverseRelations.filter((rr) => Object.keys(rr.entries).length > 0);
 	}, [reverseRelations]);
 
+	// Precompute the first URL favicon per entry once (instead of recomputing
+	// per row, per render, which used to walk every cell of every row and
+	// run ~5 regexes per cell value). With this map, the row component only
+	// does an O(1) lookup. This is the single biggest selection-perf win on
+	// large pages.
+	const faviconUrlByEntryId = useMemo(() => {
+		const urlFields = dataFields.filter((f) => f.type === "url");
+		const candidateFields = urlFields.length > 0 ? urlFields : dataFields;
+		const map = new Map<string, string>();
+		for (const entry of localEntries) {
+			const eid = entry.entry_id;
+			if (eid == null) {continue;}
+			const entryId = String(typeof eid === "object" ? JSON.stringify(eid) : eid);
+			if (!entryId) {continue;}
+			const url = computeEntryFaviconUrl(entry, candidateFields);
+			if (url) {map.set(entryId, url);}
+		}
+		return map;
+	}, [localEntries, dataFields]);
+
+	const getRowFaviconUrl = useCallback(
+		(row: { original: EntryRow }) => {
+			const eid = row.original.entry_id;
+			if (eid == null) {return undefined;}
+			const entryId = String(typeof eid === "object" ? JSON.stringify(eid) : eid);
+			return faviconUrlByEntryId.get(entryId);
+		},
+		[faviconUrlByEntryId],
+	);
+
 	// Column management handlers
 	const handleColumnReorder = useCallback(
 		async (newOrder: string[]) => {
@@ -830,89 +886,91 @@ export function ObjectTable({
 		}
 	}, [dataFields, handleColumnReorder]);
 
-	// Build TanStack columns from fields (excluding action fields)
+	// Build TanStack columns from fields (excluding action fields).
+	// We use stable, hoisted memo'd cell components (FirstColumnCell,
+	// EditableCell) so flexRender's child subtree can be skipped when
+	// the cell's actual displayed values haven't changed.
 	const columns = useMemo<ColumnDef<EntryRow>[]>(() => {
-		const cols: ColumnDef<EntryRow>[] = dataFields.map((field, fieldIdx) => ({
-			id: field.id,
-			accessorKey: field.name,
-			meta: { label: field.name, fieldName: field.name, fieldType: field.type },
-			header: ({ column }: { column: { getIsSorted: () => "asc" | "desc" | false; toggleSorting: (desc: boolean) => void; toggleVisibility: (visible: boolean) => void } }) => {
-				if (renamingFieldId === field.id) {
+		const cols: ColumnDef<EntryRow>[] = dataFields.map((field, fieldIdx) => {
+			// Pre-narrow relation labels to just THIS field so non-relation
+			// cells don't bust their memo when an unrelated field's labels change.
+			const fieldRelationLabels = field.type === "relation"
+				? relationLabels?.[field.name]
+				: undefined;
+			return {
+				id: field.id,
+				accessorKey: field.name,
+				meta: { label: field.name, fieldName: field.name, fieldType: field.type },
+				header: ({ column }: { column: { getIsSorted: () => "asc" | "desc" | false; toggleSorting: (desc: boolean) => void; toggleVisibility: (visible: boolean) => void } }) => {
+					if (renamingFieldId === field.id) {
+						return (
+							<InlineRenameInput
+								currentName={field.name}
+								onSave={(newName) => void handleRenameColumn(field.id, newName)}
+								onCancel={() => setRenamingFieldId(null)}
+							/>
+						);
+					}
 					return (
-						<InlineRenameInput
-							currentName={field.name}
-							onSave={(newName) => void handleRenameColumn(field.id, newName)}
-							onCancel={() => setRenamingFieldId(null)}
-						/>
-					);
-				}
-				return (
-					<span className="flex items-center gap-1.5 w-full" style={{ color: "var(--color-text-muted)" }}>
-						<FieldTypeIcon type={field.type} size={12} className="shrink-0 opacity-50" />
-						<span className="truncate">{field.name}</span>
-						{field.type === "relation" && field.related_object_name && (
-							<span className="text-[9px] font-normal normal-case tracking-normal opacity-60 shrink-0">
-								({displayObjectName(field.related_object_name)})
-							</span>
-						)}
-						<ColumnHeaderMenu
-							field={field}
-							sortDirection={column.getIsSorted()}
-							onSort={(desc) => column.toggleSorting(desc)}
-							onHide={() => column.toggleVisibility(false)}
-							onRename={() => setRenamingFieldId(field.id)}
-							onDelete={() => handleDeleteColumn(field.id, field.name)}
-							canMoveLeft={fieldIdx > 0}
-							canMoveRight={fieldIdx < dataFields.length - 1}
-							onMoveLeft={() => handleMoveColumn(field.id, "left")}
-							onMoveRight={() => handleMoveColumn(field.id, "right")}
-						/>
-					</span>
-				);
-			},
-			cell: (info: CellContext<EntryRow, unknown>) => {
-				const eid = info.row.original.entry_id;
-				const entryId = String(eid != null && typeof eid === "object" ? JSON.stringify(eid) : (eid ?? ""));
-
-				// First column (sticky): bold link that opens the entry detail modal
-				if (fieldIdx === 0 && onEntryClick) {
-					const val = info.getValue();
-					const displayVal = val === null || val === undefined || val === "" ? "--" : safeString(val);
-					const isEmpty = displayVal === "--";
-					return (
-						<span
-							className={`font-semibold truncate block max-w-[300px] ${isEmpty ? "" : "cursor-pointer hover:underline"}`}
-							style={{ color: isEmpty ? "var(--color-text-muted)" : "var(--color-accent)", opacity: isEmpty ? 0.5 : 1 }}
-							onClick={(e) => {
-								e.stopPropagation();
-								if (entryId && !isEmpty) {onEntryClick(entryId);}
-							}}
-						>
-							{displayVal}
+						<span className="flex items-center gap-1.5 w-full" style={{ color: "var(--color-text-muted)" }}>
+							<FieldTypeIcon type={field.type} size={12} className="shrink-0 opacity-50" />
+							<span className="truncate">{field.name}</span>
+							{field.type === "relation" && field.related_object_name && (
+								<span className="text-[9px] font-normal normal-case tracking-normal opacity-60 shrink-0">
+									({displayObjectName(field.related_object_name)})
+								</span>
+							)}
+							<ColumnHeaderMenu
+								field={field}
+								sortDirection={column.getIsSorted()}
+								onSort={(desc) => column.toggleSorting(desc)}
+								onHide={() => column.toggleVisibility(false)}
+								onRename={() => setRenamingFieldId(field.id)}
+								onDelete={() => handleDeleteColumn(field.id, field.name)}
+								canMoveLeft={fieldIdx > 0}
+								canMoveRight={fieldIdx < dataFields.length - 1}
+								onMoveLeft={() => handleMoveColumn(field.id, "left")}
+								onMoveRight={() => handleMoveColumn(field.id, "right")}
+							/>
 						</span>
 					);
-				}
+				},
+				cell: (info: CellContext<EntryRow, unknown>) => {
+					const eid = info.row.original.entry_id;
+					const entryId = String(eid != null && typeof eid === "object" ? JSON.stringify(eid) : (eid ?? ""));
 
-				return (
-					<EditableCell
-						value={info.getValue()}
-						entryId={entryId}
-						fieldName={field.name}
-						objectName={objectName}
-						field={field}
-						members={members}
-						relationLabels={relationLabels}
-						onNavigateObject={onNavigateToObject}
-						onNavigateEntry={onNavigateToEntry}
-						onLocalValueChange={(value) => updateLocalEntryField(entryId, field.name, value)}
-						onSaved={onRefresh}
-						showUrlFavicon={fieldIdx !== 0}
-					/>
-				);
-			},
-			size: field.type === "richtext" ? 300 : field.type === "relation" || field.type === "tags" ? 220 : 200,
-			enableSorting: true,
-		}));
+					// First column (sticky): bold link that opens the entry detail modal.
+					if (fieldIdx === 0 && onEntryClick) {
+						return (
+							<FirstColumnCell
+								value={info.getValue()}
+								entryId={entryId}
+								onEntryClick={onEntryClick}
+							/>
+						);
+					}
+
+					return (
+						<EditableCell
+							value={info.getValue()}
+							entryId={entryId}
+							fieldName={field.name}
+							objectName={objectName}
+							field={field}
+							members={members}
+							fieldRelationLabels={fieldRelationLabels}
+							onNavigateObject={onNavigateToObject}
+							onNavigateEntry={onNavigateToEntry}
+							onLocalValueChange={updateLocalEntryField}
+							onSaved={onRefresh}
+							showUrlFavicon={fieldIdx !== 0}
+						/>
+					);
+				},
+				size: field.type === "richtext" ? 300 : field.type === "relation" || field.type === "tags" ? 220 : 200,
+				enableSorting: true,
+			};
+		});
 
 		cols.push({
 			id: "created_at",
@@ -1039,7 +1097,10 @@ export function ObjectTable({
 		});
 
 		return cols;
-	}, [dataFields, actionFields, activeReverseRelations, objectName, members, relationLabels, onNavigateToObject, onNavigateToEntry, onRefresh, showToast, renamingFieldId, handleRenameColumn, handleDeleteColumn, handleMoveColumn]);
+		// `onEntryClick` and `updateLocalEntryField` are read inside the `cell`
+		// closures and were missing from the original deps (stale-closure bug);
+		// they're included now.
+	}, [dataFields, actionFields, activeReverseRelations, objectName, members, relationLabels, onNavigateToObject, onNavigateToEntry, onEntryClick, onRefresh, updateLocalEntryField, showToast, renamingFieldId, handleRenameColumn, handleDeleteColumn, handleMoveColumn]);
 
 	// Add entry handler — delegates to parent when provided, otherwise opens local modal.
 	const handleAdd = useCallback(() => {
@@ -1175,7 +1236,7 @@ export function ObjectTable({
 			stickyFirstColumnValue={stickyFirstColumnValue}
 			onStickyFirstColumnChange={onStickyFirstColumnChange}
 			activeRowId={activeEntryId}
-			getRowId={(row) => String(row.entry_id ?? "")}
+			getRowId={getRowIdFromEntry}
 			initialColumnVisibility={columnVisibility}
 			onColumnVisibilityChanged={onColumnVisibilityChanged}
 			initialColumnSizing={columnSizing}
@@ -1185,7 +1246,7 @@ export function ObjectTable({
 			hideToolbar={hideInternalToolbar}
 			globalFilter={globalFilter}
 			onGlobalFilterChange={onGlobalFilterChange}
-			getFirstDataColumnFaviconUrl={getFirstUrlColumnFaviconUrl}
+			getFirstDataColumnFaviconUrl={getRowFaviconUrl}
 		/>
 
 		<BulkActionBar

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -3716,6 +3716,7 @@ function ContentRenderer({
     case "object":
       return (
         <ObjectView
+          key={content.data.object.name}
           data={content.data}
           members={members}
           onNavigateToObject={onNavigateToObject}
@@ -4261,6 +4262,41 @@ function ObjectView({
   // Use entries from server (already filtered server-side)
   const filteredEntries = entries;
 
+  // ---- Stable props for ObjectTable ----
+  // The ObjectTable / DataTable / row / cell tree is heavily memoized; if we
+  // pass fresh function/object references on every parent render, every
+  // memoization downstream busts and we end up re-rendering all 100 rows on
+  // every state tick. Keep these stable.
+
+  /** Open the entry detail modal for an entry in THIS object. */
+  const handleEntryClick = useCallback(
+    (entryId: string) => {
+      onOpenEntry?.(data.object.name, entryId);
+    },
+    [onOpenEntry, data.object.name],
+  );
+  // Pass `undefined` (not a noop) when no parent handler exists so the
+  // ObjectTable can still suppress the click affordance.
+  const handleEntryClickProp = onOpenEntry ? handleEntryClick : undefined;
+
+  /** Open the +Add entry modal. */
+  const handleOpenAddModal = useCallback(() => {
+    setShowAddModal(true);
+  }, []);
+
+  /** Server pagination prop, memoized so the object identity is stable
+   * unless one of the actual values changes. */
+  const serverPaginationProp = useMemo(
+    () => ({
+      totalCount,
+      page: serverPage,
+      pageSize: serverPageSize,
+      onPageChange: handlePageChange,
+      onPageSizeChange: handlePageSizeChange,
+    }),
+    [totalCount, serverPage, serverPageSize, handlePageChange, handlePageSizeChange],
+  );
+
   // Save view to .object.yaml via API
   const handleSaveView = useCallback(async (name: string) => {
     const newView: SavedView = {
@@ -4690,7 +4726,7 @@ function ObjectView({
               statuses={data.statuses}
               members={members}
               relationLabels={data.relationLabels}
-              onEntryClick={onOpenEntry ? (entryId) => onOpenEntry(data.object.name, entryId) : undefined}
+              onEntryClick={handleEntryClickProp}
               onRefresh={handleRefresh}
             />
           </div>
@@ -4705,27 +4741,21 @@ function ObjectView({
             reverseRelations={data.reverseRelations}
             onNavigateToObject={onNavigateToObject}
             onNavigateToEntry={onOpenEntry}
-            onEntryClick={onOpenEntry ? (entryId) => onOpenEntry(data.object.name, entryId) : undefined}
+            onEntryClick={handleEntryClickProp}
             onRefresh={handleRefresh}
             activeEntryId={activeEntryId}
             columnVisibility={columnVisibility}
             onColumnVisibilityChanged={handleColumnVisibilityChanged}
             columnSizing={columnSizing}
             onColumnSizingChanged={handleColumnSizingChanged}
-            serverPagination={{
-              totalCount,
-              page: serverPage,
-              pageSize: serverPageSize,
-              onPageChange: handlePageChange,
-              onPageSizeChange: handlePageSizeChange,
-            }}
+            serverPagination={serverPaginationProp}
             onServerSearch={handleServerSearch}
             hideInternalToolbar
             globalFilter={globalFilter}
             onGlobalFilterChange={handleGlobalFilterChange}
             stickyFirstColumnValue={stickyFirstColumn}
             onStickyFirstColumnChange={setStickyFirstColumn}
-            onAddRequest={() => setShowAddModal(true)}
+            onAddRequest={handleOpenAddModal}
           />
         )}
         {currentViewType === "calendar" && (
@@ -4739,7 +4769,7 @@ function ObjectView({
               mode={effectiveSettings.calendarMode ?? "month"}
               onModeChange={(mode) => handleViewSettingsChange({ ...effectiveSettings, calendarMode: mode })}
               members={members}
-              onEntryClick={onOpenEntry ? (entryId) => onOpenEntry(data.object.name, entryId) : undefined}
+              onEntryClick={handleEntryClickProp}
               onEntryDateChange={handleCalendarDateChange}
             />
           </div>
@@ -4756,7 +4786,7 @@ function ObjectView({
               zoom={effectiveSettings.timelineZoom ?? "week"}
               onZoomChange={(zoom) => handleViewSettingsChange({ ...effectiveSettings, timelineZoom: zoom })}
               members={members}
-              onEntryClick={onOpenEntry ? (entryId) => onOpenEntry(data.object.name, entryId) : undefined}
+              onEntryClick={handleEntryClickProp}
               onEntryDateChange={handleTimelineDateChange}
             />
           </div>
@@ -4771,7 +4801,7 @@ function ObjectView({
               coverField={effectiveSettings.galleryCoverField}
               members={members}
               relationLabels={data.relationLabels}
-              onEntryClick={onOpenEntry ? (entryId) => onOpenEntry(data.object.name, entryId) : undefined}
+              onEntryClick={handleEntryClickProp}
             />
           </div>
         )}
@@ -4784,7 +4814,7 @@ function ObjectView({
               titleField={effectiveSettings.listTitleField}
               subtitleField={effectiveSettings.listSubtitleField}
               members={members}
-              onEntryClick={onOpenEntry ? (entryId) => onOpenEntry(data.object.name, entryId) : undefined}
+              onEntryClick={handleEntryClickProp}
             />
           </div>
         )}

--- a/apps/web/lib/workspace-cell-format.ts
+++ b/apps/web/lib/workspace-cell-format.ts
@@ -512,6 +512,35 @@ function formatByHeuristics(raw: string): FormattedWorkspaceValue {
 	};
 }
 
+/**
+ * Bounded format-result cache. The function runs ~5 regexes per call and is
+ * invoked O(rows × cells) per render — caching by (value, type) makes
+ * repeated renders nearly free. We keep a soft cap and evict the oldest
+ * entries when full (Map preserves insertion order).
+ */
+const FORMAT_CACHE_MAX = 4096;
+const formatCache = new Map<string, FormattedWorkspaceValue>();
+
+function getCachedFormatted(
+	cacheKey: string,
+	compute: () => FormattedWorkspaceValue,
+): FormattedWorkspaceValue {
+	const hit = formatCache.get(cacheKey);
+	if (hit !== undefined) {
+		// Refresh insertion order so frequently-used keys aren't evicted first.
+		formatCache.delete(cacheKey);
+		formatCache.set(cacheKey, hit);
+		return hit;
+	}
+	const value = compute();
+	if (formatCache.size >= FORMAT_CACHE_MAX) {
+		const oldestKey = formatCache.keys().next().value;
+		if (oldestKey !== undefined) {formatCache.delete(oldestKey);}
+	}
+	formatCache.set(cacheKey, value);
+	return value;
+}
+
 export function formatWorkspaceFieldValue(
 	value: unknown,
 	fieldType?: string,
@@ -522,6 +551,19 @@ export function formatWorkspaceFieldValue(
 	}
 
 	const schemaType = normalizeFieldType(fieldType);
+	// Cache key length is bounded so we don't blow memory on long
+	// rich-text values; for those we bypass the cache and just compute.
+	if (raw.length <= 256) {
+		const cacheKey = `${schemaType}\u0000${raw}`;
+		return getCachedFormatted(cacheKey, () => computeFormatted(raw, schemaType));
+	}
+	return computeFormatted(raw, schemaType);
+}
+
+function computeFormatted(
+	raw: string,
+	schemaType: string,
+): FormattedWorkspaceValue {
 	const schemaFormatted = formatBySchema(raw, schemaType);
 	if (schemaFormatted) {
 		return schemaFormatted;


### PR DESCRIPTION
## Summary
Fixes the multi-second lag when clicking row checkboxes in the workspace object `DataTable` / `ObjectTable` (100+ rows). A single click used to re-render the entire `<tbody>` and re-run format detection for every cell.

## Changes
- **`data-table.tsx`**: Memoize framework columns; per-row `TableRow` memo; throttled `isScrolled`; stable `columnSizeVars` / `serverPagination` / sortable item ids; body memo keeps resize fast-path.
- **`object-table.tsx`**: Memo `EditableCell` + first-column link; O(1) favicon map; narrowed relation labels; stable `getRowId` / local update callback; fixed `columns` useMemo deps (`onEntryClick`, `updateLocalEntryField`).
- **`workspace-cell-format.ts`**: Bounded cache for `formatWorkspaceFieldValue`.
- **`workspace-content.tsx`**: Stable `onEntryClick`, `onAddRequest`, and `serverPagination` props for all object views that pass entry click.

## Verification
- `pnpm web:build` passes (types + lint).

## Out of scope
Uncommitted local changes: `workspace-links.ts` / `workspace-sync-params.test.ts` (separate path-param behavior) were left on the working tree, not in this PR.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes React memoization/equality behavior and introduces caching in `formatWorkspaceFieldValue`, which could cause stale UI if dependencies or equality checks are wrong.
> 
> **Overview**
> Reduces UI lag in workspace object tables by **stabilizing TanStack table inputs** (memoized framework columns, server pagination state, DnD header id list, and resize CSS var computation) and **throttling scroll shadow state** via `requestAnimationFrame`.
> 
> Introduces **row-level memoization** in `data-table.tsx` (`TableRow` + a column-layout key) so selection/hover/scroll updates re-render only affected rows instead of the whole `<tbody>`.
> 
> Further cuts per-render work in `object-table.tsx` by memoizing `EditableCell`/first-column link, precomputing favicon URLs per entry, narrowing relation-label props, hoisting a stable `getRowId`, and fixing missing `useMemo` deps.
> 
> Adds a **bounded LRU-style cache** to `formatWorkspaceFieldValue` (skipping long values) and passes **stable callbacks/objects** from `workspace-content.tsx` (e.g., `onEntryClick`, `onAddRequest`, `serverPagination`) to avoid downstream memo busting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c5cc447a9f2a3e4b5bc1e79c5b4c9f1da309ce0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->