### PR TITLE
fix(cron): move parseDurationToMs into lib/duration so the web build passes

### DIFF
--- a/apps/web/app/api/cron/cron.test.ts
+++ b/apps/web/app/api/cron/cron.test.ts
@@ -119,7 +119,7 @@ describe("Cron API routes", () => {
 
   describe("parseDurationToMs", () => {
     it("parses single-unit durations", async () => {
-      const { parseDurationToMs } = await import("./jobs/route.js");
+      const { parseDurationToMs } = await import("@/lib/duration");
       expect(parseDurationToMs("24h")).toBe(24 * 60 * 60_000);
       expect(parseDurationToMs("30m")).toBe(30 * 60_000);
       expect(parseDurationToMs("45s")).toBe(45_000);
@@ -127,18 +127,18 @@ describe("Cron API routes", () => {
     });
 
     it("sums compound durations like 1h30m", async () => {
-      const { parseDurationToMs } = await import("./jobs/route.js");
+      const { parseDurationToMs } = await import("@/lib/duration");
       expect(parseDurationToMs("1h30m")).toBe(60 * 60_000 + 30 * 60_000);
       expect(parseDurationToMs("1d12h")).toBe(36 * 60 * 60_000);
     });
 
     it("is case-insensitive on units", async () => {
-      const { parseDurationToMs } = await import("./jobs/route.js");
+      const { parseDurationToMs } = await import("@/lib/duration");
       expect(parseDurationToMs("24H")).toBe(24 * 60 * 60_000);
     });
 
     it("returns null for unparseable input", async () => {
-      const { parseDurationToMs } = await import("./jobs/route.js");
+      const { parseDurationToMs } = await import("@/lib/duration");
       expect(parseDurationToMs("")).toBeNull();
       expect(parseDurationToMs("forever")).toBeNull();
       expect(parseDurationToMs("24h junk")).toBeNull();

--- a/apps/web/app/api/cron/jobs/route.ts
+++ b/apps/web/app/api/cron/jobs/route.ts
@@ -1,5 +1,6 @@
 import { readFileSync, existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
+import { parseDurationToMs } from "@/lib/duration";
 import { resolveOpenClawStateDir } from "@/lib/workspace";
 
 export const dynamic = "force-dynamic";
@@ -44,39 +45,6 @@ function computeNextWakeAtMs(jobs: Array<Record<string, unknown>>): number | nul
     }
   }
   return min;
-}
-
-/**
- * Parse OpenClaw duration strings like "24h", "30m", "1h30m", "45s", "2d"
- * into milliseconds. Compound units sum (e.g. "1h30m" -> 5_400_000).
- * Returns null for empty input or strings with no recognisable units.
- */
-export function parseDurationToMs(value: string): number | null {
-  if (typeof value !== "string") {return null;}
-  const trimmed = value.trim();
-  if (!trimmed) {return null;}
-  const unitMs: Record<string, number> = {
-    s: 1_000,
-    m: 60_000,
-    h: 3_600_000,
-    d: 86_400_000,
-  };
-  const matches = trimmed.matchAll(/(\d+)\s*([smhd])/gi);
-  let total = 0;
-  let matched = false;
-  let consumed = 0;
-  for (const m of matches) {
-    matched = true;
-    const amount = Number(m[1]);
-    const unit = m[2].toLowerCase();
-    total += amount * unitMs[unit];
-    consumed += m[0].length;
-  }
-  if (!matched) {return null;}
-  // Reject inputs with junk between/around the duration tokens (e.g. "24h junk").
-  const stripped = trimmed.replaceAll(/\s+/g, "");
-  if (consumed !== stripped.length) {return null;}
-  return total;
 }
 
 /**

--- a/apps/web/lib/duration.ts
+++ b/apps/web/lib/duration.ts
@@ -1,0 +1,46 @@
+/**
+ * Duration string helpers shared between API routes and config readers.
+ *
+ * OpenClaw config values (e.g. `agents.defaults.heartbeat.every`) are written
+ * as compact strings like `"24h"`, `"30m"`, `"1h30m"`, `"45s"`, or `"2d"`.
+ * These helpers parse them into milliseconds so callers can compare against
+ * timestamps without re-implementing the same regex everywhere.
+ *
+ * Lives in `lib/` (not in a route file) because Next.js route handlers are
+ * only allowed to export specific fields (`GET`, `POST`, `dynamic`, etc.) —
+ * any other named export fails the build.
+ */
+
+/**
+ * Parse OpenClaw duration strings like "24h", "30m", "1h30m", "45s", "2d"
+ * into milliseconds. Compound units sum (e.g. "1h30m" -> 5_400_000).
+ * Returns null for empty input or strings with no recognisable units, and
+ * also for inputs with junk between/around the duration tokens
+ * (e.g. "24h junk" -> null) so we don't silently accept malformed config.
+ */
+export function parseDurationToMs(value: string): number | null {
+  if (typeof value !== "string") {return null;}
+  const trimmed = value.trim();
+  if (!trimmed) {return null;}
+  const unitMs: Record<string, number> = {
+    s: 1_000,
+    m: 60_000,
+    h: 3_600_000,
+    d: 86_400_000,
+  };
+  const matches = trimmed.matchAll(/(\d+)\s*([smhd])/gi);
+  let total = 0;
+  let matched = false;
+  let consumed = 0;
+  for (const m of matches) {
+    matched = true;
+    const amount = Number(m[1]);
+    const unit = m[2].toLowerCase();
+    total += amount * unitMs[unit];
+    consumed += m[0].length;
+  }
+  if (!matched) {return null;}
+  const stripped = trimmed.replaceAll(/\s+/g, "");
+  if (consumed !== stripped.length) {return null;}
+  return total;
+}


### PR DESCRIPTION
## Summary

The web production build (`pnpm web:build`) was failing during type-checking with:

```
app/api/cron/jobs/route.ts
Type error: Route "app/api/cron/jobs/route.ts" does not match the required types of a Next.js Route.
  "parseDurationToMs" is not a valid Route export field.
```

Next.js 15 only allows a fixed set of named exports from a `route.ts` file (HTTP method handlers like `GET`/`POST`, plus config like `dynamic`, `runtime`, `maxDuration`, etc.). The cron jobs route was also exporting `parseDurationToMs` so the test could import it, which Next.js rejects.

This PR extracts the helper into a small shared module so the route file no longer carries a disallowed export.

## Changes

- Add `apps/web/lib/duration.ts` containing `parseDurationToMs`, with a header note explaining why it lives in `lib/` rather than next to the route.
- `apps/web/app/api/cron/jobs/route.ts` now imports `parseDurationToMs` from `@/lib/duration` instead of defining and exporting it locally. `readHeartbeatIntervalMs` keeps using it unchanged — no behavioural change.
- `apps/web/app/api/cron/cron.test.ts` updates the four `await import("./jobs/route.js")` calls in the `parseDurationToMs` describe block to `await import("@/lib/duration")`.

## Test plan

- [x] `pnpm web:build` exits 0 (previously failed with the type error above).
- [x] `pnpm --filter denchclaw-web exec vitest run app/api/cron/cron.test.ts` — all 16 tests pass, including the 4 `parseDurationToMs` cases.
- [x] No new lint errors in the touched files.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that relocates a pure helper function and updates imports; behavior should be unchanged, with main risk limited to module resolution/packaging in the web build.
> 
> **Overview**
> Fixes a Next.js route build/type-check failure by **removing a non-route named export** from `app/api/cron/jobs/route.ts`.
> 
> `parseDurationToMs` is extracted into a new shared module `@/lib/duration`, the cron jobs route now imports it instead of exporting it, and the cron API tests are updated to import the helper from the new location.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9963c504037e30787131433d60290aa5eae7fb99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->