### PR TITLE
feat(cron): default heartbeat to 24h and reflect live config in dashboard

### DIFF
--- a/apps/web/app/api/cron/cron.test.ts
+++ b/apps/web/app/api/cron/cron.test.ts
@@ -69,6 +69,80 @@ describe("Cron API routes", () => {
       const json = await res.json();
       expect(json.jobs).toEqual([]);
     });
+
+    it("returns the heartbeat interval from agents.defaults.heartbeat.every", async () => {
+      const { existsSync: mockExists, readFileSync: mockReadFile } = await import("node:fs");
+      vi.mocked(mockExists).mockImplementation((p) => String(p).endsWith("openclaw.json"));
+      vi.mocked(mockReadFile).mockImplementation((p) => {
+        if (String(p).endsWith("openclaw.json")) {
+          return JSON.stringify({
+            agents: { defaults: { heartbeat: { every: "24h" } } },
+          }) as never;
+        }
+        return "" as never;
+      });
+
+      const { GET } = await import("./jobs/route.js");
+      const res = await GET();
+      const json = await res.json();
+      expect(json.heartbeat.intervalMs).toBe(24 * 60 * 60_000);
+    });
+
+    it("falls back to 24h when heartbeat.every is missing", async () => {
+      const { existsSync: mockExists, readFileSync: mockReadFile } = await import("node:fs");
+      vi.mocked(mockExists).mockImplementation((p) => String(p).endsWith("openclaw.json"));
+      vi.mocked(mockReadFile).mockImplementation((p) => {
+        if (String(p).endsWith("openclaw.json")) {
+          return JSON.stringify({ agents: { defaults: {} } }) as never;
+        }
+        return "" as never;
+      });
+
+      const { GET } = await import("./jobs/route.js");
+      const res = await GET();
+      const json = await res.json();
+      expect(json.heartbeat.intervalMs).toBe(24 * 60 * 60_000);
+    });
+
+    it("falls back to 24h when openclaw.json is missing entirely", async () => {
+      const { existsSync: mockExists } = await import("node:fs");
+      vi.mocked(mockExists).mockReturnValue(false);
+
+      const { GET } = await import("./jobs/route.js");
+      const res = await GET();
+      const json = await res.json();
+      expect(json.heartbeat.intervalMs).toBe(24 * 60 * 60_000);
+    });
+  });
+
+  // ─── parseDurationToMs ───────────────────────────────────────────
+
+  describe("parseDurationToMs", () => {
+    it("parses single-unit durations", async () => {
+      const { parseDurationToMs } = await import("./jobs/route.js");
+      expect(parseDurationToMs("24h")).toBe(24 * 60 * 60_000);
+      expect(parseDurationToMs("30m")).toBe(30 * 60_000);
+      expect(parseDurationToMs("45s")).toBe(45_000);
+      expect(parseDurationToMs("2d")).toBe(2 * 24 * 60 * 60_000);
+    });
+
+    it("sums compound durations like 1h30m", async () => {
+      const { parseDurationToMs } = await import("./jobs/route.js");
+      expect(parseDurationToMs("1h30m")).toBe(60 * 60_000 + 30 * 60_000);
+      expect(parseDurationToMs("1d12h")).toBe(36 * 60 * 60_000);
+    });
+
+    it("is case-insensitive on units", async () => {
+      const { parseDurationToMs } = await import("./jobs/route.js");
+      expect(parseDurationToMs("24H")).toBe(24 * 60 * 60_000);
+    });
+
+    it("returns null for unparseable input", async () => {
+      const { parseDurationToMs } = await import("./jobs/route.js");
+      expect(parseDurationToMs("")).toBeNull();
+      expect(parseDurationToMs("forever")).toBeNull();
+      expect(parseDurationToMs("24h junk")).toBeNull();
+    });
   });
 
   // ─── GET /api/cron/jobs/[jobId]/runs ────────────────────────────

--- a/apps/web/app/api/cron/jobs/route.ts
+++ b/apps/web/app/api/cron/jobs/route.ts
@@ -6,6 +6,12 @@ export const dynamic = "force-dynamic";
 
 const CRON_DIR = join(resolveOpenClawStateDir(), "cron");
 const JOBS_FILE = join(CRON_DIR, "jobs.json");
+const OPENCLAW_CONFIG_FILE = join(resolveOpenClawStateDir(), "openclaw.json");
+
+// Default when the user hasn't customized agents.defaults.heartbeat.every.
+// Mirrors the bootstrap default applied by ensureAgentDefaults() in
+// src/cli/bootstrap-external.ts.
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 24 * 60 * 60_000;
 
 type CronStoreFile = {
   version: 1;
@@ -40,14 +46,71 @@ function computeNextWakeAtMs(jobs: Array<Record<string, unknown>>): number | nul
   return min;
 }
 
-/** Read heartbeat config from ~/.openclaw/config.yaml (best-effort). */
-function readHeartbeatInfo(): { intervalMs: number; nextDueEstimateMs: number | null } {
-  const defaults = { intervalMs: 30 * 60_000, nextDueEstimateMs: null as number | null };
+/**
+ * Parse OpenClaw duration strings like "24h", "30m", "1h30m", "45s", "2d"
+ * into milliseconds. Compound units sum (e.g. "1h30m" -> 5_400_000).
+ * Returns null for empty input or strings with no recognisable units.
+ */
+export function parseDurationToMs(value: string): number | null {
+  if (typeof value !== "string") {return null;}
+  const trimmed = value.trim();
+  if (!trimmed) {return null;}
+  const unitMs: Record<string, number> = {
+    s: 1_000,
+    m: 60_000,
+    h: 3_600_000,
+    d: 86_400_000,
+  };
+  const matches = trimmed.matchAll(/(\d+)\s*([smhd])/gi);
+  let total = 0;
+  let matched = false;
+  let consumed = 0;
+  for (const m of matches) {
+    matched = true;
+    const amount = Number(m[1]);
+    const unit = m[2].toLowerCase();
+    total += amount * unitMs[unit];
+    consumed += m[0].length;
+  }
+  if (!matched) {return null;}
+  // Reject inputs with junk between/around the duration tokens (e.g. "24h junk").
+  const stripped = trimmed.replaceAll(/\s+/g, "");
+  if (consumed !== stripped.length) {return null;}
+  return total;
+}
 
-  // Try to read agent session stores to estimate next heartbeat from lastRunMs
+/**
+ * Read agents.defaults.heartbeat.every from the active openclaw.json and
+ * return the configured interval in milliseconds. Falls back to the
+ * Dench-recommended default (24h) when the key is missing or unparseable
+ * so the dashboard never silently shows a wrong number.
+ */
+function readHeartbeatIntervalMs(): number {
+  try {
+    if (!existsSync(OPENCLAW_CONFIG_FILE)) {return DEFAULT_HEARTBEAT_INTERVAL_MS;}
+    const raw = readFileSync(OPENCLAW_CONFIG_FILE, "utf-8");
+    const cfg = JSON.parse(raw) as Record<string, unknown>;
+    const agents = cfg.agents as { defaults?: { heartbeat?: { every?: unknown } } } | undefined;
+    const every = agents?.defaults?.heartbeat?.every;
+    if (typeof every === "string") {
+      const parsed = parseDurationToMs(every);
+      if (parsed != null && parsed > 0) {return parsed;}
+    }
+  } catch {
+    // ignore — fall through to default
+  }
+  return DEFAULT_HEARTBEAT_INTERVAL_MS;
+}
+
+/**
+ * Estimate when the next heartbeat will fire based on the most recent agent
+ * session activity plus the configured interval. Returns null when no session
+ * activity is available.
+ */
+function estimateNextHeartbeatMs(intervalMs: number): number | null {
   try {
     const agentsDir = join(resolveOpenClawStateDir(), "agents");
-    if (!existsSync(agentsDir)) {return defaults;}
+    if (!existsSync(agentsDir)) {return null;}
 
     const agentDirs = readdirSync(agentsDir, { withFileTypes: true });
     let latestHeartbeat: number | null = null;
@@ -72,14 +135,18 @@ function readHeartbeatInfo(): { intervalMs: number; nextDueEstimateMs: number | 
       }
     }
 
-    if (latestHeartbeat) {
-      defaults.nextDueEstimateMs = latestHeartbeat + defaults.intervalMs;
-    }
+    if (latestHeartbeat) {return latestHeartbeat + intervalMs;}
   } catch {
     // ignore
   }
+  return null;
+}
 
-  return defaults;
+/** Read heartbeat config + estimated next fire time. */
+function readHeartbeatInfo(): { intervalMs: number; nextDueEstimateMs: number | null } {
+  const intervalMs = readHeartbeatIntervalMs();
+  const nextDueEstimateMs = estimateNextHeartbeatMs(intervalMs);
+  return { intervalMs, nextDueEstimateMs };
 }
 
 /** GET /api/cron/jobs -- list all cron jobs with heartbeat & status info */

--- a/apps/web/app/components/cron/cron-dashboard.test.tsx
+++ b/apps/web/app/components/cron/cron-dashboard.test.tsx
@@ -70,7 +70,7 @@ const jobsResponse = {
       },
     },
   ],
-  heartbeat: { intervalMs: 30 * 60_000, nextDueEstimateMs: null },
+  heartbeat: { intervalMs: 24 * 60 * 60_000, nextDueEstimateMs: null },
   cronStatus: { enabled: true, nextWakeAtMs: ms("2026-03-21T18:00:00-07:00") },
 };
 

--- a/apps/web/app/components/cron/cron-dashboard.tsx
+++ b/apps/web/app/components/cron/cron-dashboard.tsx
@@ -114,7 +114,7 @@ export function CronDashboard({
   onCalendarDateChange?: (date: string | null) => void;
 }) {
   const [jobs, setJobs] = useState<CronJob[]>([]);
-  const [heartbeat, setHeartbeat] = useState<HeartbeatInfo>({ intervalMs: 30 * 60_000, nextDueEstimateMs: null });
+  const [heartbeat, setHeartbeat] = useState<HeartbeatInfo>({ intervalMs: 24 * 60 * 60_000, nextDueEstimateMs: null });
   const [cronStatus, setCronStatus] = useState<CronStatusInfo>({ enabled: false, nextWakeAtMs: null });
   const [loading, setLoading] = useState(true);
   const [allRuns, setAllRuns] = useState<CronRunLogEntry[]>([]);
@@ -124,7 +124,7 @@ export function CronDashboard({
       const res = await fetch("/api/cron/jobs");
       const data: CronJobsResponse = await res.json();
       setJobs(data.jobs ?? []);
-      setHeartbeat(data.heartbeat ?? { intervalMs: 30 * 60_000, nextDueEstimateMs: null });
+      setHeartbeat(data.heartbeat ?? { intervalMs: 24 * 60 * 60_000, nextDueEstimateMs: null });
       setCronStatus(data.cronStatus ?? { enabled: false, nextWakeAtMs: null });
 
       const jobIds = (data.jobs ?? []).map((j) => j.id);

--- a/src/cli/bootstrap-external.bootstrap-command.test.ts
+++ b/src/cli/bootstrap-external.bootstrap-command.test.ts
@@ -2111,6 +2111,7 @@ describe("bootstrapCommand always-onboard behavior", () => {
       { key: "agents.defaults.elevatedDefault", value: "on" },
       { key: "commands.bash", value: "true" },
       { key: "commands.config", value: "true" },
+      { key: "agents.defaults.heartbeat.every", value: "24h" },
     ];
 
     for (const { key, value } of elevatedSettings) {
@@ -2207,6 +2208,7 @@ describe("bootstrapCommand always-onboard behavior", () => {
     expect(finalConfig.commands?.bash).toBe(true);
     expect(finalConfig.commands?.config).toBe(true);
     expect(finalConfig.agents?.defaults?.timeoutSeconds).toBe(86400);
+    expect(finalConfig.agents?.defaults?.heartbeat?.every).toBe("24h");
     expect(finalConfig.tools?.profile).toBe("full");
   });
 

--- a/src/cli/bootstrap-external.ts
+++ b/src/cli/bootstrap-external.ts
@@ -1020,6 +1020,10 @@ async function ensureAgentDefaults(openclawCommand: string, profile: string): Pr
     ["agents.defaults.elevatedDefault", "on"],
     ["commands.bash", "true"],
     ["commands.config", "true"],
+    // Heartbeat: once a day instead of OpenClaw's stock 30m. Heartbeats wake
+    // the agent for autonomous follow-ups; 30m is too chatty for Dench's
+    // always-on workspace UX. See agents.defaults.heartbeat in openclaw.json.
+    ["agents.defaults.heartbeat.every", "24h"],
   ];
   for (const [key, value] of settings) {
     await runOpenClawOrThrow({


### PR DESCRIPTION
## Summary

- Bootstrap (`ensureAgentDefaults` in `src/cli/bootstrap-external.ts`) now sets `agents.defaults.heartbeat.every = "24h"` so fresh installs stop inheriting OpenClaw's stock 30m heartbeat cadence — too chatty for Dench's always-on workspace UX.
- Cron dashboard's "Heartbeat" status card no longer lies. `apps/web/app/api/cron/jobs/route.ts` now reads `agents.defaults.heartbeat.every` from the active `openclaw.json`, parses it via a small `parseDurationToMs` helper (supports `24h`, `30m`, `1h30m`, `45s`, `2d`, …, case-insensitive, rejects junk), and uses the real interval for the `nextDueEstimateMs` projection.
- Client-side fallback in `cron-dashboard.tsx` and its test fixture bumped from `30 * 60_000` to `24 * 60 * 60_000` to match the new server default.

## Test plan

- [x] `pnpm vitest run --config vitest.unit.config.ts src/cli/bootstrap-external.bootstrap-command.test.ts` — 46/46 pass (includes new `agents.defaults.heartbeat.every=24h` assertions in both the post-onboard CLI-call list and the final-config snapshot).
- [x] `pnpm --dir apps/web vitest run app/api/cron/cron.test.ts app/components/cron/cron-dashboard.test.tsx` — 18/18 pass (includes 4 new tests for the openclaw.json reader + missing-key/missing-file fallbacks, plus 4 new unit tests for `parseDurationToMs`).
- [x] Lint clean on all touched files (`pnpm lint apps/web/app/api/cron/jobs/route.ts apps/web/app/api/cron/cron.test.ts` → 0 errors).
- [ ] After merge: re-run `denchclaw bootstrap` on a profile and confirm `openclaw --profile dench config get agents.defaults.heartbeat.every` returns `24h`.
- [ ] After merge: open the cron dashboard and confirm "Interval: 24h" is displayed in the Heartbeat card (instead of the previous hardcoded "30m").

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes how heartbeat intervals are derived (now parsed from `openclaw.json`) and affects dashboard scheduling/estimates; parsing/IO edge cases could misreport timing if incorrect.
> 
> **Overview**
> Cron heartbeat reporting is updated to use the **live** `agents.defaults.heartbeat.every` value from `openclaw.json` (defaulting to `24h` when missing/unparseable) instead of a hardcoded interval, and the server now estimates `nextDueEstimateMs` using that configured interval.
> 
> This introduces a small duration parser (`parseDurationToMs`) supporting compound values like `1h30m` and adds/updates unit tests around config fallbacks and parsing behavior.
> 
> Bootstrap now explicitly seeds `agents.defaults.heartbeat.every=24h`, and the cron dashboard client/test fixtures update their fallback heartbeat interval to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecce6f29facafef71353f7569dc5955bdd538115. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->