### PR TITLE
chore(dench-cloud): refresh fallback catalog

### DIFF
--- a/apps/web/app/api/settings/cloud/route.test.ts
+++ b/apps/web/app/api/settings/cloud/route.test.ts
@@ -45,7 +45,7 @@ const validState = {
       supportsImages: true,
       supportsResponses: true,
       supportsReasoning: false,
-      cost: { input: 6.75, output: 33.75, cacheRead: 0, cacheWrite: 0, marginPercent: 0.35 },
+      cost: { input: 6.75, output: 33.75, cacheRead: 0, cacheWrite: 0 },
     },
   ],
   recommendedModelId: "claude-opus-4.6",

--- a/extensions/dench-ai-gateway/models.ts
+++ b/extensions/dench-ai-gateway/models.ts
@@ -1,12 +1,10 @@
 export const DEFAULT_DENCH_CLOUD_GATEWAY_URL = "https://gateway.merseoriginals.com";
-export const DEFAULT_DENCH_CLOUD_MARGIN_PERCENT = 0.35;
 
 export type DenchCloudCatalogCost = {
   input: number;
   output: number;
   cacheRead: number;
   cacheWrite: number;
-  marginPercent?: number;
 };
 
 export type DenchCloudCatalogModel = {
@@ -28,14 +26,6 @@ export type DenchCloudCatalogModel = {
 };
 
 type UnknownRecord = Record<string, unknown>;
-
-function roundUsd(value: number): number {
-  return Number(value.toFixed(8));
-}
-
-function markupCost(value: number): number {
-  return roundUsd(value * (1 + DEFAULT_DENCH_CLOUD_MARGIN_PERCENT));
-}
 
 function asRecord(value: unknown): UnknownRecord | undefined {
   return value && typeof value === "object" ? (value as UnknownRecord) : undefined;
@@ -131,6 +121,8 @@ export function buildDenchGatewayCatalogUrl(gatewayUrl: string | undefined): str
 
 export const RECOMMENDED_DENCH_CLOUD_MODEL_ID = "kimi-k2.5";
 
+// Fallback list used only when the live gateway catalog is unreachable.
+// Live pricing always comes from the gateway's /v1/public/models response.
 export const FALLBACK_DENCH_CLOUD_MODELS: DenchCloudCatalogModel[] = [
   {
     id: "kimi-k2.5",
@@ -148,11 +140,10 @@ export const FALLBACK_DENCH_CLOUD_MODELS: DenchCloudCatalogModel[] = [
     supportsResponses: true,
     supportsReasoning: true,
     cost: {
-      input: markupCost(0.6),
-      output: markupCost(3),
+      input: 0.81,
+      output: 4.05,
       cacheRead: 0,
       cacheWrite: 0,
-      marginPercent: DEFAULT_DENCH_CLOUD_MARGIN_PERCENT,
     },
   },
   {
@@ -163,19 +154,18 @@ export const FALLBACK_DENCH_CLOUD_MODELS: DenchCloudCatalogModel[] = [
     transportProvider: "bedrock",
     api: "openai-responses",
     input: ["text", "image"],
-    reasoning: false,
-    contextWindow: 200000,
-    maxTokens: 64000,
+    reasoning: true,
+    contextWindow: 971000,
+    maxTokens: 128000,
     supportsStreaming: true,
     supportsImages: true,
     supportsResponses: true,
-    supportsReasoning: false,
+    supportsReasoning: true,
     cost: {
-      input: markupCost(5),
-      output: markupCost(25),
-      cacheRead: 0,
-      cacheWrite: 0,
-      marginPercent: DEFAULT_DENCH_CLOUD_MARGIN_PERCENT,
+      input: 6.75,
+      output: 33.75,
+      cacheRead: 0.675,
+      cacheWrite: 8.4375,
     },
   },
   {
@@ -186,19 +176,18 @@ export const FALLBACK_DENCH_CLOUD_MODELS: DenchCloudCatalogModel[] = [
     transportProvider: "openai",
     api: "openai-responses",
     input: ["text", "image"],
-    reasoning: false,
-    contextWindow: 128000,
+    reasoning: true,
+    contextWindow: 971000,
     maxTokens: 128000,
     supportsStreaming: true,
     supportsImages: true,
     supportsResponses: true,
-    supportsReasoning: false,
+    supportsReasoning: true,
     cost: {
-      input: markupCost(2.5),
-      output: markupCost(15),
-      cacheRead: 0,
+      input: 3.375,
+      output: 20.25,
+      cacheRead: 0.3375,
       cacheWrite: 0,
-      marginPercent: DEFAULT_DENCH_CLOUD_MARGIN_PERCENT,
     },
   },
   {
@@ -209,19 +198,18 @@ export const FALLBACK_DENCH_CLOUD_MODELS: DenchCloudCatalogModel[] = [
     transportProvider: "bedrock",
     api: "openai-responses",
     input: ["text", "image"],
-    reasoning: false,
-    contextWindow: 200000,
+    reasoning: true,
+    contextWindow: 971000,
     maxTokens: 64000,
     supportsStreaming: true,
     supportsImages: true,
     supportsResponses: true,
-    supportsReasoning: false,
+    supportsReasoning: true,
     cost: {
-      input: markupCost(3),
-      output: markupCost(15),
-      cacheRead: 0,
-      cacheWrite: 0,
-      marginPercent: DEFAULT_DENCH_CLOUD_MARGIN_PERCENT,
+      input: 4.05,
+      output: 20.25,
+      cacheRead: 0.405,
+      cacheWrite: 5.0625,
     },
   },
 ];
@@ -271,7 +259,6 @@ export function normalizeDenchCloudCatalogModel(input: unknown): DenchCloudCatal
   const outputCost = readNumber(costRecord, "output") ?? 0;
   const cacheRead = readNumber(costRecord, "cacheRead", "cache_read") ?? 0;
   const cacheWrite = readNumber(costRecord, "cacheWrite", "cache_write") ?? 0;
-  const marginPercent = readNumber(costRecord, "marginPercent", "margin_percent");
 
   return {
     id: publicId,
@@ -293,7 +280,6 @@ export function normalizeDenchCloudCatalogModel(input: unknown): DenchCloudCatal
       output: outputCost,
       cacheRead,
       cacheWrite,
-      ...(marginPercent !== undefined ? { marginPercent } : {}),
     },
   };
 }

--- a/src/cli/dench-cloud.test.ts
+++ b/src/cli/dench-cloud.test.ts
@@ -57,13 +57,15 @@ describe("dench-cloud helpers", () => {
         displayName: "GPT-5.4",
         contextWindow: 128000,
         maxTokens: 128000,
-        cost: expect.objectContaining({
+        cost: {
           input: 3.375,
           output: 20.25,
-          marginPercent: 0.35,
-        }),
+          cacheRead: 0,
+          cacheWrite: 0,
+        },
       }),
     ]);
+    expect(models[0]?.cost).not.toHaveProperty("marginPercent");
   });
 
   it("falls back to the bundled model list when the public catalog is unavailable", async () => {
@@ -119,7 +121,6 @@ describe("dench-cloud helpers", () => {
             output: 33.75,
             cacheRead: 0,
             cacheWrite: 0,
-            marginPercent: 0.35,
           },
         },
       ],
@@ -181,7 +182,6 @@ describe("dench-cloud helpers", () => {
             output: 33.75,
             cacheRead: 0,
             cacheWrite: 0,
-            marginPercent: 0.35,
           },
         },
       ],

--- a/src/cli/dench-cloud.ts
+++ b/src/cli/dench-cloud.ts
@@ -1,12 +1,10 @@
 export const DEFAULT_DENCH_CLOUD_GATEWAY_URL = "https://gateway.merseoriginals.com";
-export const DEFAULT_DENCH_CLOUD_MARGIN_PERCENT = 0.35;
 
 export type DenchCloudCatalogCost = {
   input: number;
   output: number;
   cacheRead: number;
   cacheWrite: number;
-  marginPercent?: number;
 };
 
 export type DenchCloudCatalogModel = {
@@ -36,14 +34,6 @@ export type DenchCloudCatalogLoadResult = {
 };
 
 type UnknownRecord = Record<string, unknown>;
-
-function roundUsd(value: number): number {
-  return Number(value.toFixed(8));
-}
-
-function markupCost(value: number): number {
-  return roundUsd(value * (1 + DEFAULT_DENCH_CLOUD_MARGIN_PERCENT));
-}
 
 function asRecord(value: unknown): UnknownRecord | undefined {
   return value && typeof value === "object" ? (value as UnknownRecord) : undefined;
@@ -143,6 +133,8 @@ export const DENCH_COMPOSIO_WRAPPER_TOOLS = [
   "dench_execute_integrations",
 ] as const;
 
+// Fallback list used only when the live gateway catalog is unreachable.
+// Live pricing always comes from the gateway's /v1/public/models response.
 export const FALLBACK_DENCH_CLOUD_MODELS: DenchCloudCatalogModel[] = [
   {
     id: "kimi-k2.5",
@@ -160,11 +152,10 @@ export const FALLBACK_DENCH_CLOUD_MODELS: DenchCloudCatalogModel[] = [
     supportsResponses: true,
     supportsReasoning: true,
     cost: {
-      input: markupCost(0.6),
-      output: markupCost(3),
+      input: 0.81,
+      output: 4.05,
       cacheRead: 0,
       cacheWrite: 0,
-      marginPercent: DEFAULT_DENCH_CLOUD_MARGIN_PERCENT,
     },
   },
   {
@@ -175,19 +166,18 @@ export const FALLBACK_DENCH_CLOUD_MODELS: DenchCloudCatalogModel[] = [
     transportProvider: "bedrock",
     api: "openai-responses",
     input: ["text", "image"],
-    reasoning: false,
-    contextWindow: 200000,
-    maxTokens: 64000,
+    reasoning: true,
+    contextWindow: 971000,
+    maxTokens: 128000,
     supportsStreaming: true,
     supportsImages: true,
     supportsResponses: true,
-    supportsReasoning: false,
+    supportsReasoning: true,
     cost: {
-      input: markupCost(5),
-      output: markupCost(25),
-      cacheRead: 0,
-      cacheWrite: 0,
-      marginPercent: DEFAULT_DENCH_CLOUD_MARGIN_PERCENT,
+      input: 6.75,
+      output: 33.75,
+      cacheRead: 0.675,
+      cacheWrite: 8.4375,
     },
   },
   {
@@ -198,19 +188,18 @@ export const FALLBACK_DENCH_CLOUD_MODELS: DenchCloudCatalogModel[] = [
     transportProvider: "openai",
     api: "openai-responses",
     input: ["text", "image"],
-    reasoning: false,
-    contextWindow: 128000,
+    reasoning: true,
+    contextWindow: 971000,
     maxTokens: 128000,
     supportsStreaming: true,
     supportsImages: true,
     supportsResponses: true,
-    supportsReasoning: false,
+    supportsReasoning: true,
     cost: {
-      input: markupCost(2.5),
-      output: markupCost(15),
-      cacheRead: 0,
+      input: 3.375,
+      output: 20.25,
+      cacheRead: 0.3375,
       cacheWrite: 0,
-      marginPercent: DEFAULT_DENCH_CLOUD_MARGIN_PERCENT,
     },
   },
   {
@@ -221,19 +210,18 @@ export const FALLBACK_DENCH_CLOUD_MODELS: DenchCloudCatalogModel[] = [
     transportProvider: "bedrock",
     api: "openai-responses",
     input: ["text", "image"],
-    reasoning: false,
-    contextWindow: 200000,
+    reasoning: true,
+    contextWindow: 971000,
     maxTokens: 64000,
     supportsStreaming: true,
     supportsImages: true,
     supportsResponses: true,
-    supportsReasoning: false,
+    supportsReasoning: true,
     cost: {
-      input: markupCost(3),
-      output: markupCost(15),
-      cacheRead: 0,
-      cacheWrite: 0,
-      marginPercent: DEFAULT_DENCH_CLOUD_MARGIN_PERCENT,
+      input: 4.05,
+      output: 20.25,
+      cacheRead: 0.405,
+      cacheWrite: 5.0625,
     },
   },
 ];
@@ -283,7 +271,6 @@ export function normalizeDenchCloudCatalogModel(input: unknown): DenchCloudCatal
   const outputCost = readNumber(costRecord, "output") ?? 0;
   const cacheRead = readNumber(costRecord, "cacheRead", "cache_read") ?? 0;
   const cacheWrite = readNumber(costRecord, "cacheWrite", "cache_write") ?? 0;
-  const marginPercent = readNumber(costRecord, "marginPercent", "margin_percent");
 
   return {
     id: publicId,
@@ -305,7 +292,6 @@ export function normalizeDenchCloudCatalogModel(input: unknown): DenchCloudCatal
       output: outputCost,
       cacheRead,
       cacheWrite,
-      ...(marginPercent !== undefined ? { marginPercent } : {}),
     },
   };
 }


### PR DESCRIPTION


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates Dench Cloud catalog pricing/model metadata and removes the `marginPercent` field from normalized costs, which could affect displayed pricing or downstream config consumers expecting the old shape.
> 
> **Overview**
> Refreshes the Dench Cloud *fallback* catalog entries (pricing, context windows/max tokens, reasoning support, and cache read/write costs) in both the CLI helper and the `dench-ai-gateway` extension.
> 
> Removes the `DEFAULT_DENCH_CLOUD_MARGIN_PERCENT`/markup logic and strips `marginPercent` from the `DenchCloudCatalogCost` type and catalog normalization, updating related tests to assert the new cost shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ebbd7b5482d23800c6fccec0b649c1a92939520. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->