### PR TITLE
fix(web): Composio disconnect and client helpers

### DIFF
--- a/apps/web/app/api/composio/disconnect/route.test.ts
+++ b/apps/web/app/api/composio/disconnect/route.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { POST } from "./route";
 
 vi.mock("@/lib/composio", () => ({
   disconnectComposioApp: vi.fn(),
@@ -12,6 +11,12 @@ vi.mock("@/lib/integrations", () => ({
   refreshIntegrationsRuntime: vi.fn(),
 }));
 
+vi.mock("@/lib/denchclaw-state", () => ({
+  readConnections: vi.fn(),
+  clearConnection: vi.fn(),
+}));
+
+const { POST } = await import("./route");
 const {
   disconnectComposioApp,
   resolveComposioApiKey,
@@ -19,12 +24,23 @@ const {
   resolveComposioGatewayUrl,
 } = await import("@/lib/composio");
 const { refreshIntegrationsRuntime } = await import("@/lib/integrations");
+const { readConnections, clearConnection } = await import("@/lib/denchclaw-state");
 
 const mockedDisconnectComposioApp = vi.mocked(disconnectComposioApp);
 const mockedResolveComposioApiKey = vi.mocked(resolveComposioApiKey);
 const mockedResolveComposioEligibility = vi.mocked(resolveComposioEligibility);
 const mockedResolveComposioGatewayUrl = vi.mocked(resolveComposioGatewayUrl);
 const mockedRefreshIntegrationsRuntime = vi.mocked(refreshIntegrationsRuntime);
+const mockedReadConnections = vi.mocked(readConnections);
+const mockedClearConnection = vi.mocked(clearConnection);
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/composio/disconnect", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
 
 describe("Composio disconnect API", () => {
   beforeEach(() => {
@@ -36,25 +52,19 @@ describe("Composio disconnect API", () => {
       lockBadge: null,
     });
     mockedResolveComposioGatewayUrl.mockReturnValue("https://gateway.merseoriginals.com");
-    mockedDisconnectComposioApp.mockResolvedValue({
-      ok: true,
-    } as never);
+    mockedDisconnectComposioApp.mockResolvedValue({ deleted: true });
     mockedRefreshIntegrationsRuntime.mockResolvedValue({
       attempted: true,
       restarted: true,
       error: null,
       profile: "dench",
     });
+    mockedReadConnections.mockReturnValue({ version: 1, updatedAt: "2026-01-01T00:00:00.000Z" });
+    mockedClearConnection.mockReturnValue({ version: 1, updatedAt: "2026-01-01T00:00:00.000Z" });
   });
 
   it("restarts the runtime after disconnecting", async () => {
-    const response = await POST(
-      new Request("http://localhost/api/composio/disconnect", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ connection_id: "conn_123" }),
-      }),
-    );
+    const response = await POST(makeRequest({ connection_id: "conn_123" }));
 
     const body = await response.json();
     expect(response.status).toBe(200);
@@ -69,5 +79,124 @@ describe("Composio disconnect API", () => {
       restarted: true,
       profile: "dench",
     });
+  });
+
+  it("clears the local connections.json record when the disconnected id matches gmail", async () => {
+    // Without this, the sync runner keeps using the dead Composio id
+    // every 5 minutes after disconnect — the SyncHealthBanner never
+    // clears even though the user did the right thing.
+    mockedReadConnections.mockReturnValue({
+      version: 1,
+      gmail: {
+        connectionId: "conn_dead",
+        toolkitSlug: "gmail",
+        connectedAt: "2026-01-01T00:00:00.000Z",
+      },
+      calendar: {
+        connectionId: "conn_other",
+        toolkitSlug: "google-calendar",
+        connectedAt: "2026-01-01T00:00:00.000Z",
+      },
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    const response = await POST(makeRequest({ connection_id: "conn_dead" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockedClearConnection).toHaveBeenCalledWith("gmail");
+    expect(mockedClearConnection).not.toHaveBeenCalledWith("calendar");
+    expect(body.local_cleanup).toEqual({ clearedGmail: true, clearedCalendar: false });
+  });
+
+  it("does not clear unrelated local records when disconnecting a different connection", async () => {
+    // Disconnecting a no-longer-active Gmail account must NOT wipe the
+    // currently-active Calendar entry from local state.
+    mockedReadConnections.mockReturnValue({
+      version: 1,
+      gmail: {
+        connectionId: "conn_active_gmail",
+        toolkitSlug: "gmail",
+        connectedAt: "2026-01-01T00:00:00.000Z",
+      },
+      calendar: {
+        connectionId: "conn_active_cal",
+        toolkitSlug: "google-calendar",
+        connectedAt: "2026-01-01T00:00:00.000Z",
+      },
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    const response = await POST(makeRequest({ connection_id: "conn_unrelated" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockedClearConnection).not.toHaveBeenCalled();
+    expect(body.local_cleanup).toEqual({ clearedGmail: false, clearedCalendar: false });
+  });
+
+  it("propagates alreadyGone from the lib through the response (HTTP 404 = success)", async () => {
+    // The end-to-end story for the screenshot bug: Composio returned
+    // 404 → lib turned it into success+alreadyGone → route returns 200
+    // with the flag → modal shows "Disconnected" instead of an angry
+    // red error toast.
+    mockedDisconnectComposioApp.mockResolvedValueOnce({ deleted: true, alreadyGone: true });
+    mockedReadConnections.mockReturnValue({
+      version: 1,
+      gmail: {
+        connectionId: "ca_dead",
+        toolkitSlug: "gmail",
+        connectedAt: "2026-01-01T00:00:00.000Z",
+      },
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    const response = await POST(makeRequest({ connection_id: "ca_dead" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.deleted).toBe(true);
+    expect(body.alreadyGone).toBe(true);
+    // Local cleanup still runs for the now-dead id.
+    expect(mockedClearConnection).toHaveBeenCalledWith("gmail");
+  });
+
+  it("returns 502 with the error message when the lib throws (transient gateway failure)", async () => {
+    mockedDisconnectComposioApp.mockRejectedValueOnce(
+      new Error("Failed to disconnect (HTTP 502)"),
+    );
+    const response = await POST(makeRequest({ connection_id: "conn_xxx" }));
+    const body = await response.json();
+    expect(response.status).toBe(502);
+    expect(body.error).toMatch(/HTTP 502/);
+    // Local cleanup MUST NOT run when the disconnect fails — otherwise
+    // we'd be lying about what was deleted upstream.
+    expect(mockedClearConnection).not.toHaveBeenCalled();
+  });
+
+  it("rejects requests without an api key (403)", async () => {
+    mockedResolveComposioApiKey.mockReturnValue(undefined);
+    const response = await POST(makeRequest({ connection_id: "conn_xxx" }));
+    expect(response.status).toBe(403);
+    expect(mockedDisconnectComposioApp).not.toHaveBeenCalled();
+  });
+
+  it("rejects ineligible Dench Cloud profile (403)", async () => {
+    mockedResolveComposioEligibility.mockReturnValue({
+      eligible: false,
+      lockReason: "primary_provider_mismatch",
+      lockBadge: "external",
+    });
+    const response = await POST(makeRequest({ connection_id: "conn_xxx" }));
+    expect(response.status).toBe(403);
+    expect(mockedDisconnectComposioApp).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing/empty connection_id (400)", async () => {
+    const response = await POST(makeRequest({}));
+    expect(response.status).toBe(400);
+    const blank = await POST(makeRequest({ connection_id: "  " }));
+    expect(blank.status).toBe(400);
+    expect(mockedDisconnectComposioApp).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/composio/disconnect/route.ts
+++ b/apps/web/app/api/composio/disconnect/route.ts
@@ -5,6 +5,7 @@ import {
   resolveComposioGatewayUrl,
 } from "@/lib/composio";
 import { refreshIntegrationsRuntime } from "@/lib/integrations";
+import { clearConnection, readConnections } from "@/lib/denchclaw-state";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -12,6 +13,35 @@ export const runtime = "nodejs";
 type DisconnectRequestBody = {
   connection_id?: unknown;
 };
+
+/**
+ * Wipe any local `~/.openclaw-dench/.../connections.json` record that
+ * points at the just-disconnected Composio connection. Without this,
+ * the sync runner keeps re-trying the dead connection every 5 minutes
+ * (because `connections.json` still has the stale id), so the
+ * `SyncHealthBanner` never clears even after the user disconnects.
+ *
+ * We compare connection ids strictly — disconnecting one Gmail account
+ * doesn't clobber the local record for a different Gmail account that
+ * happens to be active.
+ */
+function clearLocalSyncRecordsFor(connectionId: string): {
+  clearedGmail: boolean;
+  clearedCalendar: boolean;
+} {
+  const current = readConnections();
+  let clearedGmail = false;
+  let clearedCalendar = false;
+  if (current.gmail?.connectionId === connectionId) {
+    clearConnection("gmail");
+    clearedGmail = true;
+  }
+  if (current.calendar?.connectionId === connectionId) {
+    clearConnection("calendar");
+    clearedCalendar = true;
+  }
+  return { clearedGmail, clearedCalendar };
+}
 
 export async function POST(request: Request) {
   const apiKey = resolveComposioApiKey();
@@ -49,12 +79,18 @@ export async function POST(request: Request) {
   }
 
   const gatewayUrl = resolveComposioGatewayUrl();
+  const connectionId = body.connection_id.trim();
 
   try {
-    const data = await disconnectComposioApp(gatewayUrl, apiKey, body.connection_id.trim());
+    const data = await disconnectComposioApp(gatewayUrl, apiKey, connectionId);
+    // Both real disconnects and `alreadyGone` 404s clear the local
+    // record — the upstream truth is "this id is dead", so any local
+    // pointer to it is stale.
+    const localCleanup = clearLocalSyncRecordsFor(connectionId);
     const refresh = await refreshIntegrationsRuntime();
     return Response.json({
       ...data,
+      local_cleanup: localCleanup,
       runtime_refresh: refresh,
     });
   } catch (err) {

--- a/apps/web/lib/composio-execute.test.ts
+++ b/apps/web/lib/composio-execute.test.ts
@@ -1,5 +1,53 @@
 import { describe, expect, it } from "vitest";
-import { createConcurrencyLimiter } from "./composio-execute";
+import { createConcurrencyLimiter, isLikelyNoConnection } from "./composio-execute";
+
+describe("isLikelyNoConnection", () => {
+  // Status-code gating: only 4xx (and 422 specifically) qualifies as a
+  // "no-connection" candidate. 5xx is always retried by the caller, and
+  // 200/3xx never reach this predicate. We pin those explicitly so an
+  // accidental widening (e.g., catching 500) doesn't quietly flip a
+  // transient gateway failure into "user must reconnect".
+  it.each([200, 201, 301, 304, 405, 500, 502, 503, 504])(
+    "returns false for status %i regardless of body",
+    (status) => {
+      expect(isLikelyNoConnection(status, "is not active or does not exist")).toBe(false);
+    },
+  );
+
+  it("returns false for 4xx with an unrelated body", () => {
+    expect(isLikelyNoConnection(400, "Bad request: missing field foo")).toBe(false);
+    expect(isLikelyNoConnection(404, "Tool GMAIL_FOO not found")).toBe(false);
+  });
+
+  it("matches the historical Composio hints", () => {
+    // Original four hints — covered separately so a refactor that
+    // accidentally drops one will fail in isolation.
+    expect(isLikelyNoConnection(400, "composio_account_selection_required")).toBe(true);
+    expect(isLikelyNoConnection(400, "Error: no active connection for tool")).toBe(true);
+    expect(isLikelyNoConnection(400, "no connection found for slug")).toBe(true);
+    expect(isLikelyNoConnection(400, '"connected_account_id is required"')).toBe(true);
+  });
+
+  // The bug that motivated this overhaul: Composio's `composio_client_error`
+  // body for a revoked Gmail OAuth uses the phrase
+  // `is not active or does not exist`, which the original hint list
+  // didn't cover. The poll loop swallowed it silently and the inbox
+  // froze for 3 days. Pin all the variants we've seen so we never
+  // regress.
+  it.each([
+    'Connected account "ca_xxx" is not active or does not exist.',
+    "Account is not active",
+    "account does not exist",
+    "Connection has been disabled by the workspace owner",
+    "connection is disabled",
+  ])("matches Composio dead-account body: %s", (body) => {
+    expect(isLikelyNoConnection(400, body)).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isLikelyNoConnection(400, "IS NOT ACTIVE OR DOES NOT EXIST")).toBe(true);
+  });
+});
 
 describe("createConcurrencyLimiter", () => {
   it("rejects maxConcurrent <= 0", () => {

--- a/apps/web/lib/composio-execute.ts
+++ b/apps/web/lib/composio-execute.ts
@@ -94,11 +94,35 @@ export class ComposioToolNoConnectionError extends ComposioToolError {
 // ---------------------------------------------------------------------------
 
 const RETRY_STATUS = new Set<number>([408, 425, 429, 500, 502, 503, 504]);
+// Substrings that Composio returns (lowercased) when the upstream OAuth
+// connection is gone — either revoked by the provider, hand-deleted in
+// Composio's dashboard, or expired without a refresh token.
+//
+// We classify these as `ComposioToolNoConnectionError` so callers
+// (notably `tickPoller`) surface a "Reconnect from Integrations" toast
+// instead of a generic 4xx/5xx that the silent-failure catch swallows.
+//
+// Additions are easy to discover after the fact: Composio's response
+// body always lowercases cleanly via `body.toLowerCase()`, and the
+// substring check is permissive on whitespace + punctuation. When in
+// doubt, run the failing tool with curl and grep the response for a
+// stable phrase before adding it here.
 const NO_CONNECTION_HINTS = [
   "composio_account_selection_required",
   "no active connection",
   "no connection found",
   "connected_account_id is required",
+  // Observed 2026-04 against a revoked Gmail OAuth connection — the
+  // exact phrasing from Composio's `composio_client_error` body. Without
+  // this, the error fell through as a generic ComposioToolError and the
+  // poll loop swallowed it silently for days.
+  "is not active or does not exist",
+  // Defensive: catch slight wording variants Composio has used on other
+  // toolkits (Slack/Notion) for the same root cause.
+  "account is not active",
+  "account does not exist",
+  "connection has been disabled",
+  "connection is disabled",
 ];
 const DEFAULT_MAX_RETRIES = 6;
 const FIRST_RETRY_DELAY_MS = 1_000;
@@ -130,7 +154,15 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   });
 }
 
-function isLikelyNoConnection(status: number, body: string): boolean {
+/**
+ * Decide whether a Composio HTTP response is the "your account is gone,
+ * reconnect" failure mode (vs. a transient or unrelated 4xx/5xx).
+ *
+ * Exported only so the unit tests can pin down the substring matrix in
+ * `NO_CONNECTION_HINTS` without going through a full executeComposioTool
+ * round-trip.
+ */
+export function isLikelyNoConnection(status: number, body: string): boolean {
   if (status !== 400 && status !== 404 && status !== 422) {return false;}
   const lower = body.toLowerCase();
   return NO_CONNECTION_HINTS.some((hint) => lower.includes(hint));

--- a/apps/web/lib/composio.test.ts
+++ b/apps/web/lib/composio.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/lib/workspace", () => ({
 }));
 
 const {
+  disconnectComposioApp,
   fetchComposioMcpToolsList,
   resolveComposioGatewayUrl,
 } = await import("./composio");
@@ -83,5 +84,99 @@ describe("composio config resolution", () => {
       "GMAIL_FETCH_EMAILS",
       "SLACK_SEND_MESSAGE",
     ]);
+  });
+});
+
+/**
+ * `disconnectComposioApp` contract — pinned because the original code
+ * threw on every non-2xx including 404, which surfaced as a confusing
+ * "Failed to disconnect (HTTP 404)" toast when the user clicked
+ * Disconnect on a stale row whose Composio account had already been
+ * revoked upstream (the screenshot bug). The fix: 404 is success
+ * with `alreadyGone: true`, anything else still throws.
+ */
+describe("disconnectComposioApp", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns deleted: true on a successful 200 with JSON body", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ deleted: true }), { status: 200 }),
+    );
+    const result = await disconnectComposioApp("https://gw.example.com", "key", "ca_xxx");
+    expect(result).toEqual({ deleted: true });
+  });
+
+  it("returns deleted: true with no body when Composio returns an empty 200", async () => {
+    // Real REST DELETE responses often have no body; we shouldn't
+    // surface "Unexpected end of JSON input" in that case. Note: we
+    // can't model 204 here because the WHATWG Response constructor
+    // refuses to pair a body with 204 (per spec) — 200 with empty
+    // body covers the same code path inside `disconnectComposioApp`.
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("", { status: 200 }),
+    );
+    const result = await disconnectComposioApp("https://gw.example.com", "key", "ca_xxx");
+    expect(result).toEqual({ deleted: true });
+  });
+
+  it("treats HTTP 404 as already-gone success (the screenshot bug)", async () => {
+    // The exact body Composio returns for a connection that no longer
+    // exists upstream. Without the 404 special case, this would throw
+    // and the user sees "Failed to disconnect (HTTP 404)".
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: {
+            message: "Connected account not found",
+            type: "invalid_request_error",
+            code: "composio_client_error",
+          },
+        }),
+        { status: 404 },
+      ),
+    );
+    const result = await disconnectComposioApp("https://gw.example.com", "key", "ca_dead");
+    expect(result).toEqual({ deleted: true, alreadyGone: true });
+  });
+
+  it("throws on non-2xx, non-404 errors so transient failures aren't masked", async () => {
+    // 502 = real gateway problem. We must throw so the route surfaces
+    // a 502 to the client and the modal keeps the row in the list.
+    // Treating 5xx as alreadyGone would silently delete entries the
+    // user actually wanted to keep.
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("bad gateway", { status: 502 }),
+    );
+    await expect(
+      disconnectComposioApp("https://gw.example.com", "key", "ca_xxx"),
+    ).rejects.toThrow(/Failed to disconnect.*502/);
+  });
+
+  it("hits the right URL with DELETE + Bearer auth", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ deleted: true }), { status: 200 }),
+    );
+    await disconnectComposioApp("https://gw.example.com", "secret_key", "ca_abc");
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("https://gw.example.com/v1/composio/connections/ca_abc");
+    expect(init?.method).toBe("DELETE");
+    const headers = new Headers(init?.headers as HeadersInit);
+    expect(headers.get("authorization")).toBe("Bearer secret_key");
+  });
+
+  it("URL-encodes weird connection ids defensively", async () => {
+    // Composio ids are usually slug-safe, but we encode anyway so a
+    // future id format with `/` or `%` doesn't punch through to a
+    // different gateway path.
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ deleted: true }), { status: 200 }),
+    );
+    await disconnectComposioApp("https://gw.example.com", "k", "ca/with weird?chars");
+    const [url] = fetchSpy.mock.calls[0];
+    expect(url).toBe(
+      "https://gw.example.com/v1/composio/connections/ca%2Fwith%20weird%3Fchars",
+    );
   });
 });

--- a/apps/web/lib/composio.ts
+++ b/apps/web/lib/composio.ts
@@ -466,21 +466,58 @@ export async function initiateComposioConnect(
   return res.json() as Promise<ComposioConnectResponse>;
 }
 
+export type DisconnectComposioAppResult = {
+  deleted: boolean;
+  /**
+   * True when the upstream connection was already gone (HTTP 404 from
+   * Composio) before we tried to delete it. From the user's
+   * perspective the intent is achieved either way, so we surface this
+   * as success — the caller can decide whether to whisper "already
+   * disconnected" in the UI vs. saying nothing at all.
+   *
+   * Without this, a stale localStorage cache showing a connection that
+   * Composio revoked upstream produces a misleading "Failed to
+   * disconnect (HTTP 404)" error when the user clicks Disconnect on a
+   * row that's already history.
+   */
+  alreadyGone?: boolean;
+};
+
 export async function disconnectComposioApp(
   gatewayUrl: string,
   apiKey: string,
   connectionId: string,
-): Promise<{ deleted: boolean }> {
+): Promise<DisconnectComposioAppResult> {
   const res = await gatewayFetch(
     gatewayUrl,
     apiKey,
     `/v1/composio/connections/${encodeURIComponent(connectionId)}`,
     { method: "DELETE" },
   );
+  if (res.status === 404) {
+    // Connection isn't on Composio anymore — either we revoked it on
+    // their side (dashboard, support ticket) or the OAuth provider
+    // pulled the rug. The local state needs cleaning up regardless,
+    // and the caller's `refreshIntegrationsRuntime()` will re-sync the
+    // gateway-visible truth into the rest of the app.
+    return { deleted: true, alreadyGone: true };
+  }
   if (!res.ok) {
     throw new Error(`Failed to disconnect (HTTP ${res.status})`);
   }
-  return res.json() as Promise<{ deleted: boolean }>;
+  // Some Composio responses return an empty body on successful DELETE
+  // (typical REST behaviour); fall back to a synthesized success in
+  // that case rather than surfacing "Unexpected end of JSON input".
+  const body = await res.text().catch(() => "");
+  if (!body.trim()) {
+    return { deleted: true };
+  }
+  try {
+    const parsed = JSON.parse(body) as Partial<DisconnectComposioAppResult>;
+    return { deleted: parsed.deleted ?? true };
+  } catch {
+    return { deleted: true };
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Clears local `connections.json` gmail/calendar rows when the disconnected Composio connection id matches, so background sync stops hammering a dead connection (and health UI can recover after disconnect).

Updates Composio client and execute modules with expanded unit tests.

## Scope
**Included:** `apps/web` Composio disconnect route, `composio.ts`, `composio-execute.ts`, and tests.

**Excluded (follow-up PRs to v3.0.0):** `/api/sync/*`, `sync-runner`, Dench AI gateway sync tools, workspace tabs refactor, sync health banner, CLI bootstrap.

## Verification
`cd apps/web && pnpm vitest run app/api/composio/disconnect/route.test.ts lib/composio.test.ts lib/composio-execute.test.ts`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes disconnect semantics (treating upstream 404 as success) and adds local state cleanup, which can affect integration state consistency if the matching logic is wrong, but scope is limited to Composio integration helpers and their API route.
> 
> **Overview**
> Fixes Composio disconnect behavior to be more resilient and to recover the app’s sync state: `disconnectComposioApp` now **treats HTTP 404 as successful** (`alreadyGone: true`), URL-encodes connection IDs, and tolerates empty/non-JSON DELETE responses.
> 
> The `/api/composio/disconnect` route now **clears local `connections.json` entries** for Gmail/Calendar when their stored `connectionId` matches the disconnected ID, returns a `local_cleanup` result in the response, and includes expanded unit tests covering success, validation/eligibility failures, transient gateway errors, and the `alreadyGone` path.
> 
> Improves Composio tool execution error classification by expanding `NO_CONNECTION_HINTS`, exporting `isLikelyNoConnection`, and adding tests to pin status-code gating and new “dead OAuth connection” message variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a63a832eea153779dcf301ac871fd85887b42015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->