### PR TITLE
feat: sync status/refresh, runner health, gateway tools, CLI

### DIFF
--- a/apps/web/app/api/sync/refresh/route.test.ts
+++ b/apps/web/app/api/sync/refresh/route.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Contract for the `/api/sync/refresh` endpoint shared by the agent
+ * tools (`denchclaw_refresh_sync`, `denchclaw_resync_full`) and the
+ * `SyncHealthBanner`'s "Refresh now" button.
+ *
+ * Cases pinned here:
+ *
+ *   1. Loopback host check rejects external traffic with 403, same way
+ *      `poll-tick` does.
+ *   2. Default mode is "incremental" → calls `tickPoller`, never
+ *      `startBackfill` — important so a "Refresh now" button click
+ *      doesn't accidentally re-import the user's whole mailbox.
+ *   3. `mode: "backfill"` → calls `startBackfill`. Already-running
+ *      surfaces as a 200 with `alreadyRunning: true` (intent satisfied
+ *      either way), missing Gmail connection surfaces as 409.
+ *   4. Incremental tick during an in-progress backfill is skipped, not
+ *      run twice — same semantics as `poll-tick`.
+ *   5. Missing/empty body defaults to incremental (no Content-Length
+ *      shenanigans), invalid JSON returns 400, invalid mode returns 400.
+ *   6. `tickPoller` throws → 500 with the error message surfaced.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/sync-runner", () => ({
+  tickPoller: vi.fn(async () => {}),
+  startBackfill: vi.fn(),
+  isBackfillRunning: vi.fn(() => false),
+  getLastProgressEvent: vi.fn(() => null),
+}));
+
+const { POST } = await import("./route");
+const {
+  tickPoller,
+  startBackfill,
+  isBackfillRunning,
+  getLastProgressEvent,
+} = await import("@/lib/sync-runner");
+
+const mockedTick = vi.mocked(tickPoller);
+const mockedStartBackfill = vi.mocked(startBackfill);
+const mockedBackfillRunning = vi.mocked(isBackfillRunning);
+const mockedLastEvent = vi.mocked(getLastProgressEvent);
+
+function makeRequest(opts: {
+  body?: unknown;
+  /** Pass `null` to omit the body entirely (matches `fetch(url, { method: "POST" })`). */
+  omitBody?: boolean;
+  host?: string | null;
+  forwardedHost?: string | null;
+  /** Override the JSON body with raw text (for the malformed-JSON test). */
+  rawBody?: string;
+}): Request {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (opts.host !== null) {
+    headers.set("host", opts.host ?? "127.0.0.1:3100");
+  }
+  if (opts.forwardedHost) {
+    headers.set("x-forwarded-host", opts.forwardedHost);
+  }
+  let body: string | undefined;
+  if (opts.rawBody !== undefined) {
+    body = opts.rawBody;
+  } else if (!opts.omitBody) {
+    body = JSON.stringify(opts.body ?? {});
+  }
+  return new Request("http://127.0.0.1:3100/api/sync/refresh", {
+    method: "POST",
+    headers,
+    body,
+  });
+}
+
+describe("/api/sync/refresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedBackfillRunning.mockReturnValue(false);
+    mockedLastEvent.mockReturnValue(null);
+    mockedStartBackfill.mockReturnValue({ started: true, alreadyRunning: false });
+  });
+
+  it("rejects non-loopback hosts with 403 (no work attempted)", async () => {
+    const res = await POST(makeRequest({ host: "evil.example.com" }));
+    expect(res.status).toBe(403);
+    expect(mockedTick).not.toHaveBeenCalled();
+    expect(mockedStartBackfill).not.toHaveBeenCalled();
+  });
+
+  it.each(["127.0.0.1:3100", "localhost:3100", "[::1]:3100"])(
+    "accepts loopback host %s",
+    async (host) => {
+      const res = await POST(makeRequest({ host }));
+      expect(res.status).toBe(200);
+    },
+  );
+
+  it("rejects spoofed x-forwarded-host even when host is loopback", async () => {
+    const res = await POST(
+      makeRequest({ host: "127.0.0.1:3100", forwardedHost: "evil.example.com" }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("defaults to incremental mode when body is omitted", async () => {
+    // Critical: `fetch(url, { method: "POST" })` from the UI button
+    // sends no body. The route must treat that as incremental, not
+    // accidentally fall through to backfill.
+    const res = await POST(makeRequest({ omitBody: true }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.mode).toBe("incremental");
+    expect(mockedTick).toHaveBeenCalledTimes(1);
+    expect(mockedStartBackfill).not.toHaveBeenCalled();
+  });
+
+  it("defaults to incremental mode when body is empty object", async () => {
+    const res = await POST(makeRequest({ body: {} }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.mode).toBe("incremental");
+    expect(mockedTick).toHaveBeenCalledTimes(1);
+  });
+
+  it("explicit mode: incremental calls tickPoller", async () => {
+    mockedLastEvent.mockReturnValue({
+      phase: "polling",
+      message: "Synced 2 new emails.",
+      messagesProcessed: 2,
+      peopleProcessed: 0,
+      companiesProcessed: 0,
+      threadsProcessed: 0,
+      eventsProcessed: 0,
+    });
+    const res = await POST(makeRequest({ body: { mode: "incremental" } }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.mode).toBe("incremental");
+    expect(body.lastEvent?.message).toBe("Synced 2 new emails.");
+    expect(typeof body.ranAt).toBe("string");
+    expect(mockedTick).toHaveBeenCalledTimes(1);
+    expect(mockedStartBackfill).not.toHaveBeenCalled();
+  });
+
+  it("explicit mode: backfill calls startBackfill", async () => {
+    const res = await POST(makeRequest({ body: { mode: "backfill" } }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.mode).toBe("backfill");
+    expect(body.started).toBe(true);
+    expect(mockedStartBackfill).toHaveBeenCalledTimes(1);
+    expect(mockedTick).not.toHaveBeenCalled();
+  });
+
+  it("backfill mode: already-running surfaces as 200 with alreadyRunning flag", async () => {
+    mockedBackfillRunning.mockReturnValue(true);
+    const res = await POST(makeRequest({ body: { mode: "backfill" } }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.alreadyRunning).toBe(true);
+    // Critically, we don't call startBackfill again — that would no-op,
+    // but the explicit short-circuit makes the contract obvious.
+    expect(mockedStartBackfill).not.toHaveBeenCalled();
+  });
+
+  it("backfill mode: refusal (no Gmail connection) surfaces as 409", async () => {
+    mockedStartBackfill.mockReturnValue({
+      started: false,
+      alreadyRunning: false,
+      reason: "No Gmail connection. Connect Gmail before starting the sync.",
+    });
+    const res = await POST(makeRequest({ body: { mode: "backfill" } }));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/No Gmail connection/);
+  });
+
+  it("incremental mode: skipped when a backfill is in flight", async () => {
+    // Same contract as poll-tick — the backfill will catch up the
+    // incremental window so an additional tick would be wasted work.
+    mockedBackfillRunning.mockReturnValue(true);
+    const res = await POST(makeRequest({ body: { mode: "incremental" } }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.skipped).toBe("backfill-in-progress");
+    expect(mockedTick).not.toHaveBeenCalled();
+  });
+
+  it("incremental mode: surfaces tickPoller errors as 500", async () => {
+    mockedTick.mockRejectedValueOnce(new Error("DuckDB locked"));
+    const res = await POST(makeRequest({ body: { mode: "incremental" } }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/DuckDB locked/);
+  });
+
+  it("malformed JSON body returns 400", async () => {
+    const res = await POST(
+      new Request("http://127.0.0.1:3100/api/sync/refresh", {
+        method: "POST",
+        headers: { "content-type": "application/json", host: "127.0.0.1:3100" },
+        body: "{not-json",
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/Invalid JSON/);
+  });
+
+  it("invalid mode value returns 400", async () => {
+    const res = await POST(makeRequest({ body: { mode: "nuke" } }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/Invalid mode/);
+    expect(mockedTick).not.toHaveBeenCalled();
+    expect(mockedStartBackfill).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/sync/refresh/route.ts
+++ b/apps/web/app/api/sync/refresh/route.ts
@@ -1,0 +1,208 @@
+/**
+ * Manual sync trigger — shared by the agent's `denchclaw_refresh_sync` /
+ * `denchclaw_resync_full` tools (in `extensions/dench-ai-gateway/`) and
+ * the workspace `SyncHealthBanner`'s "Refresh now" button.
+ *
+ * Why this exists alongside `/api/sync/poll-tick`:
+ *
+ * - `poll-tick` is the gateway-cron path. It demands a Bearer token
+ *   matching the Dench Cloud API key — appropriate for the long-lived
+ *   gateway daemon, but the browser can't read that key from the
+ *   workspace state directory, so a UI "Refresh now" button can't use
+ *   it.
+ * - `refresh` is the user-initiated path. Loopback-only is enough
+ *   security here: the same-origin browser is trusted (it's the user's
+ *   own machine), the gateway daemon is also loopback-local, and any
+ *   external traffic gets blocked by the host check exactly the way
+ *   `poll-tick` does it. We deliberately do NOT require a Bearer here
+ *   so the UI button can call it without smuggling secrets to the
+ *   browser.
+ *
+ * Modes:
+ *
+ * - `incremental` (default) → `tickPoller()`. Cheap; 1–2 sec on a
+ *   healthy connection. This is the "I just want my new emails" path.
+ * - `backfill` → `startBackfill()`. Heavy; can run for minutes on a
+ *   large mailbox. The "I just reconnected my Gmail / nothing's syncing
+ *   right" path. Returns immediately (`backfill` runs in the background)
+ *   so the caller doesn't block on a multi-minute SSE-driven flow.
+ *
+ * Concurrency:
+ *
+ * - `tickPoller()` is mutex-gated internally — overlapping incremental
+ *   ticks are dropped, not queued. The route still returns 200 in that
+ *   case so the UI doesn't surface a fake error when the gateway cron
+ *   happens to land in the same second as the user's button click.
+ * - `startBackfill()` is idempotent — calling it while one is already
+ *   in flight returns `{ started: false, alreadyRunning: true }` and we
+ *   surface that as `200 { ok: true, alreadyRunning: true }` so the UI
+ *   can show "already syncing".
+ */
+
+import {
+  getLastProgressEvent,
+  isBackfillRunning,
+  startBackfill,
+  tickPoller,
+} from "@/lib/sync-runner";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export type SyncRefreshMode = "incremental" | "backfill";
+
+type RefreshRequestBody = {
+  mode?: unknown;
+};
+
+/**
+ * Mirrors `isLoopbackHost` from poll-tick exactly — same threat model,
+ * same accepted hosts. Kept as a private copy rather than shared util
+ * so a defensive change to one doesn't silently widen the other.
+ */
+function isLoopbackHost(rawHost: string | null): boolean {
+  if (!rawHost) {return false;}
+  const host = rawHost.split(",")[0]?.trim().toLowerCase();
+  if (!host) {return false;}
+  let bare = host;
+  if (bare.startsWith("[")) {
+    const closing = bare.indexOf("]");
+    bare = closing > 0 ? bare.slice(1, closing) : bare;
+  } else {
+    const lastColon = bare.lastIndexOf(":");
+    if (lastColon > 0 && /^\d+$/.test(bare.slice(lastColon + 1))) {
+      bare = bare.slice(0, lastColon);
+    }
+  }
+  return (
+    bare === "localhost" ||
+    bare === "127.0.0.1" ||
+    bare === "::1" ||
+    bare.startsWith("127.")
+  );
+}
+
+function describeBadMode(raw: unknown): string {
+  if (typeof raw === "string") {return raw;}
+  if (typeof raw === "number" || typeof raw === "boolean") {return String(raw);}
+  try {
+    return JSON.stringify(raw);
+  } catch {
+    return "(unserializable)";
+  }
+}
+
+function parseMode(raw: unknown): SyncRefreshMode | { error: string } {
+  if (raw === undefined || raw === null) {return "incremental";}
+  if (raw === "incremental" || raw === "backfill") {return raw;}
+  return {
+    error: `Invalid mode "${describeBadMode(raw)}" — expected "incremental" or "backfill".`,
+  };
+}
+
+export async function POST(req: Request) {
+  const hostHeader =
+    req.headers.get("x-forwarded-host") ?? req.headers.get("host");
+  if (!isLoopbackHost(hostHeader)) {
+    return Response.json(
+      { error: "sync refresh is loopback-only" },
+      { status: 403 },
+    );
+  }
+
+  // Body is optional — a `POST` with no body defaults to incremental,
+  // which is what both the UI button and the agent's most common case
+  // want. We only error on a body that's explicitly present and
+  // malformed; an empty body silently defaults so the route is
+  // friendly to `fetch(url, { method: "POST" })` calls that don't
+  // construct a JSON literal. We read text first because
+  // `Content-Length` isn't reliably set by the WHATWG `Request`
+  // constructor used in tests, and `req.json()` on an empty body
+  // throws a confusing "Unexpected end of JSON input".
+  let body: RefreshRequestBody = {};
+  const raw = await req.text().catch(() => "");
+  if (raw.trim().length > 0) {
+    try {
+      body = JSON.parse(raw) as RefreshRequestBody;
+    } catch {
+      return Response.json({ error: "Invalid JSON body." }, { status: 400 });
+    }
+  }
+
+  const mode = parseMode(body.mode);
+  if (typeof mode === "object") {
+    return Response.json({ error: mode.error }, { status: 400 });
+  }
+
+  const ranAt = new Date().toISOString();
+
+  if (mode === "backfill") {
+    // Already-running case is success-shaped on purpose — the user's
+    // intent ("a backfill should be happening") is satisfied either
+    // way, no point making them dismiss an error toast.
+    if (isBackfillRunning()) {
+      return Response.json({
+        ok: true,
+        mode,
+        ranAt,
+        alreadyRunning: true,
+        lastEvent: getLastProgressEvent(),
+      });
+    }
+    const result = startBackfill();
+    if (!result.started) {
+      // `startBackfill` only refuses for a missing Gmail connection —
+      // surface that as 409 Conflict so the caller can prompt for OAuth
+      // instead of pretending the backfill is happening in the
+      // background.
+      return Response.json(
+        {
+          ok: false,
+          mode,
+          error: result.reason ?? "Backfill could not be started.",
+        },
+        { status: 409 },
+      );
+    }
+    return Response.json({
+      ok: true,
+      mode,
+      ranAt,
+      started: true,
+      lastEvent: getLastProgressEvent(),
+    });
+  }
+
+  // Incremental path: skip the tick if a backfill is in progress
+  // (matches `poll-tick`'s contract — the backfill will catch
+  // everything the incremental tick would have).
+  if (isBackfillRunning()) {
+    return Response.json({
+      ok: true,
+      mode,
+      ranAt,
+      skipped: "backfill-in-progress",
+      lastEvent: getLastProgressEvent(),
+    });
+  }
+
+  try {
+    await tickPoller();
+  } catch (err) {
+    return Response.json(
+      {
+        ok: false,
+        mode,
+        error: err instanceof Error ? err.message : "tickPoller failed",
+      },
+      { status: 500 },
+    );
+  }
+
+  return Response.json({
+    ok: true,
+    mode,
+    ranAt,
+    lastEvent: getLastProgressEvent(),
+  });
+}

--- a/apps/web/app/api/sync/status/route.test.ts
+++ b/apps/web/app/api/sync/status/route.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Contract for `/api/sync/status`. The endpoint fans together two
+ * independent signals — in-memory `getSyncStatus()` from `sync-runner`
+ * and on-disk `lastPolledAt` from `denchclaw-state` — into a single
+ * payload the workspace banner component polls every 60s.
+ *
+ * Cases pinned here:
+ *
+ *   1. Happy path: returns both sources with `stale: false` when the
+ *      most recent success was within the staleness window.
+ *   2. `stale: true` when no successful tick (in-memory or on-disk)
+ *      has happened in > 30min — that's the "gateway daemon crashed"
+ *      signal the banner uses to nag the operator to run
+ *      `denchclaw start`.
+ *   3. The on-disk `lastPolledAt` is honoured even when the in-memory
+ *      `lastSuccessAt` is null (= post-restart, before the first new
+ *      tick). Without this, every Next.js HMR would falsely show a
+ *      stale banner for the first 30 minutes.
+ *   4. `Cache-Control: no-store` is set so the banner reflects truth
+ *      the moment a tick succeeds/fails.
+ *   5. `serverNow` is a valid ISO timestamp so the client can use it
+ *      as the "now" reference instead of a skewed local clock.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/sync-runner", () => ({
+  getSyncStatus: vi.fn(),
+}));
+vi.mock("@/lib/denchclaw-state", () => ({
+  readSyncCursors: vi.fn(),
+}));
+
+const { GET } = await import("./route");
+const { getSyncStatus } = await import("@/lib/sync-runner");
+const { readSyncCursors } = await import("@/lib/denchclaw-state");
+
+const mockedStatus = vi.mocked(getSyncStatus);
+const mockedCursors = vi.mocked(readSyncCursors);
+
+function emptyStatus() {
+  return {
+    lastError: null,
+    lastErrorAt: null,
+    lastSuccessAt: null,
+    consecutiveFailures: 0,
+    needsReconnect: false,
+  };
+}
+
+describe("/api/sync/status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns gmail/calendar/serverNow with no-store caching", async () => {
+    mockedStatus.mockReturnValue({
+      gmail: { ...emptyStatus(), lastSuccessAt: new Date().toISOString() },
+      calendar: { ...emptyStatus(), lastSuccessAt: new Date().toISOString() },
+    });
+    mockedCursors.mockReturnValue({
+      version: 1,
+      updatedAt: new Date().toISOString(),
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    const body = await res.json();
+    expect(body.gmail).toBeDefined();
+    expect(body.calendar).toBeDefined();
+    expect(typeof body.serverNow).toBe("string");
+    // serverNow must round-trip through Date.parse without NaN —
+    // critical because the client uses it as the staleness anchor.
+    expect(Number.isFinite(Date.parse(body.serverNow))).toBe(true);
+    expect(body.gmail.stale).toBe(false);
+    expect(body.calendar.stale).toBe(false);
+  });
+
+  it("marks a source as stale when the most recent tick is > 30min old", async () => {
+    const longAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString(); // 1h ago
+    mockedStatus.mockReturnValue({
+      gmail: { ...emptyStatus(), lastSuccessAt: longAgo },
+      calendar: { ...emptyStatus() },
+    });
+    mockedCursors.mockReturnValue({
+      version: 1,
+      gmail: { lastPolledAt: longAgo },
+      calendar: { lastPolledAt: longAgo },
+      updatedAt: new Date().toISOString(),
+    });
+
+    const res = await GET();
+    const body = await res.json();
+    expect(body.gmail.stale).toBe(true);
+    expect(body.calendar.stale).toBe(true);
+  });
+
+  it("uses on-disk lastPolledAt when in-memory lastSuccessAt is null (post-restart)", async () => {
+    // Simulates a fresh Next.js process: in-memory state is empty, but
+    // the on-disk cursor reflects a recent successful poll done by an
+    // earlier process. Without honouring the cursor, the banner would
+    // false-positive "stale" for 30 minutes after every dev HMR.
+    const recent = new Date(Date.now() - 60_000).toISOString(); // 1min ago
+    mockedStatus.mockReturnValue({
+      gmail: emptyStatus(),
+      calendar: emptyStatus(),
+    });
+    mockedCursors.mockReturnValue({
+      version: 1,
+      gmail: { lastPolledAt: recent },
+      calendar: { lastPolledAt: recent },
+      updatedAt: recent,
+    });
+
+    const res = await GET();
+    const body = await res.json();
+    expect(body.gmail.stale).toBe(false);
+    expect(body.calendar.stale).toBe(false);
+    // The on-disk timestamp surfaces in the response so the client
+    // doesn't have to round-trip back to the cursor file.
+    expect(body.gmail.lastPolledAt).toBe(recent);
+    expect(body.calendar.lastPolledAt).toBe(recent);
+  });
+
+  it("never reports stale when there has never been any successful tick", async () => {
+    // First-run / pre-backfill state: no in-memory success, no cursor.
+    // We deliberately don't show "stale" here because the user simply
+    // hasn't connected anything yet — banner stays quiet until a
+    // genuine error or a long-stale tick.
+    mockedStatus.mockReturnValue({
+      gmail: emptyStatus(),
+      calendar: emptyStatus(),
+    });
+    mockedCursors.mockReturnValue({
+      version: 1,
+      updatedAt: new Date().toISOString(),
+    });
+
+    const res = await GET();
+    const body = await res.json();
+    expect(body.gmail.stale).toBe(false);
+    expect(body.calendar.stale).toBe(false);
+  });
+
+  it("propagates lastError + needsReconnect through to the response", async () => {
+    mockedStatus.mockReturnValue({
+      gmail: {
+        ...emptyStatus(),
+        lastError: "Connected account ca_xxx is not active or does not exist.",
+        lastErrorAt: new Date().toISOString(),
+        consecutiveFailures: 4,
+        needsReconnect: true,
+      },
+      calendar: emptyStatus(),
+    });
+    mockedCursors.mockReturnValue({ version: 1, updatedAt: new Date().toISOString() });
+
+    const res = await GET();
+    const body = await res.json();
+    expect(body.gmail.lastError).toMatch(/not active or does not exist/);
+    expect(body.gmail.needsReconnect).toBe(true);
+    expect(body.gmail.consecutiveFailures).toBe(4);
+  });
+});

--- a/apps/web/app/api/sync/status/route.ts
+++ b/apps/web/app/api/sync/status/route.ts
@@ -1,0 +1,84 @@
+/**
+ * Per-source sync health snapshot for the workspace UI.
+ *
+ * Returns whatever `getSyncStatus()` from `sync-runner.ts` is holding
+ * for the Gmail + Calendar incremental loops, plus a synthesized
+ * `gmailFresh` / `calendarFresh` boolean derived from the on-disk
+ * sync-cursors file. The fresh booleans let the workspace render a
+ * "we haven't successfully polled in N hours" banner even right after
+ * a process restart, before the in-memory `lastSuccessAt` has had a
+ * chance to populate from a real tick.
+ *
+ * No auth: this is workspace-local read-only state with no secrets in
+ * the response. Same threat model as `/api/onboarding/sync/progress`.
+ *
+ * Why a polling endpoint instead of SSE:
+ *
+ * - The workspace banner only needs to flip every ~minute; sub-second
+ *   updates would be over-engineering for an error state.
+ * - SSE clients leak fd's during dev hot-reload more than fetch does,
+ *   and we already pay the SSE cost in the onboarding wizard.
+ * - Polling makes it trivial to render the banner from a server
+ *   component or a /healthz curl, both of which we'd want eventually.
+ */
+
+import { getSyncStatus, type SyncSourceStatus } from "@/lib/sync-runner";
+import { readSyncCursors } from "@/lib/denchclaw-state";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+// Anything older than this counts as "stale" — the polling cron runs
+// every 5 minutes, so 30 minutes covers at least 6 ticks of slack
+// before we accuse the loop of being broken.
+const STALE_AFTER_MS = 30 * 60 * 1000;
+
+type ResponseBody = {
+  gmail: SyncSourceStatus & { lastPolledAt: string | null; stale: boolean };
+  calendar: SyncSourceStatus & { lastPolledAt: string | null; stale: boolean };
+  /**
+   * ISO timestamp of when the response was generated. The UI uses this
+   * as the "now" reference for staleness math so client clock skew
+   * doesn't show false-positive stale banners on a freshly-booted
+   * machine that hasn't NTP'd yet.
+   */
+  serverNow: string;
+};
+
+function classify(
+  status: SyncSourceStatus,
+  lastPolledAt: string | null,
+  nowMs: number,
+): SyncSourceStatus & { lastPolledAt: string | null; stale: boolean } {
+  // Use whichever signal of "still working" is most recent. The
+  // in-memory `lastSuccessAt` only spans the current Next.js process
+  // lifetime, but the on-disk `lastPolledAt` survives restarts — taking
+  // the max of both means a fresh process boot doesn't claim "stale"
+  // for 30 minutes on a workspace that's actually been polling fine.
+  const inMemoryMs = status.lastSuccessAt ? Date.parse(status.lastSuccessAt) : 0;
+  const onDiskMs = lastPolledAt ? Date.parse(lastPolledAt) : 0;
+  const newestSuccessMs = Math.max(
+    Number.isFinite(inMemoryMs) ? inMemoryMs : 0,
+    Number.isFinite(onDiskMs) ? onDiskMs : 0,
+  );
+  const stale = newestSuccessMs > 0 && nowMs - newestSuccessMs > STALE_AFTER_MS;
+  return { ...status, lastPolledAt, stale };
+}
+
+export async function GET() {
+  const status = getSyncStatus();
+  const cursors = readSyncCursors();
+  const nowMs = Date.now();
+  const body: ResponseBody = {
+    gmail: classify(status.gmail, cursors.gmail?.lastPolledAt ?? null, nowMs),
+    calendar: classify(status.calendar, cursors.calendar?.lastPolledAt ?? null, nowMs),
+    serverNow: new Date(nowMs).toISOString(),
+  };
+  return Response.json(body, {
+    headers: {
+      // Banner needs to flip the moment a tick succeeds/fails — no
+      // intermediate caching.
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/apps/web/lib/sync-runner.test.ts
+++ b/apps/web/lib/sync-runner.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Behavioural contract for the per-source sync health tracking added to
+ * `sync-runner.ts`. The motivating bug:
+ *
+ *   `tickPoller` used to swallow every Gmail/Calendar incremental
+ *   failure that wasn't a `ComposioToolNoConnectionError`. A revoked
+ *   OAuth produced a generic Composio 400 ("Connected account ... is
+ *   not active or does not exist."), which fell into the silent catch
+ *   and left the user staring at a 3-day-old inbox with no UI signal.
+ *
+ * This file pins down:
+ *
+ *   1. Successful ticks clear any prior error state and bump
+ *      `lastSuccessAt` for the affected source.
+ *   2. `ComposioToolNoConnectionError` flips `needsReconnect: true`
+ *      and emits a "Reconnect from Integrations" progress event.
+ *   3. Generic errors (HTTP 400/500/anything else) ALSO get recorded,
+ *      ALSO emit a `phase: "error"` progress event, and ALSO log to
+ *      `console.error` (the bug fix).
+ *   4. Per-source isolation: a Gmail failure doesn't bleed into
+ *      `calendar.lastError`, and vice versa.
+ *   5. Streak suppression: identical consecutive failures only log the
+ *      first occurrence (mirrors the gateway's sync-trigger pattern).
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+// All external dependencies are mocked so the test exercises only the
+// orchestration logic in `tickPoller` / `recordSync*`. Real Composio
+// calls, DuckDB writes, and FS IO are out of scope here.
+vi.mock("./denchclaw-state", () => ({
+  readConnections: vi.fn(),
+  readSyncCursors: vi.fn(),
+  writeSyncCursors: vi.fn(),
+  readPersonalDomainsOverrides: vi.fn(() => ({ add: [], remove: [] })),
+}));
+vi.mock("./gmail-sync", () => ({
+  runGmailBackfill: vi.fn(),
+  runGmailIncremental: vi.fn(),
+}));
+vi.mock("./calendar-sync", () => ({
+  runCalendarBackfill: vi.fn(),
+  runCalendarIncremental: vi.fn(),
+}));
+vi.mock("./strength-score", () => ({
+  recomputeAllScores: vi.fn(async () => {}),
+}));
+vi.mock("./workspace-schema-migrations", () => ({
+  ensureLatestSchema: vi.fn(async () => {}),
+}));
+vi.mock("./onboarding-views", () => ({
+  ensureOnboardingObjectDirs: vi.fn(),
+  installDefaultViews: vi.fn(),
+}));
+vi.mock("./people-merge", () => ({
+  mergeDuplicatePeople: vi.fn(async () => ({ rowsMerged: 0 })),
+}));
+
+const { ComposioToolNoConnectionError } = await import("./composio-execute");
+const sync = await import("./sync-runner");
+const denchclawState = await import("./denchclaw-state");
+const gmailSync = await import("./gmail-sync");
+const calendarSync = await import("./calendar-sync");
+
+const mockedConnections = vi.mocked(denchclawState.readConnections);
+const mockedCursors = vi.mocked(denchclawState.readSyncCursors);
+const mockedGmailIncr = vi.mocked(gmailSync.runGmailIncremental);
+const mockedCalIncr = vi.mocked(calendarSync.runCalendarIncremental);
+
+function defaultConnections(): import("./denchclaw-state").ConnectionsFile {
+  return {
+    version: 1,
+    gmail: {
+      connectionId: "ca_gmail",
+      toolkitSlug: "gmail",
+      connectedAt: "2026-01-01T00:00:00.000Z",
+    },
+    calendar: {
+      connectionId: "ca_cal",
+      toolkitSlug: "google-calendar",
+      connectedAt: "2026-01-01T00:00:00.000Z",
+    },
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function defaultCursors(): import("./denchclaw-state").SyncCursors {
+  return {
+    version: 1,
+    gmail: { historyId: "1000" },
+    calendar: { syncToken: "tok" },
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function gmailSummary(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    ok: true,
+    messagesProcessed: 0,
+    peopleProcessed: 0,
+    companiesProcessed: 0,
+    threadsProcessed: 0,
+    selfEmail: "me@example.com",
+    historyId: "1001",
+    pagesProcessed: 1,
+    resumedFromPageToken: false,
+    ...over,
+  } as Awaited<ReturnType<typeof gmailSync.runGmailIncremental>>;
+}
+
+function calSummary(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    ok: true,
+    eventsProcessed: 0,
+    peopleProcessed: 0,
+    pagesProcessed: 1,
+    syncToken: "tok2",
+    ...over,
+  } as Awaited<ReturnType<typeof calendarSync.runCalendarIncremental>>;
+}
+
+describe("sync-runner status tracking", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sync._resetSyncRunnerForTests();
+    mockedConnections.mockReturnValue(defaultConnections());
+    mockedCursors.mockReturnValue(defaultCursors());
+    // Silence the intentional console.error in the "first failure in a
+    // streak" code path so the test runner's terminal stays readable.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "info").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("starts with empty per-source status", () => {
+    const s = sync.getSyncStatus();
+    expect(s.gmail.lastError).toBeNull();
+    expect(s.gmail.lastSuccessAt).toBeNull();
+    expect(s.gmail.needsReconnect).toBe(false);
+    expect(s.calendar.lastError).toBeNull();
+    expect(s.calendar.consecutiveFailures).toBe(0);
+  });
+
+  it("records lastSuccessAt on a successful Gmail tick", async () => {
+    mockedGmailIncr.mockResolvedValueOnce(gmailSummary({ messagesProcessed: 0 }));
+    mockedCalIncr.mockResolvedValueOnce(calSummary({ eventsProcessed: 0 }));
+
+    await sync.tickPoller();
+    const s = sync.getSyncStatus();
+    expect(s.gmail.lastError).toBeNull();
+    expect(s.gmail.lastSuccessAt).toBeTypeOf("string");
+    expect(s.calendar.lastSuccessAt).toBeTypeOf("string");
+  });
+
+  it("records a ComposioToolNoConnectionError as needsReconnect", async () => {
+    mockedGmailIncr.mockRejectedValueOnce(
+      new ComposioToolNoConnectionError("GMAIL_FETCH_EMAILS", "no conn", ""),
+    );
+    mockedCalIncr.mockResolvedValueOnce(calSummary());
+
+    const seen: import("./sync-runner").SyncProgressEvent[] = [];
+    const unsub = sync.subscribeProgress((e) => seen.push(e));
+    await sync.tickPoller();
+    unsub();
+
+    const s = sync.getSyncStatus();
+    expect(s.gmail.needsReconnect).toBe(true);
+    expect(s.gmail.lastError).toMatch(/no conn/i);
+    expect(s.gmail.consecutiveFailures).toBe(1);
+    // Calendar was unaffected.
+    expect(s.calendar.lastError).toBeNull();
+    expect(s.calendar.lastSuccessAt).toBeTypeOf("string");
+
+    const errorEvent = seen.find((e) => e.phase === "error" && e.source === "gmail");
+    expect(errorEvent?.message).toMatch(/Reconnect from Integrations/);
+  });
+
+  it("records a generic Gmail failure (the silent-swallow bug fix)", async () => {
+    // Plain Error — NOT a ComposioToolNoConnectionError. Pre-fix this
+    // would have vanished into a dead try/catch with no log, no event,
+    // no status update. Post-fix it must log + record + emit.
+    const err = new Error('Composio HTTP 400 — "is not active or does not exist"');
+    mockedGmailIncr.mockRejectedValueOnce(err);
+    mockedCalIncr.mockResolvedValueOnce(calSummary());
+
+    const consoleErrSpy = vi.spyOn(console, "error");
+    const seen: import("./sync-runner").SyncProgressEvent[] = [];
+    const unsub = sync.subscribeProgress((e) => seen.push(e));
+    await sync.tickPoller();
+    unsub();
+
+    const s = sync.getSyncStatus();
+    expect(s.gmail.lastError).toBe(err.message);
+    expect(s.gmail.needsReconnect).toBe(false);
+    expect(s.gmail.lastSuccessAt).toBeNull(); // never had one
+    // First failure in a streak → console.error fires.
+    expect(consoleErrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[sync-runner] gmail sync failed:"),
+    );
+    // SSE listener saw a structured error event with source: "gmail".
+    const errorEvent = seen.find((e) => e.phase === "error" && e.source === "gmail");
+    expect(errorEvent?.message).toContain("Gmail sync failed");
+    expect(errorEvent?.error).toBe(err.message);
+  });
+
+  it("clears prior error state on the next successful tick", async () => {
+    mockedGmailIncr.mockRejectedValueOnce(new Error("transient 502"));
+    mockedCalIncr.mockResolvedValueOnce(calSummary());
+    await sync.tickPoller();
+    expect(sync.getSyncStatus().gmail.lastError).toMatch(/502/);
+
+    mockedGmailIncr.mockResolvedValueOnce(gmailSummary());
+    mockedCalIncr.mockResolvedValueOnce(calSummary());
+    await sync.tickPoller();
+
+    const s = sync.getSyncStatus();
+    expect(s.gmail.lastError).toBeNull();
+    expect(s.gmail.consecutiveFailures).toBe(0);
+    expect(s.gmail.lastSuccessAt).toBeTypeOf("string");
+  });
+
+  it("counts consecutive identical failures into the streak counter", async () => {
+    const sameErr = new Error("Composio HTTP 502 — bad gateway");
+    mockedGmailIncr.mockRejectedValue(sameErr);
+    mockedCalIncr.mockResolvedValue(calSummary());
+
+    const consoleErrSpy = vi.spyOn(console, "error");
+
+    await sync.tickPoller();
+    await sync.tickPoller();
+    await sync.tickPoller();
+
+    const s = sync.getSyncStatus();
+    expect(s.gmail.consecutiveFailures).toBe(3);
+    // Only the first identical failure logs (mirrors sync-trigger).
+    expect(consoleErrSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the streak counter when the failure mode changes", async () => {
+    mockedGmailIncr.mockRejectedValueOnce(new Error("HTTP 502 — bad gateway"));
+    mockedCalIncr.mockResolvedValueOnce(calSummary());
+    await sync.tickPoller();
+
+    mockedGmailIncr.mockRejectedValueOnce(new Error("HTTP 500 — different mode"));
+    mockedCalIncr.mockResolvedValueOnce(calSummary());
+    await sync.tickPoller();
+
+    expect(sync.getSyncStatus().gmail.consecutiveFailures).toBe(1);
+  });
+
+  it("isolates Gmail and Calendar failures from each other", async () => {
+    mockedGmailIncr.mockRejectedValueOnce(new Error("gmail boom"));
+    mockedCalIncr.mockRejectedValueOnce(new Error("calendar boom"));
+    await sync.tickPoller();
+
+    const s = sync.getSyncStatus();
+    expect(s.gmail.lastError).toBe("gmail boom");
+    expect(s.calendar.lastError).toBe("calendar boom");
+    // Each gets its own first-failure log line.
+    // (Asserted indirectly via streak counters being 1 for both.)
+    expect(s.gmail.consecutiveFailures).toBe(1);
+    expect(s.calendar.consecutiveFailures).toBe(1);
+  });
+
+  it("does not run Gmail incremental when no historyId is in the cursor", async () => {
+    // Backfill hasn't completed yet → no historyId → tick is a no-op for Gmail.
+    mockedCursors.mockReturnValue({
+      version: 1,
+      gmail: {},
+      calendar: { syncToken: "tok" },
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    mockedCalIncr.mockResolvedValueOnce(calSummary());
+    await sync.tickPoller();
+    expect(mockedGmailIncr).not.toHaveBeenCalled();
+    // Status stays empty for Gmail, success for Calendar.
+    expect(sync.getSyncStatus().gmail.lastError).toBeNull();
+    expect(sync.getSyncStatus().gmail.lastSuccessAt).toBeNull();
+    expect(sync.getSyncStatus().calendar.lastSuccessAt).toBeTypeOf("string");
+  });
+});

--- a/apps/web/lib/sync-runner.ts
+++ b/apps/web/lib/sync-runner.ts
@@ -65,9 +65,72 @@ export type SyncProgressEvent = {
   threadsProcessed: number;
   eventsProcessed: number;
   error?: string;
+  /** Which subsystem the error/progress is about (only set on error events
+   *  emitted by the incremental poller). Lets the UI render
+   *  source-specific banners without having to grep `message`. */
+  source?: "gmail" | "calendar";
 };
 
 type ProgressListener = (event: SyncProgressEvent) => void;
+
+// ---------------------------------------------------------------------------
+// Per-source sync health (used by the workspace UI banner + /api/sync/status)
+// ---------------------------------------------------------------------------
+
+/**
+ * Snapshot of the most recent failure/success for one source. The UI
+ * shows a sticky banner whenever `lastError` is non-null AND there
+ * hasn't been a more recent successful tick.
+ */
+export type SyncSourceStatus = {
+  /** Plain-English failure message, or null when last tick succeeded. */
+  lastError: string | null;
+  /** ISO timestamp of the most recent failure (sticky until next success). */
+  lastErrorAt: string | null;
+  /** ISO timestamp of the most recent successful tick (poll *or* backfill). */
+  lastSuccessAt: string | null;
+  /**
+   * Streak counter: how many consecutive failures we've seen with the
+   * same error key. Used by the gateway-style "first-failure-only" log
+   * suppression so logs don't fill up with identical lines every 5min.
+   */
+  consecutiveFailures: number;
+  /**
+   * True when the failure looks like an OAuth-revocation
+   * (`ComposioToolNoConnectionError`) — UI surfaces a "Reconnect"
+   * button for these instead of a generic "retry later" message.
+   */
+  needsReconnect: boolean;
+};
+
+export type SyncStatus = {
+  gmail: SyncSourceStatus;
+  calendar: SyncSourceStatus;
+};
+
+function emptyStatus(): SyncSourceStatus {
+  return {
+    lastError: null,
+    lastErrorAt: null,
+    lastSuccessAt: null,
+    consecutiveFailures: 0,
+    needsReconnect: false,
+  };
+}
+
+const syncStatus: SyncStatus = {
+  gmail: emptyStatus(),
+  calendar: emptyStatus(),
+};
+
+// Keys for the latest failure mode per source — used by the
+// "log first failure in a streak, then suppress identical repeats"
+// pattern (mirrors the gateway sync-trigger logger so a 5-min poll loop
+// against a dead Gmail OAuth doesn't spam stderr 288 times a day).
+const lastLoggedFailureKey: { gmail: string | null; calendar: string | null } = {
+  gmail: null,
+  calendar: null,
+};
 
 // ---------------------------------------------------------------------------
 // Module-singleton state
@@ -114,6 +177,103 @@ export function subscribeProgress(listener: ProgressListener): () => void {
 
 export function getLastProgressEvent(): SyncProgressEvent | null {
   return lastEvent;
+}
+
+// ---------------------------------------------------------------------------
+// Per-source status (consumed by `/api/sync/status` + workspace banner)
+// ---------------------------------------------------------------------------
+
+/**
+ * Snapshot the current per-source sync health. Returns a structural copy
+ * so callers can't mutate the singleton state by accident.
+ */
+export function getSyncStatus(): SyncStatus {
+  return {
+    gmail: { ...syncStatus.gmail },
+    calendar: { ...syncStatus.calendar },
+  };
+}
+
+/**
+ * Stringify an unknown thrown value without triggering `[object Object]`.
+ * Mirrors what the rest of the file does in the catch blocks so the
+ * streak key and the user-visible message stay consistent — diverging
+ * here would cause the dedupe logic to flap between key shapes.
+ */
+function describeError(err: unknown): string {
+  if (err instanceof Error) {return err.message;}
+  if (typeof err === "string") {return err;}
+  if (typeof err === "number" || typeof err === "boolean") {return String(err);}
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return "unknown error";
+  }
+}
+
+/**
+ * Coarse error key used for streak-based log suppression. We collapse
+ * identical Composio responses (same status + first 80 chars of message)
+ * so a stuck 5-min poll loop doesn't write the same stack to stderr
+ * every tick. Keep this stable: changing the key shape would defeat the
+ * suppression on the very next deploy after an upgrade.
+ */
+function failureKeyFor(err: unknown, kind: "no-connection" | "other"): string {
+  if (kind === "no-connection") {return "no-connection";}
+  const message = describeError(err);
+  if (err && typeof err === "object" && "status" in err) {
+    const status = (err as { status?: number }).status ?? 0;
+    return `http:${status}:${message.slice(0, 80)}`;
+  }
+  if (err instanceof Error) {return `error:${message.slice(0, 80)}`;}
+  return `unknown:${message.slice(0, 80)}`;
+}
+
+function recordSyncFailure(
+  source: "gmail" | "calendar",
+  err: unknown,
+  opts: { needsReconnect: boolean },
+): void {
+  const message = describeError(err);
+  const key = failureKeyFor(err, opts.needsReconnect ? "no-connection" : "other");
+  const previousKey = lastLoggedFailureKey[source];
+  const previous = syncStatus[source];
+  const now = new Date().toISOString();
+  syncStatus[source] = {
+    lastError: message,
+    lastErrorAt: now,
+    lastSuccessAt: previous.lastSuccessAt,
+    // Reset the counter when the failure mode changes — it's the
+    // *streak* of identical failures, not the running total of all
+    // failures since boot.
+    consecutiveFailures: previousKey === key ? previous.consecutiveFailures + 1 : 1,
+    needsReconnect: opts.needsReconnect,
+  };
+  // Mirror sync-trigger's "first failure in a streak only" logging so
+  // operators see a single line on the failure mode change but not
+  // 288 identical lines per day for a chronically-broken connection.
+  if (previousKey !== key) {
+    console.error(`[sync-runner] ${source} sync failed: ${message}`);
+  }
+  lastLoggedFailureKey[source] = key;
+}
+
+function recordSyncSuccess(source: "gmail" | "calendar"): void {
+  const previous = syncStatus[source];
+  syncStatus[source] = {
+    lastError: null,
+    lastErrorAt: null,
+    lastSuccessAt: new Date().toISOString(),
+    consecutiveFailures: 0,
+    needsReconnect: false,
+  };
+  if (previous.lastError) {
+    // Recovery line so operators can correlate "stopped failing" with a
+    // re-OAuth or upstream Composio fix, mirroring sync-trigger's
+    // recovery log.
+    console.info(`[sync-runner] ${source} sync recovered`);
+  }
+  lastLoggedFailureKey[source] = null;
 }
 
 // ---------------------------------------------------------------------------
@@ -222,15 +382,21 @@ async function runBackfillInner(options: StartBackfillOptions): Promise<void> {
         totalCompanies = summary.companiesProcessed;
         totalThreads = summary.threadsProcessed;
         selfEmail = summary.selfEmail ?? null;
+        recordSyncSuccess("gmail");
       } catch (err) {
         // Surface the full stack to stderr so dev-mode terminal shows
         // exactly where the failure happened — the SSE only carries the
         // message, which is often not enough to tell e.g. "the field map
         // came back empty" from "the Composio call returned a 4xx".
         console.error("[sync-runner] Gmail backfill failed:", err);
+        const needsReconnect = err instanceof ComposioToolNoConnectionError;
+        recordSyncFailure("gmail", err, { needsReconnect });
         emit({
           phase: "error",
-          message: `Gmail sync failed: ${(err as Error).message}`,
+          source: "gmail",
+          message: needsReconnect
+            ? "Gmail connection expired. Reconnect from Integrations."
+            : `Gmail sync failed: ${(err as Error).message}`,
           messagesProcessed: totalMessages,
           peopleProcessed: totalPeople,
           companiesProcessed: totalCompanies,
@@ -238,7 +404,7 @@ async function runBackfillInner(options: StartBackfillOptions): Promise<void> {
           eventsProcessed: totalEvents,
           error: (err as Error).message,
         });
-        if (err instanceof ComposioToolNoConnectionError) {
+        if (needsReconnect) {
           // Don't proceed to calendar if Gmail is broken — likely both
           // need a re-OAuth and the user gets a clearer error this way.
           return;
@@ -267,11 +433,17 @@ async function runBackfillInner(options: StartBackfillOptions): Promise<void> {
         });
         totalEvents = summary.eventsProcessed;
         totalPeople += summary.peopleProcessed;
+        recordSyncSuccess("calendar");
       } catch (err) {
         console.error("[sync-runner] Calendar backfill failed:", err);
+        const needsReconnect = err instanceof ComposioToolNoConnectionError;
+        recordSyncFailure("calendar", err, { needsReconnect });
         emit({
           phase: "error",
-          message: `Calendar sync failed: ${(err as Error).message}`,
+          source: "calendar",
+          message: needsReconnect
+            ? "Calendar connection expired. Reconnect from Integrations."
+            : `Calendar sync failed: ${(err as Error).message}`,
           messagesProcessed: totalMessages,
           peopleProcessed: totalPeople,
           companiesProcessed: totalCompanies,
@@ -399,6 +571,7 @@ export async function tickPoller(): Promise<void> {
           connectionId: connections.gmail.connectionId,
           startHistoryId: cursors.gmail.historyId,
         });
+        recordSyncSuccess("gmail");
         if (summary.messagesProcessed > 0) {
           didWork = true;
           emit({
@@ -414,19 +587,29 @@ export async function tickPoller(): Promise<void> {
           });
         }
       } catch (err) {
-        if (err instanceof ComposioToolNoConnectionError) {
-          // Surface the error but don't break the poller; user fixes by reconnecting.
-          emit({
-            phase: "error",
-            message: "Gmail connection expired. Reconnect from Integrations.",
-            messagesProcessed: 0,
-            peopleProcessed: 0,
-            companiesProcessed: 0,
-            threadsProcessed: 0,
-            eventsProcessed: 0,
-            error: err.message,
-          });
-        }
+        // Every failure mode (revoked OAuth, transient 5xx, malformed
+        // Composio response, DuckDB lock contention, classifier crash —
+        // all of it) gets recorded so the workspace banner can surface
+        // it. Previously only `ComposioToolNoConnectionError` made it
+        // out and everything else vanished into a dead try/catch — the
+        // single bug that hid the inbox-frozen-for-3-days symptom that
+        // motivated this overhaul.
+        const needsReconnect = err instanceof ComposioToolNoConnectionError;
+        recordSyncFailure("gmail", err, { needsReconnect });
+        const description = describeError(err);
+        emit({
+          phase: "error",
+          source: "gmail",
+          message: needsReconnect
+            ? "Gmail connection expired. Reconnect from Integrations."
+            : `Gmail sync failed: ${description}`,
+          messagesProcessed: 0,
+          peopleProcessed: 0,
+          companiesProcessed: 0,
+          threadsProcessed: 0,
+          eventsProcessed: 0,
+          error: description,
+        });
       }
     }
 
@@ -437,6 +620,7 @@ export async function tickPoller(): Promise<void> {
           syncToken: cursors.calendar.syncToken,
           selfEmail: connections.gmail?.accountEmail ?? null,
         });
+        recordSyncSuccess("calendar");
         if (summary.eventsProcessed > 0) {
           didWork = true;
           emit({
@@ -452,18 +636,22 @@ export async function tickPoller(): Promise<void> {
           });
         }
       } catch (err) {
-        if (err instanceof ComposioToolNoConnectionError) {
-          emit({
-            phase: "error",
-            message: "Calendar connection expired. Reconnect from Integrations.",
-            messagesProcessed: 0,
-            peopleProcessed: 0,
-            companiesProcessed: 0,
-            threadsProcessed: 0,
-            eventsProcessed: 0,
-            error: err.message,
-          });
-        }
+        const needsReconnect = err instanceof ComposioToolNoConnectionError;
+        recordSyncFailure("calendar", err, { needsReconnect });
+        const description = describeError(err);
+        emit({
+          phase: "error",
+          source: "calendar",
+          message: needsReconnect
+            ? "Calendar connection expired. Reconnect from Integrations."
+            : `Calendar sync failed: ${description}`,
+          messagesProcessed: 0,
+          peopleProcessed: 0,
+          companiesProcessed: 0,
+          threadsProcessed: 0,
+          eventsProcessed: 0,
+          error: description,
+        });
       }
     }
 
@@ -501,4 +689,8 @@ export function _resetSyncRunnerForTests(): void {
   lastEvent = null;
   backfillRunning = false;
   backfillPromise = null;
+  syncStatus.gmail = emptyStatus();
+  syncStatus.calendar = emptyStatus();
+  lastLoggedFailureKey.gmail = null;
+  lastLoggedFailureKey.calendar = null;
 }

--- a/apps/web/lib/workspace-sync-params.test.ts
+++ b/apps/web/lib/workspace-sync-params.test.ts
@@ -192,6 +192,20 @@ describe("buildWorkspaceSyncParams core behavior", () => {
     expect(params.get("pageSize")).toBe("25");
   });
 
+  it("drops object-view params when activePath changes (prevents stale view across tables)", () => {
+    const current = new URLSearchParams(
+      "path=tableA&view=Active&filters=e30%3D&cols=name,status&viewType=kanban&sort=W10%3D&page=2&pageSize=25&search=acme",
+    );
+    const params = buildWorkspaceSyncParams(
+      defaultState({ activePath: "tableB" }),
+      current,
+    );
+    expect(params.get("path")).toBe("tableB");
+    for (const k of ["view", "filters", "cols", "viewType", "sort", "page", "pageSize", "search"]) {
+      expect(params.has(k)).toBe(false);
+    }
+  });
+
   it("does not carry object-view params in chat mode", () => {
     const current = new URLSearchParams("viewType=kanban&search=acme");
     const params = buildWorkspaceSyncParams(

--- a/extensions/dench-ai-gateway/index.test.ts
+++ b/extensions/dench-ai-gateway/index.test.ts
@@ -38,9 +38,10 @@ function writeWebRuntimeProcessFile(stateDir: string, port: number): void {
  * Build a minimal plugin api shim with optional sync-trigger config.
  * Mirrors the shape `dench-ai-gateway/index.ts`'s `register()` reads.
  */
-function createSyncTriggerApi(params?: {
-  syncTrigger?: Record<string, unknown> | null;
-}): { api: any; logs: string[] } {
+function createSyncTriggerApi(params?: { syncTrigger?: Record<string, unknown> | null }): {
+  api: any;
+  logs: string[];
+} {
   const logs: string[] = [];
   const api: any = {
     config: {
@@ -50,9 +51,7 @@ function createSyncTriggerApi(params?: {
             config: {
               enabled: true,
               gatewayUrl: "https://gateway.example.com",
-              ...(params?.syncTrigger !== null
-                ? { syncTrigger: params?.syncTrigger ?? {} }
-                : {}),
+              ...(params?.syncTrigger !== null ? { syncTrigger: params?.syncTrigger ?? {} } : {}),
             },
           },
         },
@@ -186,13 +185,23 @@ describe("dench-ai-gateway composio bridge", () => {
 
     expect(providers).toHaveLength(1);
     expect(services).toHaveLength(1);
-    expect(tools.map((tool) => tool.name)).toEqual(["dench_execute_integrations"]);
+    // Use arrayContaining so this test stays meaningful when other
+    // tools (e.g. denchclaw_refresh_sync, denchclaw_resync_full) are
+    // added in the same `register()` pass — we only care here that the
+    // composio bridge tool is among them.
+    expect(tools.map((tool) => tool.name)).toEqual(
+      expect.arrayContaining(["dench_execute_integrations"]),
+    );
     expect(api.config.mcp).toBeUndefined();
     expect(info).toHaveBeenCalledWith(
       "[dench-ai-gateway] registered dench_execute_integrations bridge tool",
     );
 
-    const result = await tools[0].execute("call-1", {
+    const bridgeTool = tools.find(
+      (tool: { name: string }) => tool.name === "dench_execute_integrations",
+    );
+    expect(bridgeTool).toBeDefined();
+    const result = await bridgeTool.execute("call-1", {
       tool_slug: "GMAIL_FETCH_EMAILS",
       arguments: {
         label_ids: ["INBOX"],
@@ -220,9 +229,15 @@ describe("dench-ai-gateway composio bridge", () => {
     const { api, tools } = createApi();
     register(api);
 
-    expect(tools).toHaveLength(1);
-    expect(tools[0].name).toBe("dench_execute_integrations");
-    expect(tools[0].parameters).toMatchObject({
+    // The composio bridge tool is one of several tools that may be
+    // registered in `register()` — assert specifically on it by name
+    // rather than by count, so additions like the sync refresh tools
+    // don't cause false-positive failures here.
+    const bridgeTool = tools.find(
+      (tool: { name: string }) => tool.name === "dench_execute_integrations",
+    );
+    expect(bridgeTool).toBeDefined();
+    expect(bridgeTool.parameters).toMatchObject({
       type: "object",
       additionalProperties: false,
       required: ["tool_slug"],
@@ -671,9 +686,7 @@ describe("dench-ai-gateway sync-trigger", () => {
     writeAuthProfiles(stateDir, "dc-key");
 
     let status = 404;
-    const fetchMock = vi.fn(
-      async () => new Response("err", { status }),
-    ) as unknown as typeof fetch;
+    const fetchMock = vi.fn(async () => new Response("err", { status })) as unknown as typeof fetch;
     globalThis.fetch = fetchMock;
     const { api, logs } = createSyncTriggerApi({
       syncTrigger: { intervalMs: 5000 },
@@ -741,5 +754,256 @@ describe("dench-ai-gateway sync-trigger", () => {
 
     const timeoutLogs = logs.filter((m) => m.includes("timed out"));
     expect(timeoutLogs).toHaveLength(1);
+  });
+});
+
+/**
+ * Sync refresh tools (`denchclaw_refresh_sync`, `denchclaw_resync_full`)
+ * — the user-facing escape hatch when someone says "refresh my inbox"
+ * mid-conversation. Pinned here because:
+ *
+ *   1. They MUST register only when a Dench Cloud key is present —
+ *      without it the underlying `tickPoller` can't talk to Composio
+ *      and the tools would just return errors.
+ *   2. They MUST hit `/api/sync/refresh` (not the older Bearer-gated
+ *      `/api/sync/poll-tick`) — otherwise the UI button and the tool
+ *      diverge and bug-fixing one ignores the other.
+ *   3. The tool descriptions matter to the model — a wording change
+ *      should be deliberate, so we pin the "incremental"/"backfill"
+ *      verbiage at the test level.
+ */
+describe("dench-ai-gateway sync refresh tools", () => {
+  const originalFetch = globalThis.fetch;
+  const originalStateDir = process.env.OPENCLAW_STATE_DIR;
+  let stateDir: string | undefined;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+    if (stateDir) {
+      rmSync(stateDir, { recursive: true, force: true });
+      stateDir = undefined;
+    }
+    if (originalStateDir !== undefined) {
+      process.env.OPENCLAW_STATE_DIR = originalStateDir;
+    } else {
+      delete process.env.OPENCLAW_STATE_DIR;
+    }
+    _resetSyncTriggerForTests();
+  });
+
+  it("registers both refresh tools when a Dench Cloud key is present", () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "dench-ai-gateway-refresh-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+
+    const { api, tools, info } = createApi();
+    register(api);
+
+    const names = tools.map((tool: { name: string }) => tool.name);
+    expect(names).toEqual(
+      expect.arrayContaining(["denchclaw_refresh_sync", "denchclaw_resync_full"]),
+    );
+    expect(info).toHaveBeenCalledWith(expect.stringContaining("registered sync refresh tools"));
+  });
+
+  it("does NOT register refresh tools when no Dench Cloud key is configured", () => {
+    // Same threat model as the gateway sync trigger: without a key,
+    // the underlying `tickPoller` can't authenticate against Composio,
+    // so exposing the tools would just produce a confusing 401 → 5xx
+    // chain in chat. Better to omit them entirely.
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "dench-ai-gateway-refresh-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    delete process.env.DENCH_CLOUD_API_KEY;
+    delete process.env.DENCH_API_KEY;
+    // Deliberately NOT calling writeAuthProfiles → no key.
+
+    const { api, tools, info } = createApi();
+    register(api);
+
+    const names = tools.map((tool: { name: string }) => tool.name);
+    expect(names).not.toContain("denchclaw_refresh_sync");
+    expect(names).not.toContain("denchclaw_resync_full");
+    expect(info).not.toHaveBeenCalledWith(expect.stringContaining("sync refresh tools"));
+  });
+
+  it("denchclaw_refresh_sync executes against /api/sync/refresh with mode incremental", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "dench-ai-gateway-refresh-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+    // Pin a known port so the URL assertion is deterministic.
+    writeWebRuntimeProcessFile(stateDir, 31000);
+
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            mode: "incremental",
+            ranAt: "2026-04-22T01:00:00.000Z",
+            lastEvent: {
+              phase: "polling",
+              message: "Synced 3 new emails.",
+              messagesProcessed: 3,
+              eventsProcessed: 0,
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    ) as typeof fetch;
+    globalThis.fetch = fetchMock;
+
+    const { api, tools } = createApi();
+    register(api);
+    const refreshTool = tools.find(
+      (tool: { name: string }) => tool.name === "denchclaw_refresh_sync",
+    );
+    expect(refreshTool).toBeDefined();
+
+    const result = await refreshTool.execute("call-1", {});
+
+    // URL pulls from the process.json port we wrote; body is the
+    // explicit incremental discriminator the route expects.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = (fetchMock as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(url).toBe("http://127.0.0.1:31000/api/sync/refresh");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body ?? "{}"))).toEqual({ mode: "incremental" });
+
+    // The text the agent reads back should summarize the work done so
+    // it can paraphrase to the user. We assert on the substance, not
+    // the exact wording, to keep the test resilient to minor copy edits.
+    expect(result.content[0]?.text).toMatch(/3 new email/);
+    expect(result.details).toMatchObject({
+      mode: "incremental",
+      response: expect.objectContaining({ ok: true, mode: "incremental" }),
+    });
+  });
+
+  it("denchclaw_resync_full executes against /api/sync/refresh with mode backfill", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "dench-ai-gateway-refresh-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+    writeWebRuntimeProcessFile(stateDir, 31000);
+
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            mode: "backfill",
+            ranAt: "2026-04-22T01:00:00.000Z",
+            started: true,
+            lastEvent: null,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    ) as typeof fetch;
+    globalThis.fetch = fetchMock;
+
+    const { api, tools } = createApi();
+    register(api);
+    const resyncTool = tools.find(
+      (tool: { name: string }) => tool.name === "denchclaw_resync_full",
+    );
+    expect(resyncTool).toBeDefined();
+
+    const result = await resyncTool.execute("call-1", {});
+
+    const [url, init] = (fetchMock as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(url).toBe("http://127.0.0.1:31000/api/sync/refresh");
+    expect(JSON.parse(String(init?.body ?? "{}"))).toEqual({ mode: "backfill" });
+    expect(result.content[0]?.text).toMatch(/[Bb]ackfill started/);
+    expect(result.details).toMatchObject({ mode: "backfill" });
+  });
+
+  it("surfaces a route 4xx as a structured error rather than throwing", async () => {
+    // Critical: tool errors must be returned as content, not exceptions
+    // — the agent runner can't recover from a thrown error mid-tool-call
+    // and we want a graceful "Refresh failed: <reason>" instead.
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "dench-ai-gateway-refresh-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            ok: false,
+            error: "No Gmail connection. Connect Gmail before starting the sync.",
+          }),
+          { status: 409, headers: { "content-type": "application/json" } },
+        ),
+    ) as typeof fetch;
+
+    const { api, tools } = createApi();
+    register(api);
+    const resyncTool = tools.find(
+      (tool: { name: string }) => tool.name === "denchclaw_resync_full",
+    );
+
+    const result = await resyncTool.execute("call-1", {});
+    expect(result.details).toMatchObject({ status: "error", httpStatus: 409 });
+    expect(result.content[0]?.text).toContain("No Gmail connection");
+  });
+
+  it("surfaces a network error as a structured error", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "dench-ai-gateway-refresh-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as typeof fetch;
+
+    const { api, tools } = createApi();
+    register(api);
+    const refreshTool = tools.find(
+      (tool: { name: string }) => tool.name === "denchclaw_refresh_sync",
+    );
+
+    const result = await refreshTool.execute("call-1", {});
+    expect(result.details).toMatchObject({ status: "error" });
+    expect(result.content[0]?.text).toContain("ECONNREFUSED");
+  });
+
+  it("describes both tools clearly enough for the model to pick the right one", () => {
+    // The descriptions are the model's only signal for which tool to
+    // call when a user says "refresh sync." Pin a few key phrases so
+    // accidental wording drift in a refactor doesn't silently regress
+    // tool selection.
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "dench-ai-gateway-refresh-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+
+    const { api, tools } = createApi();
+    register(api);
+
+    const refreshTool = tools.find(
+      (tool: { name: string }) => tool.name === "denchclaw_refresh_sync",
+    );
+    const resyncTool = tools.find(
+      (tool: { name: string }) => tool.name === "denchclaw_resync_full",
+    );
+
+    expect(refreshTool.description).toMatch(/incremental/i);
+    expect(refreshTool.description).toMatch(/refresh|sync now|new emails/i);
+    expect(resyncTool.description).toMatch(/full|backfill|re-?import/i);
+    expect(resyncTool.description).toMatch(/heavi(er|est)|background/i);
+
+    // Schemas: zero parameters for both — the agent picks the tool by
+    // name, not by passing a `mode`. Allowing a mode would let the
+    // model paint itself into "I'll just always call refresh with
+    // mode='backfill'" corners.
+    expect(refreshTool.parameters).toMatchObject({
+      type: "object",
+      additionalProperties: false,
+      properties: {},
+    });
+    expect(resyncTool.parameters).toMatchObject({
+      type: "object",
+      additionalProperties: false,
+      properties: {},
+    });
   });
 });

--- a/extensions/dench-ai-gateway/index.ts
+++ b/extensions/dench-ai-gateway/index.ts
@@ -1,3 +1,4 @@
+import { readDenchAuthProfileKey } from "../shared/dench-auth.js";
 import { registerDenchIntegrationsBridge } from "./composio-bridge.js";
 import { buildDenchCloudConfigPatch, buildDenchCloudProviderConfig } from "./config-patch.js";
 import {
@@ -11,6 +12,7 @@ import {
   resolveDenchCloudModel,
   type DenchCloudCatalogModel,
 } from "./models.js";
+import { registerSyncRefreshTools } from "./sync-refresh-tools.js";
 import { armSyncTrigger } from "./sync-trigger.js";
 export { buildDenchCloudConfigPatch } from "./config-patch.js";
 
@@ -308,6 +310,18 @@ export default function register(api: any) {
   // and web-runtime restarts. No-op when no Dench Cloud key is present
   // or when `syncTrigger.enabled` is explicitly disabled in plugin config.
   armSyncTrigger(api);
+
+  // Register on-demand sync tools the agent can call when the user
+  // asks for a manual refresh. Gated on the same key check as
+  // `armSyncTrigger`: without a Dench Cloud key, the underlying
+  // sync runner can't talk to Composio, so exposing the tools would
+  // just produce confusing failures.
+  if (typeof api?.registerTool === "function" && readDenchAuthProfileKey()) {
+    const registered = registerSyncRefreshTools(api);
+    api.logger?.info?.(
+      `[dench-ai-gateway] registered sync refresh tools: ${registered.join(", ")}`,
+    );
+  }
 
   api.registerService({
     id: "dench-ai-gateway",

--- a/extensions/dench-ai-gateway/models.ts
+++ b/extensions/dench-ai-gateway/models.ts
@@ -117,9 +117,32 @@ export function buildDenchGatewayCatalogUrl(gatewayUrl: string | undefined): str
   return `${normalizeDenchGatewayUrl(gatewayUrl)}/v1/public/models`;
 }
 
-export const RECOMMENDED_DENCH_CLOUD_MODEL_ID = "claude-opus-4.6";
+export const RECOMMENDED_DENCH_CLOUD_MODEL_ID = "kimi-k2.5";
 
 export const FALLBACK_DENCH_CLOUD_MODELS: DenchCloudCatalogModel[] = [
+  {
+    id: "kimi-k2.5",
+    stableId: "moonshotai.kimi-k2.5",
+    displayName: "Kimi K2.5",
+    provider: "moonshot",
+    transportProvider: "bedrock",
+    api: "openai-responses",
+    input: ["text", "image"],
+    reasoning: true,
+    contextWindow: 262000,
+    maxTokens: 64000,
+    supportsStreaming: true,
+    supportsImages: true,
+    supportsResponses: true,
+    supportsReasoning: true,
+    cost: {
+      input: markupCost(0.6),
+      output: markupCost(3),
+      cacheRead: 0,
+      cacheWrite: 0,
+      marginPercent: DEFAULT_DENCH_CLOUD_MARGIN_PERCENT,
+    },
+  },
   {
     id: "claude-opus-4.6",
     stableId: "anthropic.claude-opus-4-6-v1",

--- a/extensions/dench-ai-gateway/sync-refresh-tools.ts
+++ b/extensions/dench-ai-gateway/sync-refresh-tools.ts
@@ -1,0 +1,248 @@
+/**
+ * Two callable agent tools that let the user (via the chat agent) ask
+ * for an immediate Gmail/Calendar sync without waiting for the gateway
+ * cron's next 5-minute tick:
+ *
+ *   - `denchclaw_refresh_sync`  → cheap incremental tick (`tickPoller`).
+ *   - `denchclaw_resync_full`   → full backfill (`startBackfill`).
+ *
+ * Both tools POST to the workspace's `/api/sync/refresh` route, which
+ * is loopback-only and unauthenticated by design (see the route file
+ * for the threat-model rationale). The route is also what the
+ * `SyncHealthBanner`'s "Refresh now" button calls, so we have a single
+ * code path for "user-initiated sync."
+ *
+ * Why two tools instead of one tool with a `mode` parameter:
+ *   The model picks tools by name + description. Two narrow tools with
+ *   targeted descriptions ("incremental, fast" vs "full re-import,
+ *   heavy") make the agent's decision crisp; one tool with a `mode`
+ *   parameter would need the agent to reason about both the name and
+ *   the parameter on every call, which empirically leads to occasional
+ *   wrong-mode invocations.
+ *
+ * The execute handlers return short, human-readable text content so the
+ * agent can repeat the result back to the user verbatim ("Synced 3 new
+ * emails." / "Backfill started — N messages so far.").
+ */
+
+import type { AnyAgentTool } from "openclaw/plugin-sdk";
+import { resolveSyncTriggerConfig, resolveWebBaseUrl } from "./sync-trigger.js";
+
+const REFRESH_TOOL_NAME = "denchclaw_refresh_sync";
+const RESYNC_TOOL_NAME = "denchclaw_resync_full";
+const REFRESH_TIMEOUT_MS = 30_000;
+// Backfill returns immediately (background work) but `startBackfill`
+// itself acquires the runner mutex synchronously, so we still want a
+// generous timeout in case the schema-migration step at the front is
+// slow on a cold workspace.
+const RESYNC_TIMEOUT_MS = 60_000;
+
+type UnknownRecord = Record<string, unknown>;
+
+/**
+ * Shape returned by `/api/sync/refresh` on success. Loose because the
+ * route may add fields over time (e.g. `alreadyRunning`, `skipped`,
+ * `started`); we surface anything we receive without strictly typing
+ * every variant.
+ */
+type RefreshResponse = {
+  ok?: boolean;
+  mode?: "incremental" | "backfill";
+  ranAt?: string;
+  lastEvent?: {
+    phase?: string;
+    message?: string;
+    messagesProcessed?: number;
+    peopleProcessed?: number;
+    companiesProcessed?: number;
+    threadsProcessed?: number;
+    eventsProcessed?: number;
+    error?: string;
+    source?: "gmail" | "calendar";
+  } | null;
+  alreadyRunning?: boolean;
+  started?: boolean;
+  skipped?: string;
+  error?: string;
+};
+
+const REFRESH_PARAMETERS = {
+  type: "object",
+  additionalProperties: false,
+  properties: {},
+} as const;
+
+function jsonResult(payload: unknown, details?: Record<string, unknown>) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+    details: details ?? (payload as Record<string, unknown>),
+  };
+}
+
+/**
+ * Build a one-line summary of a refresh response. Used as the `text`
+ * the agent reads back. We keep this terse on purpose — the agent
+ * will paraphrase, and a long blob would just bloat its context.
+ */
+function summarize(mode: "incremental" | "backfill", body: RefreshResponse): string {
+  if (body.ok === false) {
+    return `Sync ${mode} failed: ${body.error ?? "unknown error"}`;
+  }
+  if (body.alreadyRunning) {
+    return `A ${mode} sync is already running — no new tick started.`;
+  }
+  if (body.skipped === "backfill-in-progress") {
+    return "Skipped incremental tick because a full backfill is currently in progress.";
+  }
+  const evt = body.lastEvent;
+  if (evt?.phase === "error") {
+    return `Sync ${mode} reported an error: ${evt.error ?? evt.message ?? "unknown"}`;
+  }
+  if (mode === "incremental") {
+    const newMessages = evt?.messagesProcessed ?? 0;
+    const newEvents = evt?.eventsProcessed ?? 0;
+    if (newMessages === 0 && newEvents === 0) {
+      return "Incremental sync ran — no new emails or calendar events since the last tick.";
+    }
+    const parts: string[] = [];
+    if (newMessages > 0) {
+      parts.push(`${newMessages} new email${newMessages === 1 ? "" : "s"}`);
+    }
+    if (newEvents > 0) {
+      parts.push(`${newEvents} new event${newEvents === 1 ? "" : "s"}`);
+    }
+    return `Synced ${parts.join(" and ")}.`;
+  }
+  // backfill
+  if (body.started) {
+    return "Full backfill started — Gmail and Calendar are re-importing in the background.";
+  }
+  return "Full backfill request acknowledged.";
+}
+
+async function callRefreshRoute(
+  webBaseUrl: string,
+  mode: "incremental" | "backfill",
+  timeoutMs: number,
+): Promise<{ status: number; body: RefreshResponse }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${webBaseUrl}/api/sync/refresh`, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json" },
+      body: JSON.stringify({ mode }),
+      signal: controller.signal,
+    });
+    const text = await res.text();
+    let body: RefreshResponse = {};
+    if (text.trim()) {
+      try {
+        body = JSON.parse(text) as RefreshResponse;
+      } catch {
+        body = { error: text.slice(0, 240) };
+      }
+    }
+    return { status: res.status, body };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Build the `denchclaw_refresh_sync` tool — the lightweight incremental
+ * tick. Equivalent to one beat of the gateway's 5-min cron, but on
+ * demand.
+ */
+export function createRefreshSyncTool(api: any): AnyAgentTool {
+  const webBaseUrl = resolveWebBaseUrl(api, resolveSyncTriggerConfig(api));
+  return {
+    name: REFRESH_TOOL_NAME,
+    label: "Refresh Gmail/Calendar sync",
+    description:
+      "Trigger an incremental Gmail and Calendar sync tick right now. Use this when the user asks to refresh, sync now, pull new emails, or check whether anything new has arrived. Cheap and fast (1-2 seconds). For a full re-import use denchclaw_resync_full instead.",
+    parameters: REFRESH_PARAMETERS,
+    async execute(_toolCallId: string, _input: UnknownRecord) {
+      try {
+        const { status, body } = await callRefreshRoute(
+          webBaseUrl,
+          "incremental",
+          REFRESH_TIMEOUT_MS,
+        );
+        if (status >= 400) {
+          return jsonResult(
+            {
+              error: body.error ?? `Refresh failed (HTTP ${status}).`,
+              mode: "incremental",
+            },
+            { status: "error", httpStatus: status },
+          );
+        }
+        return {
+          content: [{ type: "text" as const, text: summarize("incremental", body) }],
+          details: { mode: "incremental", response: body },
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return jsonResult(
+          { error: `Refresh request failed: ${message}`, mode: "incremental" },
+          { status: "error" },
+        );
+      }
+    },
+  } as AnyAgentTool;
+}
+
+/**
+ * Build the `denchclaw_resync_full` tool — full Gmail + Calendar
+ * backfill. Heavier than the incremental tick; expected use cases are
+ * "I just reconnected my Gmail account" or "incremental refresh isn't
+ * catching what I'm seeing in Gmail."
+ */
+export function createResyncFullTool(api: any): AnyAgentTool {
+  const webBaseUrl = resolveWebBaseUrl(api, resolveSyncTriggerConfig(api));
+  return {
+    name: RESYNC_TOOL_NAME,
+    label: "Full Gmail/Calendar resync",
+    description:
+      "Trigger a full Gmail and Calendar backfill — re-imports messages and events from scratch. Use this only when the user explicitly asks for a full resync, after they have reconnected an account, or when the incremental refresh (denchclaw_refresh_sync) repeatedly fails to surface messages they expect to see. Heavier than incremental sync; runs in the background.",
+    parameters: REFRESH_PARAMETERS,
+    async execute(_toolCallId: string, _input: UnknownRecord) {
+      try {
+        const { status, body } = await callRefreshRoute(webBaseUrl, "backfill", RESYNC_TIMEOUT_MS);
+        if (status >= 400) {
+          return jsonResult(
+            {
+              error: body.error ?? `Resync failed (HTTP ${status}).`,
+              mode: "backfill",
+            },
+            { status: "error", httpStatus: status },
+          );
+        }
+        return {
+          content: [{ type: "text" as const, text: summarize("backfill", body) }],
+          details: { mode: "backfill", response: body },
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return jsonResult(
+          { error: `Resync request failed: ${message}`, mode: "backfill" },
+          { status: "error" },
+        );
+      }
+    },
+  } as AnyAgentTool;
+}
+
+/**
+ * Register both tools on the OpenClaw plugin API. Idempotent only via
+ * the caller — usually invoked once from the plugin's `register`
+ * function. Returns the tool names so the caller can log them.
+ */
+export function registerSyncRefreshTools(api: any): string[] {
+  const refresh = createRefreshSyncTool(api);
+  const resync = createResyncFullTool(api);
+  api.registerTool(refresh);
+  api.registerTool(resync);
+  return [refresh.name, resync.name];
+}

--- a/extensions/dench-ai-gateway/sync-trigger.ts
+++ b/extensions/dench-ai-gateway/sync-trigger.ts
@@ -44,8 +44,8 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
-import path from "node:path";
 import { homedir } from "node:os";
+import path from "node:path";
 import { readDenchAuthProfileKey } from "../shared/dench-auth.js";
 
 type UnknownRecord = Record<string, unknown>;
@@ -69,10 +69,16 @@ function readNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
-function resolveSyncTriggerConfig(api: any): UnknownRecord | undefined {
-  const pluginConfig = asRecord(
-    asRecord(asRecord(api?.config)?.plugins)?.entries,
-  )?.["dench-ai-gateway"];
+/**
+ * Exported so sibling code (e.g. `sync-refresh-tools.ts`) can read the
+ * same `syncTrigger.*` config block without re-implementing the
+ * three-deep `plugins.entries["dench-ai-gateway"].config.syncTrigger`
+ * lookup. Re-exported for symmetry; not part of any public-facing API.
+ */
+export function resolveSyncTriggerConfig(api: any): UnknownRecord | undefined {
+  const pluginConfig = asRecord(asRecord(asRecord(api?.config)?.plugins)?.entries)?.[
+    "dench-ai-gateway"
+  ];
   return asRecord(asRecord(pluginConfig)?.config?.["syncTrigger"] as unknown);
 }
 
@@ -104,7 +110,20 @@ function resolveWebPortFromProcessFile(stateDir: string): number | undefined {
   }
 }
 
-function resolveWebBaseUrl(api: any, syncTriggerConfig: UnknownRecord | undefined): string {
+/**
+ * Resolve where the Next.js web app is listening, in this priority:
+ *
+ *   1. Plugin config `syncTrigger.webBaseUrl` (explicit override).
+ *   2. `DENCHCLAW_WEB_BASE_URL` env (test / dev override).
+ *   3. `<stateDir>/web-runtime/process.json#port` (managed-runtime sidecar).
+ *   4. Default `http://127.0.0.1:3100`.
+ *
+ * Exported so sibling tools (e.g. `denchclaw_refresh_sync`) hit the
+ * exact same URL as the cron, rather than independently re-deriving
+ * the port and risking a drift where one of them targets a stale
+ * default.
+ */
+export function resolveWebBaseUrl(api: any, syncTriggerConfig: UnknownRecord | undefined): string {
   const fromConfig = readString(syncTriggerConfig?.webBaseUrl);
   if (fromConfig) {
     return fromConfig.replace(/\/$/, "");
@@ -184,17 +203,13 @@ export function armSyncTrigger(api: any): void {
 
   const config = resolveSyncTriggerConfig(api);
   if (config?.enabled === false) {
-    api?.logger?.info?.(
-      "[dench-ai-gateway] sync-trigger disabled via syncTrigger.enabled=false",
-    );
+    api?.logger?.info?.("[dench-ai-gateway] sync-trigger disabled via syncTrigger.enabled=false");
     return;
   }
 
   const apiKey = readDenchAuthProfileKey();
   if (!apiKey) {
-    api?.logger?.info?.(
-      "[dench-ai-gateway] No Dench Cloud API key; sync trigger not armed.",
-    );
+    api?.logger?.info?.("[dench-ai-gateway] No Dench Cloud API key; sync trigger not armed.");
     return;
   }
 
@@ -237,11 +252,8 @@ export function armSyncTrigger(api: any): void {
       // fires; surface it as a distinct timeout outcome so streak logging
       // can collapse it independently of plain network errors.
       const aborted =
-        err instanceof Error &&
-        (err.name === "AbortError" || /aborted/i.test(message));
-      outcome = aborted
-        ? { kind: "timeout" }
-        : { kind: "network", message };
+        err instanceof Error && (err.name === "AbortError" || /aborted/i.test(message));
+      outcome = aborted ? { kind: "timeout" } : { kind: "network", message };
     } finally {
       clearTimeout(timeoutHandle);
     }
@@ -250,9 +262,7 @@ export function armSyncTrigger(api: any): void {
     const wasFailing = lastOutcomeKey !== "ok";
     if (outcome.kind === "ok") {
       if (wasFailing) {
-        api?.logger?.info?.(
-          `[dench-ai-gateway] sync-trigger recovered (was: ${lastOutcomeKey})`,
-        );
+        api?.logger?.info?.(`[dench-ai-gateway] sync-trigger recovered (was: ${lastOutcomeKey})`);
       }
     } else if (key !== lastOutcomeKey) {
       // First failure in a streak (or failure mode changed). Log it.
@@ -272,9 +282,7 @@ export function armSyncTrigger(api: any): void {
   }, intervalMs);
 
   _armed = true;
-  api?.logger?.info?.(
-    `[dench-ai-gateway] sync-trigger armed (every ${intervalMs}ms → ${tickUrl})`,
-  );
+  api?.logger?.info?.(`[dench-ai-gateway] sync-trigger armed (every ${intervalMs}ms → ${tickUrl})`);
 }
 
 /**

--- a/extensions/dench-identity/index.ts
+++ b/extensions/dench-identity/index.ts
@@ -2046,6 +2046,12 @@ For multi-session projects, write a session handoff summary to \`${workspaceDir}
 - **Never** use \`gog\` for Gmail/Calendar/Drive when ${DENCH_INTEGRATIONS_DISPLAY_NAME} is connected or the user mentions the connected-app layer/rube/map/MCP. \`gog\` is a fallback only when the user explicitly asks for it or the integration layer is unavailable.
 
 ${composioGuidance ? `\n${composioGuidance}\n` : ""}
+## Sync controls
+
+Gmail and Calendar are kept fresh by a background poll every ~5 minutes. When the user explicitly asks to refresh sync (\"refresh\", \"sync now\", \"any new emails?\", \"pull latest\", \"my inbox looks stale\"), call \`denchclaw_refresh_sync\` to run an immediate incremental tick — fast (1-2 seconds) and surfaces a one-line summary of what was synced.
+
+Use \`denchclaw_resync_full\` only when the user explicitly asks for a full re-import, after they have just reconnected an account, or when \`denchclaw_refresh_sync\` consistently reports no new messages but the user can see them in Gmail directly. Full backfill runs in the background and is much heavier than the incremental tick — never reach for it as the default.
+
 ## Links
 
 - Website: https://denchclaw.com

--- a/src/cli/bootstrap-external.ts
+++ b/src/cli/bootstrap-external.ts
@@ -42,6 +42,7 @@ import {
   type DenchCloudCatalogModel,
 } from "./dench-cloud.js";
 import { applyCliProfileEnv } from "./profile.js";
+import { kickoffSyncPoll, summarizeKickoffSyncPoll } from "./sync-poll.js";
 import {
   DEFAULT_WEB_APP_PORT,
   ensureManagedWebRuntime,
@@ -49,7 +50,6 @@ import {
   resolveProfileStateDir,
   waitForWebRuntime,
 } from "./web-runtime.js";
-import { kickoffSyncPoll, summarizeKickoffSyncPoll } from "./sync-poll.js";
 import { seedWorkspaceFromAssets, type WorkspaceSeedResult } from "./workspace-seed.js";
 
 const DEFAULT_DENCHCLAW_PROFILE = "dench";
@@ -1106,18 +1106,7 @@ async function runOpenClawInteractiveOrThrow(params: {
   /** Grace between SIGTERM and SIGKILL. Default 5s. */
   sigtermGraceMs?: number;
 }): Promise<SpawnResult> {
-  // #region debug-e2e66e: H1/H2 — confirm onboard subprocess spawn + lifetime
-  const _dbgStart = Date.now();
-  fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H1+H2',location:'bootstrap-external.ts:runOpenClawInteractiveOrThrow:start',message:'spawning interactive openclaw',data:{cmd:params.openclawCommand,args:params.args,timeoutMs:params.timeoutMs,gatewayLogPath:params.gatewayLogPath},timestamp:_dbgStart})}).catch(()=>{});
-  const _dbgPing = setInterval(() => {
-    fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H1',location:'bootstrap-external.ts:runOpenClawInteractiveOrThrow:still-waiting',message:'still awaiting onboard exit',data:{elapsedMs:Date.now()-_dbgStart,argsTail:params.args.slice(-6)},timestamp:Date.now()})}).catch(()=>{});
-  }, 30_000);
-  // #endregion
   const result = await runOpenClawInteractiveWithMarkerCutoff(params);
-  // #region debug-e2e66e: H1/H2 — onboard subprocess actually exited
-  clearInterval(_dbgPing);
-  fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H1+H2',location:'bootstrap-external.ts:runOpenClawInteractiveOrThrow:exit',message:'interactive openclaw exited',data:{code:result.code,elapsedMs:Date.now()-_dbgStart},timestamp:Date.now()})}).catch(()=>{});
-  // #endregion
   if (result.code === 0) {
     return result;
   }
@@ -1128,11 +1117,11 @@ async function runOpenClawInteractiveOrThrow(params: {
   throw new Error(parts.join("\n"));
 }
 
-// 0 = SIGTERM the moment the marker fires. Runtime evidence (debug session
-// e2e66e, log entries 4 → 7 → 8) showed onboard exits within 24ms of SIGTERM
-// after the marker, so any non-zero grace is pure dead time bootstrap-side.
-// Caller can opt back into a grace period if they hit a reproducible case
-// where onboard needs more time to flush state after the marker.
+// 0 = SIGTERM the moment the marker fires. In practice onboard often exits
+// within tens of ms of SIGTERM after the marker, so any non-zero grace is
+// mostly dead time bootstrap-side. Callers can opt back into a grace period
+// if they hit a reproducible case where onboard needs more time to flush
+// state after the marker.
 const ONBOARD_DEFAULT_MARKER_GRACE_MS = 0;
 const ONBOARD_DEFAULT_SIGTERM_GRACE_MS = 5_000;
 // Poll the gateway log roughly twice per second so the marker is detected
@@ -1180,7 +1169,9 @@ async function runOpenClawInteractiveWithMarkerCutoff(params: {
     let postMarkerSigkillTimer: NodeJS.Timeout | null = null;
 
     const outerTimer = setTimeout(() => {
-      if (settled) {return;}
+      if (settled) {
+        return;
+      }
       try {
         child.kill("SIGKILL");
       } catch {
@@ -1190,9 +1181,15 @@ async function runOpenClawInteractiveWithMarkerCutoff(params: {
 
     function clearTimers(): void {
       clearTimeout(outerTimer);
-      if (logWatcher) {clearInterval(logWatcher);}
-      if (postMarkerSigtermTimer) {clearTimeout(postMarkerSigtermTimer);}
-      if (postMarkerSigkillTimer) {clearTimeout(postMarkerSigkillTimer);}
+      if (logWatcher) {
+        clearInterval(logWatcher);
+      }
+      if (postMarkerSigtermTimer) {
+        clearTimeout(postMarkerSigtermTimer);
+      }
+      if (postMarkerSigkillTimer) {
+        clearTimeout(postMarkerSigkillTimer);
+      }
     }
 
     // Side-channel marker watcher: tail the gateway log starting from its
@@ -1208,11 +1205,17 @@ async function runOpenClawInteractiveWithMarkerCutoff(params: {
       }
       let cursor = initialSize;
       logWatcher = setInterval(() => {
-        if (markerSeen || settled) {return;}
+        if (markerSeen || settled) {
+          return;
+        }
         try {
-          if (!existsSync(gatewayLogPath)) {return;}
+          if (!existsSync(gatewayLogPath)) {
+            return;
+          }
           const size = statSync(gatewayLogPath).size;
-          if (size <= cursor) {return;}
+          if (size <= cursor) {
+            return;
+          }
           // Read only the new bytes.
           const len = size - cursor;
           const buf = Buffer.alloc(len);
@@ -1225,25 +1228,20 @@ async function runOpenClawInteractiveWithMarkerCutoff(params: {
           cursor = size;
           if (buf.toString("utf-8").includes(ONBOARD_GATEWAY_READY_MARKER)) {
             markerSeen = true;
-            // #region debug-e2e66e: H4 — marker observed, arming graceful kill
-            fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H4',location:'bootstrap-external.ts:marker-cutoff:marker-seen',message:'gateway-ready marker detected; arming kill',data:{markerGraceMs,sigtermGraceMs},timestamp:Date.now()})}).catch(()=>{});
-            // #endregion
             const sendSigterm = (): void => {
-              if (settled || child.exitCode !== null) {return;}
+              if (settled || child.exitCode !== null) {
+                return;
+              }
               killedAfterMarker = true;
-              // #region debug-e2e66e: H4 — sending SIGTERM to onboard
-              fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H4',location:'bootstrap-external.ts:marker-cutoff:sigterm',message:'sending SIGTERM after marker grace',data:{markerGraceMs},timestamp:Date.now()})}).catch(()=>{});
-              // #endregion
               try {
                 child.kill("SIGTERM");
               } catch {
                 // ignore
               }
               postMarkerSigkillTimer = setTimeout(() => {
-                if (settled || child.exitCode !== null) {return;}
-                // #region debug-e2e66e: H4 — escalating to SIGKILL
-                fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H4',location:'bootstrap-external.ts:marker-cutoff:sigkill',message:'escalating to SIGKILL',data:{},timestamp:Date.now()})}).catch(()=>{});
-                // #endregion
+                if (settled || child.exitCode !== null) {
+                  return;
+                }
                 try {
                   child.kill("SIGKILL");
                 } catch {
@@ -1264,25 +1262,25 @@ async function runOpenClawInteractiveWithMarkerCutoff(params: {
     }
 
     child.once("error", (error: Error) => {
-      if (settled) {return;}
+      if (settled) {
+        return;
+      }
       settled = true;
       clearTimers();
       reject(error);
     });
 
     child.once("close", (code: number | null) => {
-      if (settled) {return;}
+      if (settled) {
+        return;
+      }
       settled = true;
       clearTimers();
       // If we killed it AFTER the marker fired, treat as success — the
       // wizard's user-visible work was already done. Bootstrap will run
       // its own gateway probe + autofix immediately after, so any
       // openclaw-side post-wizard verification we cut short is redundant.
-      const synthesizedCode = killedAfterMarker
-        ? 0
-        : typeof code === "number"
-          ? code
-          : 1;
+      const synthesizedCode = killedAfterMarker ? 0 : typeof code === "number" ? code : 1;
       resolve({
         code: synthesizedCode,
         stdout: "",
@@ -3526,9 +3524,6 @@ export async function bootstrapCommand(
     });
   }
 
-  // #region debug-e2e66e: H3 — onboard returned, entering post-onboard sequence
-  fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H3',location:'bootstrap-external.ts:post-onboard:enter',message:'onboard returned, starting post-onboard work',data:{},timestamp:Date.now()})}).catch(()=>{});
-  // #endregion
   const workspaceSeed = seedWorkspaceFromAssets({
     workspaceDir,
     packageRoot,
@@ -3604,10 +3599,6 @@ export async function bootstrapCommand(
     // daemon picks up plugin, model, and subagent changes that were written after
     // onboard started it.  No helper above triggers its own restart.
     postOnboardSpinner?.message("Restarting gateway…");
-    // #region debug-e2e66e: H3 — about to call openclaw gateway restart
-    const _dbgRestartStart = Date.now();
-    fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H3',location:'bootstrap-external.ts:gateway-restart:start',message:'calling openclaw gateway restart',data:{},timestamp:_dbgRestartStart})}).catch(()=>{});
-    // #endregion
     try {
       await runOpenClawOrThrow({
         openclawCommand,
@@ -3615,13 +3606,7 @@ export async function bootstrapCommand(
         timeoutMs: 60_000,
         errorMessage: "Failed to restart gateway after config update.",
       });
-      // #region debug-e2e66e: H3 — gateway restart returned
-      fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H3',location:'bootstrap-external.ts:gateway-restart:done',message:'gateway restart returned ok',data:{elapsedMs:Date.now()-_dbgRestartStart},timestamp:Date.now()})}).catch(()=>{});
-      // #endregion
     } catch (err) {
-      // #region debug-e2e66e: H3 — gateway restart threw
-      fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H3',location:'bootstrap-external.ts:gateway-restart:throw',message:'gateway restart threw (caught)',data:{elapsedMs:Date.now()-_dbgRestartStart,err:err instanceof Error?err.message:String(err)},timestamp:Date.now()})}).catch(()=>{});
-      // #endregion
       // Gateway may not be running (e.g. onboard daemon install failed on this
       // platform).  The final readiness check below will catch this.
     }
@@ -3662,9 +3647,6 @@ export async function bootstrapCommand(
   const gatewayUrl = `ws://127.0.0.1:${gatewayPort}`;
   const preferredWebPort = parseOptionalPort(opts.webPort) ?? DEFAULT_WEB_APP_PORT;
   postOnboardSpinner?.message(`Starting web runtime on port ${preferredWebPort}…`);
-  // #region debug-e2e66e: H3 — about to install/start web runtime
-  fetch('http://127.0.0.1:7651/ingest/93e0c293-34f1-4a69-8fce-870fc1b93fcb',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'e2e66e'},body:JSON.stringify({sessionId:'e2e66e',hypothesisId:'H3',location:'bootstrap-external.ts:ensureManagedWebRuntime:start',message:'starting web runtime install',data:{port:preferredWebPort},timestamp:Date.now()})}).catch(()=>{});
-  // #endregion
   let webRuntimeStatus = await ensureManagedWebRuntime({
     stateDir,
     packageRoot,

--- a/src/cli/dench-cloud.test.ts
+++ b/src/cli/dench-cloud.test.ts
@@ -74,6 +74,7 @@ describe("dench-cloud helpers", () => {
     expect(fetchMock).toHaveBeenCalledWith("https://gateway.merseoriginals.com/v1/public/models");
     expect(result.source).toBe("fallback");
     expect(result.models.map((model) => model.stableId)).toEqual([
+      "moonshotai.kimi-k2.5",
       "anthropic.claude-opus-4-6-v1",
       "gpt-5.4",
       "anthropic.claude-sonnet-4-6-v1",

--- a/src/cli/dench-cloud.ts
+++ b/src/cli/dench-cloud.ts
@@ -125,13 +125,36 @@ export function buildDenchGatewayCatalogUrl(gatewayUrl: string | undefined): str
   return `${normalizeDenchGatewayUrl(gatewayUrl)}/v1/public/models`;
 }
 
-export const RECOMMENDED_DENCH_CLOUD_MODEL_ID = "claude-opus-4.6";
+export const RECOMMENDED_DENCH_CLOUD_MODEL_ID = "kimi-k2.5";
 export const DENCH_COMPOSIO_WRAPPER_TOOLS = [
   "dench_search_integrations",
   "dench_execute_integrations",
 ] as const;
 
 export const FALLBACK_DENCH_CLOUD_MODELS: DenchCloudCatalogModel[] = [
+  {
+    id: "kimi-k2.5",
+    stableId: "moonshotai.kimi-k2.5",
+    displayName: "Kimi K2.5",
+    provider: "moonshot",
+    transportProvider: "bedrock",
+    api: "openai-responses",
+    input: ["text", "image"],
+    reasoning: true,
+    contextWindow: 262000,
+    maxTokens: 64000,
+    supportsStreaming: true,
+    supportsImages: true,
+    supportsResponses: true,
+    supportsReasoning: true,
+    cost: {
+      input: markupCost(0.6),
+      output: markupCost(3),
+      cacheRead: 0,
+      cacheWrite: 0,
+      marginPercent: DEFAULT_DENCH_CLOUD_MARGIN_PERCENT,
+    },
+  },
   {
     id: "claude-opus-4.6",
     stableId: "anthropic.claude-opus-4-6-v1",

--- a/src/cli/sync-poll.test.ts
+++ b/src/cli/sync-poll.test.ts
@@ -86,7 +86,9 @@ describe("kickoffSyncPoll", () => {
     expect(result).toEqual({ kind: "ok", status: 200 });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const firstCall = fetchMock.mock.calls[0];
-    if (!firstCall) {throw new Error("fetch not called");}
+    if (!firstCall) {
+      throw new Error("fetch not called");
+    }
     const [url, init] = firstCall;
     expect(url).toBe("http://127.0.0.1:3100/api/sync/poll-tick");
     expect((init as RequestInit).method).toBe("POST");
@@ -105,7 +107,9 @@ describe("kickoffSyncPoll", () => {
 
     expect(result).toEqual({ kind: "ok", status: 200 });
     const firstCall = fetchMock.mock.calls[0];
-    if (!firstCall) {throw new Error("fetch not called");}
+    if (!firstCall) {
+      throw new Error("fetch not called");
+    }
     const [, init] = firstCall;
     expect(((init as RequestInit).headers as Record<string, string>).authorization).toBe(
       "Bearer dc-from-env",
@@ -122,7 +126,9 @@ describe("kickoffSyncPoll", () => {
     await kickoffSyncPoll({ stateDir, port: 3100 });
 
     const firstCall = fetchMock.mock.calls[0];
-    if (!firstCall) {throw new Error("fetch not called");}
+    if (!firstCall) {
+      throw new Error("fetch not called");
+    }
     const [, init] = firstCall;
     expect(((init as RequestInit).headers as Record<string, string>).authorization).toBe(
       "Bearer dc-from-profile",

--- a/src/cli/sync-poll.ts
+++ b/src/cli/sync-poll.ts
@@ -48,11 +48,7 @@ function readKeyFromAuthProfiles(stateDir: string): string | undefined {
 }
 
 function envFallbackKey(): string | undefined {
-  return (
-    process.env.DENCH_CLOUD_API_KEY?.trim() ||
-    process.env.DENCH_API_KEY?.trim() ||
-    undefined
-  );
+  return process.env.DENCH_CLOUD_API_KEY?.trim() || process.env.DENCH_API_KEY?.trim() || undefined;
 }
 
 /**
@@ -100,9 +96,7 @@ export async function kickoffSyncPoll(params: {
     return { kind: "error", reason: "http", status: response.status };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    const aborted =
-      err instanceof Error &&
-      (err.name === "AbortError" || /aborted/i.test(message));
+    const aborted = err instanceof Error && (err.name === "AbortError" || /aborted/i.test(message));
     if (aborted) {
       return { kind: "error", reason: "timeout" };
     }

--- a/src/cli/web-runtime-command.ts
+++ b/src/cli/web-runtime-command.ts
@@ -9,6 +9,7 @@ import { stylePromptMessage } from "../terminal/prompt-style.js";
 import { theme } from "../terminal/theme.js";
 import { VERSION } from "../version.js";
 import { applyCliProfileEnv } from "./profile.js";
+import { kickoffSyncPoll, summarizeKickoffSyncPoll } from "./sync-poll.js";
 import {
   installWebRuntimeLaunchAgent,
   uninstallWebRuntimeLaunchAgent,
@@ -30,7 +31,6 @@ import {
   stopManagedWebRuntime,
   waitForWebRuntime,
 } from "./web-runtime.js";
-import { kickoffSyncPoll, summarizeKickoffSyncPoll } from "./sync-poll.js";
 import {
   discoverWorkspaceDirs,
   syncManagedSkills,


### PR DESCRIPTION
## Summary
Adds read/write HTTP endpoints for sync health (`/api/sync/status`, `/api/sync/refresh`), extends `sync-runner` with per-source status and unit tests, registers agent-facing sync refresh tools in `dench-ai-gateway`, and aligns CLI bootstrap (`bootstrap-external`), `dench-cloud`, and `sync-poll`. Removes temporary debug ingest calls from bootstrap.

## Scope
**Included:** sync API routes + tests, `sync-runner` + test, gateway (`index`, `models`, `sync-trigger`, `sync-refresh-tools`) + tests, `dench-identity`, CLI files above, `workspace-sync-params` test delta.

**Excluded:** workspace shell refactor, `SyncHealthBanner`, `workspace-tabs`, `workspace-content` (final PR).

## Depends on
Merges on top of v3.0.0 after Composio disconnect PR (`#208`).

## Verification
- `cd apps/web && pnpm vitest run app/api/sync/status/route.test.ts app/api/sync/refresh/route.test.ts lib/sync-runner.test.ts`
- `pnpm exec vitest run --config extensions/vitest.config.ts extensions/dench-ai-gateway/index.test.ts`
- `pnpm exec vitest run --config vitest.unit.config.ts src/cli/sync-poll.test.ts src/cli/dench-cloud.test.ts`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new loopback-only sync APIs and changes sync-runner error handling/state tracking, which affects how Gmail/Calendar polling/backfills are triggered and how failures surface to users/agents. Risk is moderate due to new control paths and altered logging/status semantics, but changes are well-covered by new contract tests.
> 
> **Overview**
> Adds two workspace-local sync endpoints: `GET /api/sync/status` to report per-source Gmail/Calendar health (including *staleness* derived from on-disk cursors) and `POST /api/sync/refresh` to trigger either an incremental tick (default) or a background backfill, with strict loopback host enforcement and explicit handling for malformed bodies and concurrency.
> 
> Extends `sync-runner` with per-source health state (`lastSuccessAt`, `lastError`, `needsReconnect`, streak counters) and updates both incremental and backfill flows to **record and emit all failure modes** (not just no-connection), including deduped logging and `source`-tagged error events.
> 
> Updates `dench-ai-gateway` to register new agent tools `denchclaw_refresh_sync` and `denchclaw_resync_full` (key-gated) that call `/api/sync/refresh`, exports shared URL/config resolution from `sync-trigger`, and adjusts tests accordingly; also tweaks fallback Dench Cloud model recommendation to `kimi-k2.5`, adds agent guidance for the new tools, removes temporary bootstrap debug ingest code, and tightens a workspace URL-sync test to drop object-view params when switching tables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46ce9a3bc5bd3ef035fdceaa9f6044c0ce3be866. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->