### PR TITLE
feat(composio): use the public origin for OAuth callback registration

### DIFF
--- a/apps/web/app/api/composio/callback/route.test.ts
+++ b/apps/web/app/api/composio/callback/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GET } from "./route";
 
 vi.mock("@/lib/integrations", () => ({
@@ -17,9 +17,12 @@ const { fetchComposioConnections } = await import("@/lib/composio");
 const mockedRefreshIntegrationsRuntime = vi.mocked(refreshIntegrationsRuntime);
 const mockedFetchComposioConnections = vi.mocked(fetchComposioConnections);
 
+const ORIGINAL_PUBLIC_URL = process.env.DENCHCLAW_PUBLIC_URL;
+
 describe("Composio callback API", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.DENCHCLAW_PUBLIC_URL;
     mockedRefreshIntegrationsRuntime.mockResolvedValue({
       attempted: true,
       restarted: true,
@@ -37,6 +40,14 @@ describe("Composio callback API", () => {
         },
       ],
     } as never);
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_PUBLIC_URL === undefined) {
+      delete process.env.DENCHCLAW_PUBLIC_URL;
+    } else {
+      process.env.DENCHCLAW_PUBLIC_URL = ORIGINAL_PUBLIC_URL;
+    }
   });
 
   it("refreshes the runtime after a successful connection", async () => {
@@ -61,5 +72,51 @@ describe("Composio callback API", () => {
 
     expect(response.status).toBe(200);
     expect(mockedRefreshIntegrationsRuntime).not.toHaveBeenCalled();
+  });
+
+  it("inlines the request.url origin as targetOrigin in local dev (no proxy, no env)", async () => {
+    const response = await GET(
+      new Request(
+        "http://localhost:3100/api/composio/callback?status=success&connected_account_id=acct_123",
+      ),
+    );
+
+    const html = await response.text();
+    expect(html).toContain('"http://localhost:3100"');
+  });
+
+  it("uses DENCHCLAW_PUBLIC_URL as targetOrigin so postMessage matches the parent tab origin", async () => {
+    process.env.DENCHCLAW_PUBLIC_URL =
+      "https://acme.sandbox.merseoriginals.com";
+
+    const response = await GET(
+      new Request(
+        "http://localhost:3100/api/composio/callback?status=success&connected_account_id=acct_123",
+      ),
+    );
+
+    const html = await response.text();
+    expect(html).toContain('"https://acme.sandbox.merseoriginals.com"');
+    expect(html).not.toContain('"http://localhost:3100"');
+  });
+
+  it("prefers X-Forwarded-Host so the postMessage targetOrigin reflects the actual public host", async () => {
+    process.env.DENCHCLAW_PUBLIC_URL = "https://stale.sandbox.merseoriginals.com";
+
+    const response = await GET(
+      new Request(
+        "http://localhost:3100/api/composio/callback?status=success&connected_account_id=acct_123",
+        {
+          headers: {
+            "x-forwarded-host": "real-org.sandbox.merseoriginals.com",
+            "x-forwarded-proto": "https",
+          },
+        },
+      ),
+    );
+
+    const html = await response.text();
+    expect(html).toContain('"https://real-org.sandbox.merseoriginals.com"');
+    expect(html).not.toContain('"https://stale.sandbox.merseoriginals.com"');
   });
 });

--- a/apps/web/app/api/composio/callback/route.ts
+++ b/apps/web/app/api/composio/callback/route.ts
@@ -8,6 +8,7 @@ import {
   normalizeComposioConnections,
 } from "@/lib/composio-client";
 import { refreshIntegrationsRuntime } from "@/lib/integrations";
+import { resolveAppPublicOrigin } from "@/lib/public-origin";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -64,7 +65,12 @@ export async function GET(request: Request) {
   const { searchParams } = url;
   const status = searchParams.get("status") ?? "unknown";
   const connectedAccountId = searchParams.get("connected_account_id") ?? "";
-  const targetOrigin = url.origin;
+  // Use the public origin (not `url.origin`) so the postMessage target
+  // matches `window.location.origin` in the parent tab when DenchClaw
+  // is hosted behind a reverse proxy. The parent's strict
+  // `event.origin === window.location.origin` check would otherwise
+  // discard the message and the modal would hang on "Authorizing…".
+  const targetOrigin = resolveAppPublicOrigin(request);
 
   const success = status === "success";
   let resolvedConnection:

--- a/apps/web/app/api/composio/connect/route.test.ts
+++ b/apps/web/app/api/composio/connect/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { POST } from "./route";
 
 const {
@@ -20,9 +20,12 @@ vi.mock("@/lib/composio", () => ({
   resolveComposioGatewayUrl: resolveComposioGatewayUrlMock,
 }));
 
+const ORIGINAL_PUBLIC_URL = process.env.DENCHCLAW_PUBLIC_URL;
+
 describe("Composio connect API", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.DENCHCLAW_PUBLIC_URL;
     resolveComposioApiKeyMock.mockReturnValue("dench_test_key");
     resolveComposioEligibilityMock.mockReturnValue({
       eligible: true,
@@ -33,6 +36,14 @@ describe("Composio connect API", () => {
     initiateComposioConnectMock.mockResolvedValue({
       redirect_url: "https://composio.example/connect/zoho",
     });
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_PUBLIC_URL === undefined) {
+      delete process.env.DENCHCLAW_PUBLIC_URL;
+    } else {
+      process.env.DENCHCLAW_PUBLIC_URL = ORIGINAL_PUBLIC_URL;
+    }
   });
 
   it("passes the selected toolkit slug and callback URL through to the gateway connect call", async () => {
@@ -60,5 +71,51 @@ describe("Composio connect API", () => {
       requested_toolkit: "zoho",
       connect_toolkit: "zoho",
     });
+  });
+
+  it("uses DENCHCLAW_PUBLIC_URL for the callback origin when set (Dench Cloud sandbox)", async () => {
+    process.env.DENCHCLAW_PUBLIC_URL =
+      "https://dench-com.sandbox.merseoriginals.com";
+
+    const response = await POST(
+      new Request("http://localhost/api/composio/connect", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ toolkit: "zoho" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(initiateComposioConnectMock).toHaveBeenCalledWith(
+      "https://gateway.example.com",
+      "dench_test_key",
+      "zoho",
+      "https://dench-com.sandbox.merseoriginals.com/api/composio/callback",
+    );
+  });
+
+  it("prefers X-Forwarded-* headers over DENCHCLAW_PUBLIC_URL — needed for warm-pool rebinds where the running container has a stale env value", async () => {
+    process.env.DENCHCLAW_PUBLIC_URL =
+      "https://stale-warm-pool-slug.sandbox.merseoriginals.com";
+
+    const response = await POST(
+      new Request("http://localhost/api/composio/connect", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-forwarded-host": "real-org.sandbox.merseoriginals.com",
+          "x-forwarded-proto": "https",
+        },
+        body: JSON.stringify({ toolkit: "zoho" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(initiateComposioConnectMock).toHaveBeenCalledWith(
+      "https://gateway.example.com",
+      "dench_test_key",
+      "zoho",
+      "https://real-org.sandbox.merseoriginals.com/api/composio/callback",
+    );
   });
 });

--- a/apps/web/app/api/composio/connect/route.ts
+++ b/apps/web/app/api/composio/connect/route.ts
@@ -5,6 +5,7 @@ import {
   resolveComposioGatewayUrl,
 } from "@/lib/composio";
 import { resolveComposioConnectToolkitSlug } from "@/lib/composio-normalization";
+import { resolveAppPublicOrigin } from "@/lib/public-origin";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -48,7 +49,7 @@ export async function POST(request: Request) {
     );
   }
 
-  const origin = new URL(request.url).origin;
+  const origin = resolveAppPublicOrigin(request);
   const callbackUrl = `${origin}/api/composio/callback`;
   const gatewayUrl = resolveComposioGatewayUrl();
   const requestedToolkit = body.toolkit.trim();

--- a/apps/web/lib/public-origin.test.ts
+++ b/apps/web/lib/public-origin.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveAppPublicOrigin } from "./public-origin";
+
+const ORIGINAL_ENV = process.env.DENCHCLAW_PUBLIC_URL;
+
+afterEach(() => {
+  if (ORIGINAL_ENV === undefined) {
+    delete process.env.DENCHCLAW_PUBLIC_URL;
+  } else {
+    process.env.DENCHCLAW_PUBLIC_URL = ORIGINAL_ENV;
+  }
+});
+
+beforeEach(() => {
+  delete process.env.DENCHCLAW_PUBLIC_URL;
+});
+
+function makeRequest(opts: {
+  url?: string;
+  forwardedHost?: string;
+  forwardedProto?: string;
+  host?: string;
+}): Request {
+  const headers = new Headers();
+  if (opts.forwardedHost) {
+    headers.set("x-forwarded-host", opts.forwardedHost);
+  }
+  if (opts.forwardedProto) {
+    headers.set("x-forwarded-proto", opts.forwardedProto);
+  }
+  if (opts.host) {
+    headers.set("host", opts.host);
+  }
+  return new Request(opts.url ?? "http://localhost:3100/api/composio/connect", {
+    method: "POST",
+    headers,
+  });
+}
+
+describe("resolveAppPublicOrigin", () => {
+  describe("forwarded headers (cloud / behind reverse proxy)", () => {
+    it("uses X-Forwarded-Host + X-Forwarded-Proto when both are present", () => {
+      const origin = resolveAppPublicOrigin(
+        makeRequest({
+          forwardedHost: "dench-com.sandbox.merseoriginals.com",
+          forwardedProto: "https",
+        }),
+      );
+      expect(origin).toBe("https://dench-com.sandbox.merseoriginals.com");
+    });
+
+    it("defaults to http when X-Forwarded-Proto is missing or unrecognized", () => {
+      expect(
+        resolveAppPublicOrigin(
+          makeRequest({
+            forwardedHost: "example.local",
+          }),
+        ),
+      ).toBe("http://example.local");
+
+      expect(
+        resolveAppPublicOrigin(
+          makeRequest({
+            forwardedHost: "example.local",
+            forwardedProto: "ws",
+          }),
+        ),
+      ).toBe("http://example.local");
+    });
+
+    it("takes the first value from a comma-separated forwarded header chain", () => {
+      const origin = resolveAppPublicOrigin(
+        makeRequest({
+          forwardedHost: "real.example.com, intermediate.example.com",
+          forwardedProto: "https",
+        }),
+      );
+      expect(origin).toBe("https://real.example.com");
+    });
+
+    it("prefers forwarded headers over DENCHCLAW_PUBLIC_URL — needed for warm-pool slug rebinds where the env var is stale but the Host header is live", () => {
+      process.env.DENCHCLAW_PUBLIC_URL =
+        "https://stale-warm-pool-slug.sandbox.merseoriginals.com";
+      const origin = resolveAppPublicOrigin(
+        makeRequest({
+          forwardedHost: "real-org-slug.sandbox.merseoriginals.com",
+          forwardedProto: "https",
+        }),
+      );
+      expect(origin).toBe("https://real-org-slug.sandbox.merseoriginals.com");
+    });
+  });
+
+  describe("DENCHCLAW_PUBLIC_URL fallback", () => {
+    it("uses the env var when no forwarded headers are present", () => {
+      process.env.DENCHCLAW_PUBLIC_URL =
+        "https://acme.sandbox.merseoriginals.com";
+      const origin = resolveAppPublicOrigin(makeRequest({}));
+      expect(origin).toBe("https://acme.sandbox.merseoriginals.com");
+    });
+
+    it("normalizes the env var to its origin (drops path/query)", () => {
+      process.env.DENCHCLAW_PUBLIC_URL =
+        "https://acme.sandbox.merseoriginals.com/some/path?query=1";
+      const origin = resolveAppPublicOrigin(makeRequest({}));
+      expect(origin).toBe("https://acme.sandbox.merseoriginals.com");
+    });
+
+    it("ignores a malformed env var and falls through to request.url", () => {
+      process.env.DENCHCLAW_PUBLIC_URL = "this is not a url";
+      const origin = resolveAppPublicOrigin(
+        makeRequest({
+          url: "http://localhost:3100/api/composio/connect",
+        }),
+      );
+      expect(origin).toBe("http://localhost:3100");
+    });
+  });
+
+  describe("local dev fallback", () => {
+    it("returns the request.url origin when neither forwarded headers nor env var are set", () => {
+      const origin = resolveAppPublicOrigin(
+        makeRequest({
+          url: "http://localhost:3100/api/composio/connect",
+        }),
+      );
+      expect(origin).toBe("http://localhost:3100");
+    });
+
+    it("falls back to request.url when forwarded host is empty after trimming", () => {
+      const origin = resolveAppPublicOrigin(
+        makeRequest({
+          forwardedHost: "   ",
+          forwardedProto: "https",
+          url: "http://localhost:3100/api/composio/connect",
+        }),
+      );
+      expect(origin).toBe("http://localhost:3100");
+    });
+  });
+});

--- a/apps/web/lib/public-origin.ts
+++ b/apps/web/lib/public-origin.ts
@@ -1,0 +1,71 @@
+/**
+ * Resolves the public origin DenchClaw is reachable at — used when
+ * registering OAuth callbacks (e.g. Composio) and computing the
+ * `postMessage` target origin in OAuth callback popups.
+ *
+ * Why this helper exists:
+ * - `new URL(request.url).origin` reflects the actual TCP socket
+ *   DenchClaw is listening on (`http://localhost:3100`), not the public
+ *   URL the user's browser is using.
+ * - Next.js does NOT honor `X-Forwarded-*` headers when materializing
+ *   `request.url`. Without this helper the Composio gateway would
+ *   register `http://localhost:3100/api/composio/callback` as the OAuth
+ *   redirect URI, which fails the moment the app is hosted behind any
+ *   reverse proxy (Dench Cloud, ngrok, your own k8s ingress, etc.).
+ *
+ * Priority:
+ *   1. **Trusted forwarded headers** (`X-Forwarded-Host` +
+ *      `X-Forwarded-Proto`). On Dench Cloud the in-container Nginx sets
+ *      both, so this naturally reflects the *current* public subdomain.
+ *      That matters for warm-pool slug rebinds where the underlying
+ *      container keeps running across the rebind: the env var below
+ *      becomes stale, but the Host header is always live.
+ *
+ *      Spoofing risk is bounded by deployment topology — DenchClaw
+ *      binds to 127.0.0.1:3100 inside the sandbox container, so these
+ *      headers can only originate from the colocated Nginx instance,
+ *      which sets them itself (`proxy_set_header X-Forwarded-Host
+ *      $host;`).
+ *   2. **`DENCHCLAW_PUBLIC_URL` env var.** Seeded by the sandbox boot
+ *      script from the Secrets Manager config (`publicUrl` field). Used
+ *      as a fallback when forwarded headers are absent (e.g. in-process
+ *      probes, server-internal calls) and as a debugging aid.
+ *   3. **`new URL(request.url).origin`.** Local dev fallback. With
+ *      `bun run dev` and no proxy in front, this is
+ *      `http://localhost:3100` and Composio happily accepts a localhost
+ *      callback URL during development.
+ */
+export function resolveAppPublicOrigin(request: Request): string {
+  const forwardedHost = firstHeaderValue(request, "x-forwarded-host");
+  if (forwardedHost) {
+    const forwardedProto = firstHeaderValue(request, "x-forwarded-proto");
+    const proto = forwardedProto === "https" ? "https" : "http";
+    return `${proto}://${forwardedHost}`;
+  }
+
+  const envUrl = process.env.DENCHCLAW_PUBLIC_URL?.trim();
+  if (envUrl) {
+    try {
+      return new URL(envUrl).origin;
+    } catch {
+      // DENCHCLAW_PUBLIC_URL is malformed — fall through to request.url
+      // so we still produce *some* origin instead of crashing.
+    }
+  }
+
+  return new URL(request.url).origin;
+}
+
+/**
+ * Reads the first comma-separated value from a header. Forwarded
+ * headers can stack as proxies chain (`x-forwarded-host: a, b`); the
+ * leftmost value is the original client-facing one.
+ */
+function firstHeaderValue(request: Request, name: string): string | null {
+  const raw = request.headers.get(name);
+  if (!raw) {
+    return null;
+  }
+  const first = raw.split(",")[0]?.trim();
+  return first && first.length > 0 ? first : null;
+}


### PR DESCRIPTION
## Summary

`new URL(request.url).origin` reflects the actual TCP socket Next.js is listening on (`http://localhost:3100`), not the URL the user's browser is hitting. Behind any reverse proxy — Dench Cloud, ngrok, your own ingress — the Composio gateway registers a callback that points at loopback, the OAuth popup ends up at `https://localhost:3100/...` and fails with `ERR_SSL_PROTOCOL_ERROR`. The integrations modal then sits on "Authorizing…" forever because the parent's `event.origin === window.location.origin` check rejects the postMessage even if the callback page somehow loaded.

This adds `resolveAppPublicOrigin(request)` and uses it in both `/api/composio/connect` (for the callback URL we register with the gateway) and `/api/composio/callback` (for the postMessage `targetOrigin` in the popup). Priority order:

1. **`X-Forwarded-Host` + `X-Forwarded-Proto` headers.** On Dench Cloud these come from the in-container Nginx, which sets them itself and is the only thing that can reach DenchClaw's loopback bind. Preferring headers over the env var is deliberate: the warm-pool fast-path keeps the container running across slug rebinds, so the env value pinned at boot becomes stale, but the Host header is always live.
2. **`DENCHCLAW_PUBLIC_URL` env var.** Seeded by the dench.com sandbox boot script from the Secrets Manager config (DenchHQ/dench.com#216). Useful for in-process probes and as a debugging aid.
3. **`new URL(request.url).origin`** — local dev fallback. With `bun run dev` and no proxy, this is `http://localhost:3100` and Composio happily accepts a localhost callback during development.

dench.com companion PR: DenchHQ/dench.com#216 (sets the env var + adds Nginx callback exemption + Nginx X-Forwarded-Host header).

## Test plan

- [x] `pnpm vitest run lib/public-origin.test.ts app/api/composio/connect/route.test.ts app/api/composio/callback/route.test.ts` — 17 tests pass
- [x] Full DenchClaw web suite: `pnpm vitest run` — 1655 passed, 5 skipped (one unrelated flaky timer test was the only diff vs main)
- [x] No lint regressions in touched files (verified via `pnpm lint`)
- [x] Helper priority covered: env var only, header only, header overriding stale env var (warm-pool case), malformed env var falls through, comma-separated forwarded chain
- [ ] Local dev (`bun run dev`): click Composio Connect, confirm `http://localhost:3100/api/composio/callback?...` flow still works
- [ ] Cloud sandbox: confirm popup ends at `https://{slug}.sandbox.merseoriginals.com/api/composio/callback?...` and the integration card flips to "Connected"