### PR TITLE
fix(web): sidebar CRM folders disappear due to DuckDB stringified booleans (#215)

### DIFF
--- a/apps/web/app/api/workspace/tree-browse.test.ts
+++ b/apps/web/app/api/workspace/tree-browse.test.ts
@@ -193,6 +193,53 @@ describe("Workspace Tree & Browse API", () => {
       expect(rootPaths).not.toContain("~skills");
     });
 
+    it("does not hide objects when DuckDB returns hidden_in_sidebar as the string \"false\"", async () => {
+      // Regression test for #215. DuckDB's `-json` CLI mode serializes
+      // BOOLEAN columns as JSON strings (`"true"` / `"false"`). The
+      // string `"false"` is truthy in JS, so a naive
+      // `if (row.hidden_in_sidebar)` check used to mark every object as
+      // hidden — wiping all CRM folders (people, company, …) from the
+      // sidebar tree.
+      const { resolveWorkspaceRoot, duckdbQueryAllAsync } = await import("@/lib/workspace");
+      vi.mocked(resolveWorkspaceRoot).mockReturnValue("/ws");
+      vi.mocked(duckdbQueryAllAsync).mockResolvedValue([
+        { name: "people", default_view: "table", hidden_in_sidebar: "false" },
+        { name: "company", default_view: "table", hidden_in_sidebar: "false" },
+        { name: "opportunity", default_view: "kanban", hidden_in_sidebar: "false" },
+        // Real boolean true should still hide. CRM-only objects stay
+        // hidden either way thanks to HARDCODED_HIDDEN_OBJECT_NAMES.
+        { name: "secret", default_view: "table", hidden_in_sidebar: "true" },
+      ] as never);
+
+      const { readdir: mockReaddir } = await import("node:fs/promises");
+      vi.mocked(mockReaddir).mockImplementation((dir) => {
+        if (String(dir) === "/ws") {
+          return Promise.resolve([
+            makeDirent("people", true),
+            makeDirent("company", true),
+            makeDirent("opportunity", true),
+            makeDirent("secret", true),
+            makeDirent("email_thread", true),
+          ] as unknown as Dirent[]);
+        }
+        return Promise.resolve([] as unknown as Dirent[]);
+      });
+
+      const { GET } = await import("./tree/route.js");
+      const req = new Request("http://localhost/api/workspace/tree");
+      const res = await GET(req);
+      const json = await res.json();
+      const rootPaths = (json.tree as Array<{ path: string }>).map((n) => n.path);
+      // All visible objects must appear in the tree.
+      expect(rootPaths).toContain("people");
+      expect(rootPaths).toContain("company");
+      expect(rootPaths).toContain("opportunity");
+      // The row marked `hidden_in_sidebar = "true"` should be filtered out.
+      expect(rootPaths).not.toContain("secret");
+      // Hardcoded-hidden CRM objects stay hidden regardless of the DB value.
+      expect(rootPaths).not.toContain("email_thread");
+    });
+
     it("yields before tree discovery completes (prevents UI freeze during active agent runs)", async () => {
       const { resolveWorkspaceRoot, duckdbQueryAll, duckdbQueryAllAsync } = await import("@/lib/workspace");
       vi.mocked(resolveWorkspaceRoot).mockReturnValue("/ws");

--- a/apps/web/app/api/workspace/tree/route.ts
+++ b/apps/web/app/api/workspace/tree/route.ts
@@ -38,8 +38,31 @@ export type TreeNode = {
 type DbObject = {
   name: string;
   default_view?: string;
-  hidden_in_sidebar?: boolean | null;
+  /**
+   * DuckDB's `-json` CLI mode serializes BOOLEAN columns as JSON strings
+   * (`"true"` / `"false"`), so the value can arrive as either a real
+   * boolean or the string-coerced form depending on the underlying
+   * driver. Always normalize via `parseDuckdbBool` before reading.
+   */
+  hidden_in_sidebar?: boolean | string | number | null;
 };
+
+/**
+ * Parse a value that may be a real boolean OR a DuckDB-CLI string
+ * representation (`"true"`/`"false"`/`"0"`/`"1"`). Necessary because
+ * `duckdb -json` emits booleans as strings, which makes a naive
+ * `if (row.bool_col)` check treat `"false"` as truthy.
+ */
+function parseDuckdbBool(value: unknown): boolean {
+  if (value === true) {return true;}
+  if (value === false || value == null) {return false;}
+  if (typeof value === "number") {return value !== 0;}
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return normalized === "true" || normalized === "1" || normalized === "t";
+  }
+  return false;
+}
 
 /** Read .object.yaml metadata from a directory if it exists. */
 async function pathExists(path: string): Promise<boolean> {
@@ -123,7 +146,10 @@ async function loadDbObjects(): Promise<{
     );
   }
   for (const row of rows) {
-    if (row.hidden_in_sidebar || HARDCODED_HIDDEN_OBJECT_NAMES.has(row.name)) {
+    // CRITICAL: `row.hidden_in_sidebar` may arrive as the literal string
+    // `"false"` from DuckDB's `-json` CLI mode (truthy in JS). Use
+    // `parseDuckdbBool` so we don't accidentally hide every object.
+    if (parseDuckdbBool(row.hidden_in_sidebar) || HARDCODED_HIDDEN_OBJECT_NAMES.has(row.name)) {
       hidden.add(row.name);
       // Skip CRM-only objects (email_thread / email_message / calendar_event /
       // interaction). They have dedicated UI and shouldn't show in the tree.


### PR DESCRIPTION
## Summary

Fixes #215 — sidebar CRM sections (Companies, Opportunities, Tasks, …) disappear ~1–2 min after page load, leaving only the four hard-coded buttons (Calendar, Companies, People, Inbox).

**Root cause is not a name mismatch — it's a JS truthiness bug masked by an async migration.** DuckDB's `-json` CLI mode serializes `BOOLEAN` columns as JSON strings (`"true"` / `"false"`), not real booleans. `apps/web/app/api/workspace/tree/route.ts` did:

```ts
if (row.hidden_in_sidebar || HARDCODED_HIDDEN_OBJECT_NAMES.has(row.name)) { … }
```

`Boolean("false") === true`, so every row in `objects` ended up in the `hidden` set, and `buildTree` then dropped every top-level folder whose name matched a DB row.

**Verified empirically against the seeded workspace DB:**

```bash
$ duckdb -json assets/seed/workspace.duckdb \
    "SELECT name, hidden_in_sidebar FROM objects"
[{"name":"company","hidden_in_sidebar":"false"},
 {"name":"people","hidden_in_sidebar":"false"},
 {"name":"task","hidden_in_sidebar":"false"}, …]
```

### Why every observation in #215 lines up

| Observation | Explanation |
|---|---|
| "Loads first time, disappears after 1-2 minutes" | Schema migrations run async on startup. The first request hits the DB before `hidden_in_sidebar` exists → query throws → fallback returns rows without that field (`undefined`, falsy) → tree renders fine. Once the migration completes, `"false"` arrives → bug triggers. |
| "Original folders invisible — not even as `type: 'folder'`" | They're dropped at the `entries.filter` step in `buildTree`, before becoming a tree node. |
| "Newly created folders work" | No DB row yet → name not in `hidden` set → folder survives the filter; `.object.yaml` makes it render as `type: "object"`. |
| "Recreating with same name doesn't fix it" | DB row keeps the same name → still in `hidden`. |

The "Missing icon Column" secondary issue in the report appears to be a description error — the current `route.ts` doesn't reference `icon`, and `migrateIconsFromDuckdbToYaml` is already wrapped in try/catch.

## Changes

- `apps/web/app/api/workspace/tree/route.ts`
  - Added `parseDuckdbBool(value: unknown): boolean` helper, robust to real booleans, the string forms `"true"`/`"false"`/`"1"`/`"0"`/`"t"`, numbers, and `null`/`undefined`.
  - Widened `DbObject.hidden_in_sidebar` to `boolean | string | number | null` to reflect the wire shape, with a docblock pointing readers at the helper.
  - Replaced `row.hidden_in_sidebar` with `parseDuckdbBool(row.hidden_in_sidebar)`, plus a `CRITICAL:` comment so this isn't reintroduced.
- `apps/web/app/api/workspace/tree-browse.test.ts`
  - Regression test that mocks `duckdbQueryAllAsync` returning `hidden_in_sidebar: "false"` (the literal wire shape) for `people` / `company` / `opportunity`, plus a `"true"` case and a hard-coded-hidden case, and asserts the visible objects survive the filter.

## Test plan

- [x] `npx vitest run app/api/workspace/tree-browse.test.ts` — 15/15 pass, including the new regression test.
- [x] Standalone run of `sync-health-banner.test.tsx` (the only failure in the full suite) passes both with and without this diff — pre-existing parallel-run flake, unrelated.
- [x] Verified against seeded `assets/seed/workspace.duckdb`: returns `"false"` (string) for `hidden_in_sidebar`, which would trigger the bug on the old code path.
- [ ] Manual: start `pnpm web:dev`, wait past the migration window, refresh — all CRM object folders (people, company, task, …) stay visible in the sidebar tree.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrowly changes workspace-tree filtering by normalizing `hidden_in_sidebar` values and adds a regression test; minimal surface area beyond this route’s hidden-object logic.
> 
> **Overview**
> Fixes a sidebar-tree regression where DuckDB `-json` can return `hidden_in_sidebar` as the string `"false"`, which is truthy in JS and caused all objects to be treated as hidden.
> 
> `GET /api/workspace/tree` now normalizes `hidden_in_sidebar` via a new `parseDuckdbBool` helper (and widens the `DbObject` type accordingly) before deciding whether to hide an object. Adds a targeted regression test ensuring stringified `"false"` keeps CRM objects visible while `"true"` and hardcoded-hidden objects remain filtered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 673f3c8805a6b4fe3873611ab32248a523b56d23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->