### PR TITLE
fix(settings): sync Dench auth profile key

### DIFF
--- a/apps/web/app/api/onboarding/dench-cloud/route.test.ts
+++ b/apps/web/app/api/onboarding/dench-cloud/route.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/denchclaw-state", () => ({
+  advanceOnboardingStep: vi.fn(() => ({ currentStep: "connect-gmail" })),
+  readOnboardingState: vi.fn(() => ({ currentStep: "dench-cloud" })),
+}));
+
+vi.mock("@/lib/workspace", () => ({
+  resolveOpenClawStateDir: vi.fn(() => "/home/testuser/.openclaw-dench"),
+}));
+
+vi.mock("@/lib/composio", () => ({
+  resolveComposioApiKey: vi.fn(() => null),
+}));
+
+vi.mock("@/lib/dench-auth", () => ({
+  writeDenchAuthProfileKey: vi.fn(),
+}));
+
+vi.mock("@/lib/dench-cloud-settings", () => ({
+  saveApiKey: vi.fn(),
+  selectModel: vi.fn(),
+}));
+
+vi.mock("../../../../../../src/cli/dench-cloud", () => ({
+  RECOMMENDED_DENCH_CLOUD_MODEL_ID: "claude-sonnet-4.6",
+  readConfiguredDenchCloudSettings: vi.fn(() => ({ selectedModel: null })),
+}));
+
+vi.mock("@/lib/telemetry", () => ({
+  trackServer: vi.fn(),
+}));
+
+const { POST } = await import("./route");
+const { saveApiKey, selectModel } = await import("@/lib/dench-cloud-settings");
+const { writeDenchAuthProfileKey } = await import("@/lib/dench-auth");
+
+const mockedSaveApiKey = vi.mocked(saveApiKey);
+const mockedSelectModel = vi.mocked(selectModel);
+const mockedWriteAuthProfile = vi.mocked(writeDenchAuthProfileKey);
+
+const refreshOk = { attempted: true, restarted: true, error: null, profile: "dench" };
+
+const cloudState = {
+  status: "valid" as const,
+  apiKeySource: "config" as const,
+  gatewayUrl: "https://gateway.merseoriginals.com",
+  primaryModel: null,
+  isDenchPrimary: false,
+  selectedDenchModel: null,
+  selectedVoiceId: null,
+  elevenLabsEnabled: false,
+  enrichmentMaxModeEnabled: false,
+  models: [
+    {
+      id: "dench-claude-sonnet",
+      stableId: "claude-sonnet-4.6",
+      displayName: "Claude Sonnet 4.6",
+      provider: "anthropic",
+      transportProvider: "dench-cloud",
+      api: "openai-completions" as const,
+      input: ["text"] as Array<"text" | "image">,
+      reasoning: true,
+      contextWindow: 200000,
+      maxTokens: 8192,
+      supportsStreaming: true,
+      supportsImages: false,
+      supportsResponses: true,
+      supportsReasoning: true,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+    },
+  ],
+  recommendedModelId: "claude-sonnet-4.6",
+};
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/onboarding/dench-cloud", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("Dench Cloud onboarding API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedSaveApiKey.mockResolvedValue({ state: cloudState, changed: true, refresh: refreshOk });
+    mockedSelectModel.mockResolvedValue({ state: cloudState, changed: true, refresh: refreshOk });
+  });
+
+  it("syncs the auth profile after saving the key and selecting the model", async () => {
+    const res = await POST(makeRequest({ apiKey: "dench_test_key" }));
+
+    expect(res.status).toBe(200);
+    expect(mockedSaveApiKey).toHaveBeenCalledWith("dench_test_key", { syncAuthProfile: false });
+    expect(mockedSelectModel).toHaveBeenCalledWith("claude-sonnet-4.6");
+    expect(mockedWriteAuthProfile).toHaveBeenCalledWith("dench_test_key");
+  });
+
+  it("does not write the auth profile when saving the key fails", async () => {
+    mockedSaveApiKey.mockResolvedValueOnce({
+      state: { ...cloudState, status: "no_key", apiKeySource: "missing", models: [] },
+      changed: false,
+      refresh: { attempted: false, restarted: false, error: null, profile: "default" },
+      error: "Invalid Dench Cloud API key.",
+    });
+
+    const res = await POST(makeRequest({ apiKey: "dench_bad_key" }));
+
+    expect(res.status).toBe(400);
+    expect(mockedSelectModel).not.toHaveBeenCalled();
+    expect(mockedWriteAuthProfile).not.toHaveBeenCalled();
+  });
+
+  it("does not write the auth profile when selecting the model fails", async () => {
+    mockedSelectModel.mockResolvedValueOnce({
+      state: cloudState,
+      changed: false,
+      refresh: { attempted: false, restarted: false, error: null, profile: "default" },
+      error: "Unable to select model.",
+    });
+
+    const res = await POST(makeRequest({ apiKey: "dench_test_key" }));
+
+    expect(res.status).toBe(400);
+    expect(mockedWriteAuthProfile).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/onboarding/dench-cloud/route.ts
+++ b/apps/web/app/api/onboarding/dench-cloud/route.ts
@@ -1,10 +1,11 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   advanceOnboardingStep,
   readOnboardingState,
 } from "@/lib/denchclaw-state";
 import { resolveOpenClawStateDir } from "@/lib/workspace";
+import { writeDenchAuthProfileKey } from "@/lib/dench-auth";
 import {
   resolveComposioApiKey,
 } from "@/lib/composio";
@@ -31,51 +32,6 @@ function readOpenClawConfig(): UnknownRecord {
   } catch {
     return {};
   }
-}
-
-function authProfilePath(): string {
-  return join(
-    resolveOpenClawStateDir(),
-    "agents",
-    "main",
-    "agent",
-    "auth-profiles.json",
-  );
-}
-
-/**
- * Mirror the CLI bootstrap's `writeAuthProfileKey`. The web `saveApiKey`
- * helper writes openclaw.json but not auth-profiles.json — keeping them
- * in sync prevents the "key visible in chat but agent re-prompts" footgun.
- */
-function persistAuthProfileKey(apiKey: string): void {
-  const path = authProfilePath();
-  let raw: UnknownRecord = { version: 1, profiles: {} };
-  if (existsSync(path)) {
-    try {
-      const parsed = JSON.parse(readFileSync(path, "utf-8")) as UnknownRecord;
-      if (parsed && typeof parsed === "object") {
-        raw = parsed;
-      }
-    } catch {
-      // fall through to fresh file
-    }
-  }
-
-  const profiles =
-    raw.profiles && typeof raw.profiles === "object" && !Array.isArray(raw.profiles)
-      ? (raw.profiles as UnknownRecord)
-      : {};
-  profiles["dench-cloud:default"] = {
-    type: "api_key",
-    provider: "dench-cloud",
-    key: apiKey,
-  };
-  raw.profiles = profiles;
-  if (raw.version !== 1) {raw.version = 1;}
-
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, JSON.stringify(raw, null, 2) + "\n", "utf-8");
 }
 
 function isDenchCloudPrimary(config: UnknownRecord): { ok: boolean; primary: string | null } {
@@ -151,7 +107,7 @@ export async function POST(req: Request) {
   }
 
   // Validate + persist into openclaw.json (provider config, models entries, MCP).
-  const saveResult = await saveApiKey(apiKey);
+  const saveResult = await saveApiKey(apiKey, { syncAuthProfile: false });
   if (saveResult.error) {
     return Response.json({ error: saveResult.error }, { status: 400 });
   }
@@ -173,7 +129,7 @@ export async function POST(req: Request) {
   }
 
   // Mirror into auth-profiles.json so the agent runtime sees the same key.
-  persistAuthProfileKey(apiKey);
+  writeDenchAuthProfileKey(apiKey);
 
   const next = advanceOnboardingStep("dench-cloud", "connect-gmail", {
     denchCloud: {

--- a/apps/web/lib/dench-auth.ts
+++ b/apps/web/lib/dench-auth.ts
@@ -12,8 +12,8 @@
  * Bearer token sent by the `dench-ai-gateway` plugin's sync trigger.
  */
 
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { resolveOpenClawStateDir } from "@/lib/workspace";
 
 const AUTH_PROFILES_REL = join("agents", "main", "agent", "auth-profiles.json");
@@ -35,6 +35,10 @@ function readKeyFromAuthProfiles(authPath: string): string | undefined {
   }
 }
 
+function authProfilesPath(): string {
+  return join(resolveOpenClawStateDir(), AUTH_PROFILES_REL);
+}
+
 function envFallback(): string | undefined {
   return (
     process.env.DENCH_CLOUD_API_KEY?.trim() ||
@@ -44,12 +48,43 @@ function envFallback(): string | undefined {
 }
 
 export function readDenchAuthProfileKey(): string | undefined {
-  const stateDir = resolveOpenClawStateDir();
-  if (stateDir) {
-    const key = readKeyFromAuthProfiles(join(stateDir, AUTH_PROFILES_REL));
-    if (key) {
-      return key;
-    }
+  const key = readKeyFromAuthProfiles(authProfilesPath());
+  if (key) {
+    return key;
   }
   return envFallback();
+}
+
+export function writeDenchAuthProfileKey(apiKey: string): void {
+  const authPath = authProfilesPath();
+  let raw: UnknownRecord = { version: 1, profiles: {} };
+
+  if (existsSync(authPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(authPath, "utf-8")) as UnknownRecord;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        raw = parsed;
+      }
+    } catch {
+      // Fall through to a fresh auth profile if the file is unreadable.
+    }
+  }
+
+  const profiles =
+    raw.profiles && typeof raw.profiles === "object" && !Array.isArray(raw.profiles)
+      ? (raw.profiles as UnknownRecord)
+      : {};
+
+  profiles["dench-cloud:default"] = {
+    type: "api_key",
+    provider: "dench-cloud",
+    key: apiKey,
+  };
+  raw.profiles = profiles;
+  if (raw.version !== 1) {
+    raw.version = 1;
+  }
+
+  mkdirSync(dirname(authPath), { recursive: true });
+  writeFileSync(authPath, JSON.stringify(raw, null, 2) + "\n", "utf-8");
 }

--- a/apps/web/lib/dench-cloud-settings.test.ts
+++ b/apps/web/lib/dench-cloud-settings.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => {
   const state = {
     configText: "{}\n",
+    authText: null as string | null,
   };
 
   const catalog = {
@@ -35,11 +36,27 @@ const mocks = vi.hoisted(() => {
 
   return {
     state,
-    existsSync: vi.fn(() => true),
-    readFileSync: vi.fn(() => state.configText as never),
+    existsSync: vi.fn((pathLike: unknown) => {
+      if (String(pathLike).endsWith("auth-profiles.json")) {
+        return state.authText !== null;
+      }
+      return true;
+    }),
+    readFileSync: vi.fn((pathLike: unknown) => {
+      if (String(pathLike).endsWith("auth-profiles.json")) {
+        if (state.authText === null) {
+          throw new Error("auth profile missing");
+        }
+        return state.authText as never;
+      }
+      return state.configText as never;
+    }),
     writeFileSync: vi.fn((pathLike: unknown, content: unknown) => {
       if (String(pathLike).endsWith("openclaw.json")) {
         state.configText = String(content);
+      }
+      if (String(pathLike).endsWith("auth-profiles.json")) {
+        state.authText = String(content);
       }
     }),
     mkdirSync: vi.fn(),
@@ -157,6 +174,7 @@ describe("dench cloud settings", () => {
     vi.clearAllMocks();
     vi.mocked(readIntegrationsMetadata).mockReturnValue({ schemaVersion: 1 });
     mocks.state.configText = "{}\n";
+    mocks.state.authText = null;
     mocks.validateDenchCloudApiKey.mockResolvedValue(undefined);
     mocks.fetchDenchCloudCatalog.mockResolvedValue({
       source: "live",
@@ -201,11 +219,70 @@ describe("dench cloud settings", () => {
 
     const written = JSON.parse(mocks.state.configText);
     expect(written.models.providers["dench-cloud"].apiKey).toBe("dc-key");
+    const authProfile = JSON.parse(mocks.state.authText ?? "{}");
+    expect(authProfile.profiles["dench-cloud:default"]).toEqual({
+      type: "api_key",
+      provider: "dench-cloud",
+      key: "dc-key",
+    });
     expect(written.mcp).toBeUndefined();
     expect(written.tools.alsoAllow).toEqual([
       "dench_execute_integrations",
       "dench_search_integrations",
     ]);
+  });
+
+  it("preserves unrelated auth profiles when saving the Dench Cloud API key", async () => {
+    mocks.state.authText = JSON.stringify({
+      version: 1,
+      profiles: {
+        "other-provider:default": {
+          type: "api_key",
+          provider: "other-provider",
+          key: "keep-me",
+        },
+        "dench-cloud:default": {
+          type: "api_key",
+          provider: "dench-cloud",
+          key: "old-key",
+        },
+      },
+    });
+
+    await saveApiKey("new-key");
+
+    const authProfile = JSON.parse(mocks.state.authText ?? "{}");
+    expect(authProfile.profiles["other-provider:default"]).toEqual({
+      type: "api_key",
+      provider: "other-provider",
+      key: "keep-me",
+    });
+    expect(authProfile.profiles["dench-cloud:default"]).toEqual({
+      type: "api_key",
+      provider: "dench-cloud",
+      key: "new-key",
+    });
+  });
+
+  it("does not write the auth profile when API key validation fails", async () => {
+    const existingAuthProfile = JSON.stringify({
+      version: 1,
+      profiles: {
+        "dench-cloud:default": {
+          type: "api_key",
+          provider: "dench-cloud",
+          key: "old-key",
+        },
+      },
+    });
+    mocks.state.authText = existingAuthProfile;
+    mocks.validateDenchCloudApiKey.mockRejectedValueOnce(new Error("Invalid Dench Cloud API key."));
+
+    const result = await saveApiKey("bad-key");
+
+    expect(result.error).toBe("Invalid Dench Cloud API key.");
+    expect(mocks.state.authText).toBe(existingAuthProfile);
+    expect(mocks.refreshIntegrationsRuntime).not.toHaveBeenCalled();
   });
 
   it("refreshes integrations when switching the primary model to Dench Cloud", async () => {

--- a/apps/web/lib/dench-cloud-settings.ts
+++ b/apps/web/lib/dench-cloud-settings.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { resolveOpenClawStateDir } from "@/lib/workspace";
+import { writeDenchAuthProfileKey } from "@/lib/dench-auth";
 import {
   type DenchCloudCatalogModel,
   DEFAULT_DENCH_CLOUD_GATEWAY_URL,
@@ -278,6 +279,10 @@ export type SaveActiveCloudSettingsInput = {
   integrations: DenchIntegrationToggleDraft;
   enrichmentMaxModeEnabled: boolean;
 };
+
+type SaveApiKeyOptions = {
+  syncAuthProfile?: boolean;
+};
 export async function getCloudVoiceState(): Promise<CloudVoiceState> {
   const config = readConfig();
   const apiKey = resolveDenchApiKey(config);
@@ -386,7 +391,10 @@ export async function getCloudSettingsState(): Promise<CloudSettingsState> {
   };
 }
 
-export async function saveApiKey(apiKey: string): Promise<CloudSettingsUpdateResult> {
+export async function saveApiKey(
+  apiKey: string,
+  options: SaveApiKeyOptions = {},
+): Promise<CloudSettingsUpdateResult> {
   const config = readConfig();
   const gatewayUrl = resolveGatewayUrl(config);
 
@@ -443,6 +451,9 @@ export async function saveApiKey(apiKey: string): Promise<CloudSettingsUpdateRes
   syncAllowedTools(config, readStringList(patchTools?.alsoAllow));
 
   writeConfig(config);
+  if (options.syncAuthProfile !== false) {
+    writeDenchAuthProfileKey(apiKey);
+  }
 
   const refresh = await refreshIntegrationsRuntime();
   const state = await getCloudSettingsState();


### PR DESCRIPTION
## Summary
- Sync Dench Cloud Settings saves into the runtime `auth-profiles.json` store after API key validation.
- Share the auth-profile writer with onboarding so both flows preserve unrelated profiles and update `dench-cloud:default` consistently.
- Add focused tests for settings sync, profile preservation, validation failure, and onboarding ordering.

## Test plan
- `pnpm --dir apps/web test lib/dench-cloud-settings.test.ts app/api/onboarding/dench-cloud/route.test.ts app/api/settings/cloud/route.test.ts`
- Restarted the local gateway and confirmed `/health` returned OK.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Dench Cloud API keys are persisted by writing to `auth-profiles.json`, which is credential-related and could affect gateway/plugin auth if incorrect. Scope is localized and covered by new unit tests for success/failure ordering and profile preservation.
> 
> **Overview**
> **Dench Cloud API key persistence is now synced to the runtime auth store.** `saveApiKey` now (by default) also writes `dench-cloud:default` into `agents/main/agent/auth-profiles.json`, preserving unrelated profiles, and a shared `writeDenchAuthProfileKey` helper was added to `dench-auth`.
> 
> **Onboarding flow was adjusted to control ordering.** The onboarding `POST` path calls `saveApiKey(..., { syncAuthProfile: false })`, selects the recommended model, and only then writes the auth profile key, so auth sync doesn’t happen when validation/model selection fails.
> 
> Tests were added/expanded to cover auth-profile syncing, preservation of existing profiles, and no-write behavior on validation or model-selection errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 341fde488915ad38edd64a7fbc32d0cd01678c10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->