### PR TITLE
Fix Apollo enrichment gateway payloads

### DIFF
--- a/apps/web/app/api/workspace/objects/[name]/enrich/route.test.ts
+++ b/apps/web/app/api/workspace/objects/[name]/enrich/route.test.ts
@@ -90,6 +90,59 @@ describe("workspace enrichment route", () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
+  it("forwards LinkedIn people enrichment with gateway-compatible snake_case keys", async () => {
+    const { duckdbQueryOnFile } = await import("@/lib/workspace");
+    vi.mocked(duckdbQueryOnFile).mockImplementation((_dbFile: string, sql: string) => {
+      if (sql.includes("SELECT id FROM objects WHERE name")) {
+        return [{ id: "obj_1" }] as never;
+      }
+      if (sql.includes("SELECT id, name FROM fields")) {
+        return [{ id: "input_1", name: "LinkedIn URL" }] as never;
+      }
+      if (sql.includes("SELECT id FROM fields WHERE id")) {
+        return [{ id: "field_1" }] as never;
+      }
+      if (sql.includes("FROM entries e")) {
+        return [{ entry_id: "entry_1", input_value: "https://www.linkedin.com/in/markrachapoom" }] as never;
+      }
+      if (sql.includes("COUNT(*) as cnt")) {
+        return [{ cnt: 0 }] as never;
+      }
+      return [] as never;
+    });
+
+    global.fetch = vi.fn(async (_input, init) => {
+      expect(JSON.parse(String(init?.body))).toMatchObject({
+        linkedin_url: "https://www.linkedin.com/in/markrachapoom",
+        mode: "max",
+      });
+      return new Response(JSON.stringify({ person: { name: "Mark Rachapoom" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const { POST } = await import("./route.js");
+    const response = await POST(
+      new Request("http://localhost/api/workspace/objects/leads/enrich", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          fieldId: "field_1",
+          apolloPath: "person.name",
+          category: "people",
+          inputFieldName: "LinkedIn URL",
+          scope: 1,
+        }),
+      }),
+      { params: Promise.resolve({ name: "leads" }) },
+    );
+
+    expect(response.status).toBe(200);
+    await response.text();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
   it("forwards mode=max for company enrichment requests when enabled", async () => {
     const { duckdbQueryOnFile } = await import("@/lib/workspace");
     vi.mocked(duckdbQueryOnFile).mockImplementation((_dbFile: string, sql: string) => {

--- a/apps/web/app/api/workspace/objects/[name]/enrich/route.ts
+++ b/apps/web/app/api/workspace/objects/[name]/enrich/route.ts
@@ -267,7 +267,7 @@ async function callApolloGateway(
 		const body: Record<string, string> = {};
 
 		if (inputValue.includes("linkedin.com")) {
-			body.linkedinUrl = inputValue;
+			body.linkedin_url = inputValue;
 		} else if (inputValue.includes("@")) {
 			body.email = inputValue;
 		} else {

--- a/apps/web/lib/dench-cloud-settings.test.ts
+++ b/apps/web/lib/dench-cloud-settings.test.ts
@@ -147,10 +147,15 @@ import {
   saveVoiceId,
   selectModel,
 } from "./dench-cloud-settings";
+import {
+  readIntegrationsMetadata,
+  writeIntegrationsMetadata,
+} from "./integrations";
 
 describe("dench cloud settings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(readIntegrationsMetadata).mockReturnValue({ schemaVersion: 1 });
     mocks.state.configText = "{}\n";
     mocks.validateDenchCloudApiKey.mockResolvedValue(undefined);
     mocks.fetchDenchCloudCatalog.mockResolvedValue({
@@ -273,12 +278,15 @@ describe("dench cloud settings", () => {
   });
 
   it("returns the stored enrichment max mode setting in cloud state", async () => {
+    vi.mocked(readIntegrationsMetadata).mockReturnValue({
+      schemaVersion: 1,
+      apollo: { enrichmentMaxMode: true },
+    });
     mocks.state.configText = JSON.stringify({
       models: {
         providers: {
           "dench-cloud": {
             apiKey: "dc-key",
-            enrichmentMaxMode: true,
           },
         },
       },
@@ -323,6 +331,10 @@ describe("dench cloud settings", () => {
     });
 
     const written = JSON.parse(mocks.state.configText);
-    expect(written.models.providers["dench-cloud"].enrichmentMaxMode).toBe(true);
+    expect(writeIntegrationsMetadata).toHaveBeenCalledWith({
+      schemaVersion: 1,
+      apollo: { enrichmentMaxMode: true },
+    });
+    expect(written.models.providers["dench-cloud"].enrichmentMaxMode).toBeUndefined();
   });
 });

--- a/apps/web/lib/dench-cloud-settings.ts
+++ b/apps/web/lib/dench-cloud-settings.ts
@@ -78,6 +78,14 @@ function resolveDenchApiKey(config: UnknownRecord): string | null {
 }
 
 function readDenchEnrichmentMaxModeEnabled(config: UnknownRecord): boolean {
+  try {
+    const metadataValue = readIntegrationsMetadata().apollo?.enrichmentMaxMode;
+    if (typeof metadataValue === "boolean") {
+      return metadataValue;
+    }
+  } catch {
+    // Fall back to the legacy config location if metadata is unavailable.
+  }
   const models = asRecord(config.models);
   const provider = asRecord(asRecord(models?.providers)?.["dench-cloud"]);
   return provider?.enrichmentMaxMode === true;
@@ -539,6 +547,8 @@ export async function saveActiveCloudSettings(
   const currentEnrichmentMaxModeEnabled = readDenchEnrichmentMaxModeEnabled(config);
   const nextVoiceId = input.voiceId?.trim() || null;
   const nextEnrichmentMaxModeEnabled = input.enrichmentMaxModeEnabled === true;
+  const metadata = readIntegrationsMetadata();
+  let nextMetadata = metadata;
   let changed = false;
   let requiresRefresh = false;
 
@@ -604,21 +614,25 @@ export async function saveActiveCloudSettings(
     changed = true;
   }
 
-  if (currentEnrichmentMaxModeEnabled !== nextEnrichmentMaxModeEnabled) {
-    const models = ensureRecord(config, "models");
-    const providers = ensureRecord(models, "providers");
-    const denchCloud = ensureRecord(providers, "dench-cloud");
-    if (nextEnrichmentMaxModeEnabled) {
-      denchCloud.enrichmentMaxMode = true;
-    } else {
-      delete denchCloud.enrichmentMaxMode;
+  const legacyDenchProvider = asRecord(asRecord(asRecord(config.models)?.providers)?.["dench-cloud"]);
+  if (
+    currentEnrichmentMaxModeEnabled !== nextEnrichmentMaxModeEnabled ||
+    legacyDenchProvider?.enrichmentMaxMode !== undefined
+  ) {
+    nextMetadata = {
+      ...nextMetadata,
+      schemaVersion: 1,
+      apollo: nextEnrichmentMaxModeEnabled
+        ? { ...(nextMetadata.apollo ?? {}), enrichmentMaxMode: true }
+        : {},
+    };
+    if (legacyDenchProvider) {
+      delete legacyDenchProvider.enrichmentMaxMode;
     }
     changed = true;
   }
 
   const requestedIntegrations = input.integrations ?? {};
-  const metadata = readIntegrationsMetadata();
-  let nextMetadata = metadata;
 
   for (const id of ["exa", "apollo", "elevenlabs"] as DenchIntegrationId[]) {
     const requested = requestedIntegrations[id];

--- a/apps/web/lib/integrations.ts
+++ b/apps/web/lib/integrations.ts
@@ -27,7 +27,9 @@ export type DenchIntegrationMetadata = {
     ownsSearch?: boolean;
     fallbackProvider?: string | null;
   };
-  apollo?: Record<string, never>;
+  apollo?: {
+    enrichmentMaxMode?: boolean;
+  };
   elevenlabs?: Record<string, never>;
   future?: {
     composio?: {
@@ -236,7 +238,9 @@ export function readIntegrationsMetadata(): DenchIntegrationMetadata {
   return {
     schemaVersion,
     ...(asRecord(parsed)?.exa ? { exa: asRecord(parsed)?.exa as DenchIntegrationMetadata["exa"] } : {}),
-    ...(asRecord(parsed)?.apollo ? { apollo: {} } : {}),
+    ...(asRecord(parsed)?.apollo
+      ? { apollo: asRecord(parsed)?.apollo as DenchIntegrationMetadata["apollo"] }
+      : {}),
     ...(asRecord(parsed)?.elevenlabs ? { elevenlabs: {} } : {}),
     ...(asRecord(parsed)?.future ? { future: asRecord(parsed)?.future as DenchIntegrationMetadata["future"] } : {}),
   };
@@ -1307,9 +1311,12 @@ export function resolveDenchGatewayCredentials(): {
   const config = readOpenClawConfigForIntegrations();
   const models = asRecord(config.models);
   const provider = asRecord(asRecord(models?.providers)?.["dench-cloud"]);
+  const metadata = readIntegrationsMetadata();
   return {
     apiKey: resolveDenchApiKey(config),
     gatewayUrl: resolveGatewayBaseUrl(config),
-    enrichmentMaxModeEnabled: readBoolean(provider?.enrichmentMaxMode) === true,
+    enrichmentMaxModeEnabled:
+      metadata.apollo?.enrichmentMaxMode === true ||
+      readBoolean(provider?.enrichmentMaxMode) === true,
   };
 }

--- a/extensions/apollo-enrichment/index.test.ts
+++ b/extensions/apollo-enrichment/index.test.ts
@@ -24,10 +24,17 @@ function writeOpenClawConfig(stateDir: string, enrichmentMaxMode: boolean): void
     JSON.stringify({
       models: {
         providers: {
-          "dench-cloud": {
-            enrichmentMaxMode,
-          },
+          "dench-cloud": {},
         },
+      },
+    }),
+  );
+  writeFileSync(
+    path.join(stateDir, ".dench-integrations.json"),
+    JSON.stringify({
+      schemaVersion: 1,
+      apollo: {
+        enrichmentMaxMode,
       },
     }),
   );
@@ -35,27 +42,28 @@ function writeOpenClawConfig(stateDir: string, enrichmentMaxMode: boolean): void
 
 function createApi() {
   const tools: any[] = [];
-  return {
-    api: {
-      config: {
-        plugins: {
-          entries: {
-            "dench-ai-gateway": {
-              config: {
-                enabled: true,
-                gatewayUrl: "https://gateway.example.com",
-              },
+  const api = {
+    config: {
+      plugins: {
+        entries: {
+          "dench-ai-gateway": {
+            config: {
+              enabled: true,
+              gatewayUrl: "https://gateway.example.com",
             },
           },
         },
       },
-      registerTool(tool: any) {
-        tools.push(tool);
-      },
-      logger: {
-        info: vi.fn(),
-      },
     },
+    registerTool(tool: any) {
+      tools.push(tool);
+    },
+    logger: {
+      info: vi.fn(),
+    },
+  } as unknown as Parameters<typeof register>[0];
+  return {
+    api,
     tools,
   };
 }
@@ -105,6 +113,73 @@ describe("apollo-enrichment max mode", () => {
     await tools[0].execute("call_1", {
       action: "people",
       email: "jane@acme.com",
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends person name inputs with gateway-compatible snake_case keys", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "apollo-enrichment-state-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+    writeOpenClawConfig(stateDir, true);
+
+    globalThis.fetch = vi.fn(async (_input, init) => {
+      expect(JSON.parse(String(init?.body))).toMatchObject({
+        first_name: "Mark",
+        last_name: "Rachapoom",
+        organization_name: "Dench",
+        linkedin_url: "https://www.linkedin.com/in/markrachapoom",
+        mode: "max",
+      });
+      return new Response(JSON.stringify({ person: { email: "mark@dench.com" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const { api, tools } = createApi();
+    register(api);
+
+    await tools[0].execute("call_1", {
+      action: "people",
+      firstName: "Mark",
+      lastName: "Rachapoom",
+      organizationName: "Dench",
+      linkedinUrl: "https://www.linkedin.com/in/markrachapoom",
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends people search filters with gateway-compatible snake_case keys", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "apollo-enrichment-state-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+    writeOpenClawConfig(stateDir, false);
+
+    globalThis.fetch = vi.fn(async (_input, init) => {
+      expect(JSON.parse(String(init?.body))).toMatchObject({
+        person_titles: ["Founder"],
+        person_locations: ["San Francisco"],
+        organization_domains: ["dench.com"],
+        per_page: 5,
+      });
+      return new Response(JSON.stringify({ people: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const { api, tools } = createApi();
+    register(api);
+
+    await tools[0].execute("call_1", {
+      action: "people_search",
+      personTitles: ["Founder"],
+      personLocations: ["San Francisco"],
+      organizationDomains: ["dench.com"],
+      perPage: 5,
     });
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);

--- a/extensions/apollo-enrichment/index.ts
+++ b/extensions/apollo-enrichment/index.ts
@@ -111,19 +111,19 @@ function buildPeopleBody(params: Record<string, unknown>) {
     body.email = email;
   }
   if (linkedinUrl) {
-    body.linkedinUrl = linkedinUrl;
+    body.linkedin_url = linkedinUrl;
   }
   if (firstName) {
-    body.firstName = firstName;
+    body.first_name = firstName;
   }
   if (lastName) {
-    body.lastName = lastName;
+    body.last_name = lastName;
   }
   if (domain) {
     body.domain = domain;
   }
   if (organizationName) {
-    body.organizationName = organizationName;
+    body.organization_name = organizationName;
   }
 
   return body;
@@ -145,19 +145,19 @@ function buildPeopleSearchBody(params: Record<string, unknown>) {
         : undefined;
 
   if (personTitles) {
-    body.personTitles = personTitles;
+    body.person_titles = personTitles;
   }
   if (personLocations) {
-    body.personLocations = personLocations;
+    body.person_locations = personLocations;
   }
   if (organizationDomains) {
-    body.organizationDomains = organizationDomains;
+    body.organization_domains = organizationDomains;
   }
   if (page !== undefined) {
     body.page = page;
   }
   if (perPage !== undefined) {
-    body.perPage = perPage;
+    body.per_page = perPage;
   }
 
   return body;
@@ -193,7 +193,7 @@ async function executeApolloEnrich(
       if (enrichmentMaxModeEnabled) {
         body.mode = "max";
       }
-      if (!body.email && !body.linkedinUrl && !body.firstName && !body.lastName) {
+      if (!body.email && !body.linkedin_url && !body.first_name && !body.last_name) {
         return jsonResult({
           error: "People enrichment requires at least an email, LinkedIn URL, or person name.",
         });

--- a/extensions/shared/dench-auth.ts
+++ b/extensions/shared/dench-auth.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 const DEFAULT_GATEWAY_URL = "https://gateway.merseoriginals.com";
 const AUTH_PROFILES_REL = path.join("agents", "main", "agent", "auth-profiles.json");
 const OPENCLAW_CONFIG_FILENAME = "openclaw.json";
+const INTEGRATIONS_METADATA_FILENAME = ".dench-integrations.json";
 
 /**
  * Read the Dench Cloud API key from the single source of truth
@@ -53,10 +54,17 @@ export function readDenchEnrichmentMaxModeEnabled(): boolean {
   }
 
   try {
-    const configPath = path.join(stateDir, OPENCLAW_CONFIG_FILENAME);
-    if (!existsSync(configPath)) {
-      return false;
+    const metadataPath = path.join(stateDir, INTEGRATIONS_METADATA_FILENAME);
+    if (existsSync(metadataPath)) {
+      const metadata = JSON.parse(readFileSync(metadataPath, "utf-8"));
+      const metadataValue = metadata?.apollo?.enrichmentMaxMode;
+      if (typeof metadataValue === "boolean") {
+        return metadataValue;
+      }
     }
+
+    const configPath = path.join(stateDir, OPENCLAW_CONFIG_FILENAME);
+    if (!existsSync(configPath)) return false;
     const raw = JSON.parse(readFileSync(configPath, "utf-8"));
     return raw?.models?.providers?.["dench-cloud"]?.enrichmentMaxMode === true;
   } catch {


### PR DESCRIPTION
## Summary
- Send Apollo people enrichment payloads using the snake_case keys accepted by the Dench gateway, while keeping camelCase as the local tool/UI input shape.
- Store Apollo max-mode preference in Dench integration metadata instead of writing schema-invalid keys into `openclaw.json`.
- Add focused coverage for extension payload normalization, web LinkedIn enrichment requests, and settings persistence.

## Test plan
- `pnpm exec vitest run --config extensions/vitest.config.ts extensions/apollo-enrichment/index.test.ts`
- `pnpm --dir apps/web exec vitest run 'app/api/workspace/objects/[name]/enrich/route.test.ts' lib/dench-cloud-settings.test.ts`
- Verified local Dench gateway restarts cleanly after migrating local enrichment settings out of `openclaw.json`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the request payload shape sent to the Dench gateway and migrates how the enrichment max-mode preference is read/written, which could impact enrichment behavior or settings persistence if mismatched.
> 
> **Overview**
> Fixes Apollo enrichment requests to the Dench gateway by sending *snake_case* keys where required (e.g. `linkedin_url`, `first_name`, `per_page`) while keeping existing camelCase inputs for callers.
> 
> Moves the Apollo “max mode” preference out of `openclaw.json` into `.dench-integrations.json` metadata (with legacy fallback + cleanup of old config keys), and updates credential resolution to consider metadata.
> 
> Adds focused tests covering LinkedIn people enrichment payload forwarding in the web API, payload normalization in the `apollo-enrichment` extension, and persistence/reading of the max-mode setting via integrations metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2ea777bd8102787db62b7b692a0f3056589b966. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->