### PR TITLE
feat(integrations): install managed plugins on demand

### DIFF
--- a/apps/web/app/api/integrations/[id]/toggle/route.test.ts
+++ b/apps/web/app/api/integrations/[id]/toggle/route.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/lib/integrations", () => ({
         },
         effectiveOwner: "web_search",
       },
+      managedPlugins: [],
       integrations: [
         {
           id: "exa",
@@ -106,6 +107,7 @@ vi.mock("@/lib/integrations", () => ({
         },
         effectiveOwner: enabled ? "exa" : "web_search",
       },
+      managedPlugins: [],
       integrations: [],
     },
   })),
@@ -127,6 +129,7 @@ vi.mock("@/lib/integrations", () => ({
         },
         effectiveOwner: "web_search",
       },
+      managedPlugins: [],
       integrations: [{ id: "apollo", enabled, available: true }],
     },
   })),
@@ -148,6 +151,7 @@ vi.mock("@/lib/integrations", () => ({
         },
         effectiveOwner: "web_search",
       },
+      managedPlugins: [],
       integrations: [{ id: "elevenlabs", enabled, available: true }],
     },
   })),
@@ -236,6 +240,7 @@ describe("integrations toggle API", () => {
           },
           effectiveOwner: "web_search",
         },
+        managedPlugins: [],
         integrations: [
           {
             id: "exa",

--- a/apps/web/app/api/integrations/repair/route.test.ts
+++ b/apps/web/app/api/integrations/repair/route.test.ts
@@ -1,20 +1,25 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/integrations", () => ({
-  repairOlderIntegrationsProfile: vi.fn(() => ({
+  repairManagedPluginsProfile: vi.fn(() => ({
     changed: true,
     repairs: [
       {
-        id: "exa",
-        pluginId: "exa-search",
+        id: "dench-ai-gateway",
+        pluginId: "dench-ai-gateway",
         assetAvailable: true,
         assetCopied: true,
         repaired: true,
         issues: [],
       },
     ],
-    repairedIds: ["exa"],
+    repairedIds: ["dench-ai-gateway"],
     state: {
+      denchCloud: {
+        hasKey: true,
+        isPrimaryProvider: true,
+        primaryModel: "dench-cloud/claude-sonnet-4.6",
+      },
       metadata: { schemaVersion: 1, exa: { ownsSearch: false, fallbackProvider: "duckduckgo" } },
       search: {
         builtIn: {
@@ -24,6 +29,7 @@ vi.mock("@/lib/integrations", () => ({
         },
         effectiveOwner: "web_search",
       },
+      managedPlugins: [],
       integrations: [],
     },
   })),
@@ -47,7 +53,7 @@ describe("integrations repair API", () => {
     expect(response.status).toBe(200);
     const json = await response.json();
     expect(json.changed).toBe(true);
-    expect(json.repairedIds).toEqual(["exa"]);
+    expect(json.repairedIds).toEqual(["dench-ai-gateway"]);
     expect(json.refresh.restarted).toBe(true);
   });
 });

--- a/apps/web/app/api/integrations/repair/route.ts
+++ b/apps/web/app/api/integrations/repair/route.ts
@@ -1,13 +1,13 @@
 import {
   refreshIntegrationsRuntime,
-  repairOlderIntegrationsProfile,
+  repairManagedPluginsProfile,
 } from "@/lib/integrations";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function POST() {
-  const result = repairOlderIntegrationsProfile();
+  const result = repairManagedPluginsProfile();
   const refresh = result.changed
     ? await refreshIntegrationsRuntime()
     : {

--- a/apps/web/app/api/integrations/route.test.ts
+++ b/apps/web/app/api/integrations/route.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/lib/integrations", () => ({
         },
         effectiveOwner: "exa",
       },
+      managedPlugins: [],
       integrations: [
         {
           id: "exa",

--- a/apps/web/app/api/settings/cloud/route.test.ts
+++ b/apps/web/app/api/settings/cloud/route.test.ts
@@ -193,6 +193,7 @@ describe("cloud settings API", () => {
           builtIn: { enabled: false, denied: true, provider: null },
           effectiveOwner: "exa" as const,
         },
+        managedPlugins: [],
         integrations: [],
       },
       changed: true,

--- a/apps/web/app/api/workspace/objects/[name]/enrich/route.test.ts
+++ b/apps/web/app/api/workspace/objects/[name]/enrich/route.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/lib/integrations", () => ({
       builtIn: { enabled: true, denied: false, provider: null },
       effectiveOwner: "web_search",
     },
+    managedPlugins: [],
     integrations: [{ id: "apollo", enabled: true }],
   })),
   resolveDenchGatewayCredentials: vi.fn(() => ({

--- a/apps/web/app/components/integrations/dench-integrations-section.test.tsx
+++ b/apps/web/app/components/integrations/dench-integrations-section.test.tsx
@@ -21,6 +21,7 @@ const integrationsState: IntegrationsState = {
     builtIn: { enabled: true, denied: false, provider: null },
     effectiveOwner: "web_search",
   },
+  managedPlugins: [],
   integrations: [
     {
       id: "apollo",

--- a/apps/web/app/components/integrations/dench-integrations-section.tsx
+++ b/apps/web/app/components/integrations/dench-integrations-section.tsx
@@ -10,6 +10,7 @@ import type {
   DenchIntegrationState,
   IntegrationRuntimeRefresh,
   IntegrationsState,
+  ManagedPluginRepairId,
 } from "@/lib/integrations";
 
 export type IntegrationActionNotice = {
@@ -24,7 +25,7 @@ type IntegrationToggleResponse = IntegrationsState & {
 type IntegrationRepairResponse = IntegrationsState & {
   changed: boolean;
   repairs: IntegrationRepairEntry[];
-  repairedIds: Array<"exa" | "apollo">;
+  repairedIds: ManagedPluginRepairId[];
   refresh: IntegrationRuntimeRefresh;
 };
 
@@ -77,6 +78,21 @@ function integrationDisplayNameFromId(id: DenchIntegrationId, fallbackLabel?: st
       return fallbackLabel ?? "Exa";
     case "elevenlabs":
       return fallbackLabel ?? "ElevenLabs";
+  }
+}
+
+function repairDisplayNameFromId(id: ManagedPluginRepairId): string {
+  switch (id) {
+    case "apollo":
+      return "Dench Enrichments";
+    case "exa":
+      return "Exa";
+    case "dench-ai-gateway":
+      return "Dench AI Gateway";
+    case "dench-identity":
+      return "Dench Identity";
+    case "posthog":
+      return "PostHog";
   }
 }
 
@@ -204,12 +220,14 @@ export function DenchIntegrationsSection(props: DenchIntegrationsSectionProps = 
 
   const integrations = useMemo(() => resolvedData?.integrations ?? [], [resolvedData]);
   const needsRepair = useMemo(
-    () => integrations.some(
-      (integration) =>
-        (integration.id === "exa" || integration.id === "apollo") &&
-        integration.health.pluginMissing,
-    ),
-    [integrations],
+    () =>
+      integrations.some(
+        (integration) =>
+          (integration.id === "exa" || integration.id === "apollo") &&
+          integration.health.pluginMissing,
+      ) ||
+      (resolvedData?.managedPlugins ?? []).some((plugin) => plugin.required && plugin.health.pluginMissing),
+    [integrations, resolvedData?.managedPlugins],
   );
 
   const applyState = useCallback((nextState: IntegrationsState) => {
@@ -286,7 +304,7 @@ export function DenchIntegrationsSection(props: DenchIntegrationsSectionProps = 
       if (nextState.changed && nextState.refresh.restarted) {
         const repairedNames = nextState.repairedIds.length > 0
           ? nextState.repairedIds
-            .map((id) => integrationDisplayNameFromId(id))
+            .map((id) => repairDisplayNameFromId(id))
             .join(", ")
           : "profiles";
         setNotice({

--- a/apps/web/app/components/integrations/integrations-panel.test.tsx
+++ b/apps/web/app/components/integrations/integrations-panel.test.tsx
@@ -13,6 +13,7 @@ const eligiblePayload = {
   },
   metadata: { schemaVersion: 1 },
   search: { builtIn: { enabled: false, denied: true, provider: "duckduckgo" }, effectiveOwner: "exa" },
+  managedPlugins: [],
   integrations: [],
 };
 

--- a/apps/web/app/components/settings/cloud-settings-panel.test.tsx
+++ b/apps/web/app/components/settings/cloud-settings-panel.test.tsx
@@ -87,6 +87,7 @@ const integrationsState: IntegrationsState = {
     builtIn: { enabled: true, denied: false, provider: null },
     effectiveOwner: "web_search",
   },
+  managedPlugins: [],
   integrations: [
     {
       id: "exa",

--- a/apps/web/lib/dench-cloud-settings.test.ts
+++ b/apps/web/lib/dench-cloud-settings.test.ts
@@ -85,6 +85,25 @@ const mocks = vi.hoisted(() => {
       gatewayUrl: null,
       selectedModel: null,
     })),
+    ensureDefaultManagedPluginsInstalled: vi.fn(() => ({
+      changed: false,
+      repairs: [],
+      repairedIds: [],
+      state: {
+        denchCloud: {
+          hasKey: true,
+          isPrimaryProvider: true,
+          primaryModel: "dench-cloud/claude-sonnet-4.6",
+        },
+        metadata: { schemaVersion: 1 },
+        search: {
+          builtIn: { enabled: true, denied: false, provider: null },
+          effectiveOwner: "web_search",
+        },
+        managedPlugins: [],
+        integrations: [],
+      },
+    })),
     refreshIntegrationsRuntime: vi.fn(async () => ({
       attempted: true,
       restarted: true,
@@ -122,6 +141,7 @@ vi.mock("./integrations", () => ({
     error: null,
     metadata: { schemaVersion: 1 },
   })),
+  ensureDefaultManagedPluginsInstalled: mocks.ensureDefaultManagedPluginsInstalled,
   getIntegrationsState: vi.fn(() => ({
     denchCloud: {
       hasKey: false,
@@ -133,6 +153,7 @@ vi.mock("./integrations", () => ({
       builtIn: { enabled: true, denied: false, provider: null },
       effectiveOwner: "web_search",
     },
+    managedPlugins: [],
     integrations: [],
   })),
   readIntegrationsMetadata: vi.fn(() => ({ schemaVersion: 1 })),
@@ -191,12 +212,32 @@ describe("dench cloud settings", () => {
       error: null,
       profile: "dench",
     });
+    mocks.ensureDefaultManagedPluginsInstalled.mockReturnValue({
+      changed: false,
+      repairs: [],
+      repairedIds: [],
+      state: {
+        denchCloud: {
+          hasKey: true,
+          isPrimaryProvider: true,
+          primaryModel: "dench-cloud/claude-sonnet-4.6",
+        },
+        metadata: { schemaVersion: 1 },
+        search: {
+          builtIn: { enabled: true, denied: false, provider: null },
+          effectiveOwner: "web_search",
+        },
+        managedPlugins: [],
+        integrations: [],
+      },
+    });
   });
 
   it("refreshes integrations when saving the Dench Cloud API key", async () => {
     const result = await saveApiKey("dc-key");
 
     expect(mocks.refreshIntegrationsRuntime).toHaveBeenCalledTimes(1);
+    expect(mocks.ensureDefaultManagedPluginsInstalled).toHaveBeenCalledTimes(1);
     expect(result).not.toHaveProperty("toolIndexRebuild");
 
     const written = JSON.parse(mocks.state.configText);

--- a/apps/web/lib/dench-cloud-settings.ts
+++ b/apps/web/lib/dench-cloud-settings.ts
@@ -13,6 +13,7 @@ import {
 } from "../../../src/cli/dench-cloud";
 import {
   applyDenchIntegrationToggleDraft,
+  ensureDefaultManagedPluginsInstalled,
   getIntegrationsState,
   readIntegrationsMetadata,
   refreshIntegrationsRuntime,
@@ -443,6 +444,7 @@ export async function saveApiKey(apiKey: string): Promise<CloudSettingsUpdateRes
   syncAllowedTools(config, readStringList(patchTools?.alsoAllow));
 
   writeConfig(config);
+  ensureDefaultManagedPluginsInstalled();
 
   const refresh = await refreshIntegrationsRuntime();
   const state = await getCloudSettingsState();

--- a/apps/web/lib/integrations.test.ts
+++ b/apps/web/lib/integrations.test.ts
@@ -461,8 +461,10 @@ describe("integrations state", () => {
       "/home/testuser/.openclaw-dench/extensions/exa-search",
     ]);
     expect(writtenConfig.plugins.installs["exa-search"]).toEqual({
+      source: "path",
       installPath: "/home/testuser/.openclaw-dench/extensions/exa-search",
       sourcePath: expect.any(String),
+      installedAt: expect.any(String),
     });
     expect(writtenConfig.tools.deny).toEqual(["web_search"]);
     expect(writtenConfig.tools.web.search).toEqual({ enabled: false });
@@ -574,7 +576,15 @@ describe("integrations state", () => {
         },
       },
       plugins: {
-        entries: {},
+        entries: {
+          "apollo-enrichment": {
+            enabled: false,
+            config: {
+              apiKey: "stale-local-key",
+              mode: "max",
+            },
+          },
+        },
       },
     });
 
@@ -600,13 +610,20 @@ describe("integrations state", () => {
     expect(result.changed).toBe(true);
     const writtenConfig = JSON.parse(openClawJson);
     expect(writtenConfig.plugins.allow).toEqual(["apollo-enrichment"]);
-    expect(writtenConfig.plugins.entries["apollo-enrichment"]).toEqual({ enabled: true });
+    expect(writtenConfig.plugins.entries["apollo-enrichment"]).toEqual({
+      enabled: true,
+      config: {
+        mode: "max",
+      },
+    });
     expect(writtenConfig.plugins.load.paths).toEqual([
       "/home/testuser/.openclaw-dench/extensions/apollo-enrichment",
     ]);
     expect(writtenConfig.plugins.installs["apollo-enrichment"]).toEqual({
+      source: "path",
       installPath: "/home/testuser/.openclaw-dench/extensions/apollo-enrichment",
       sourcePath: expect.any(String),
+      installedAt: expect.any(String),
     });
   });
 
@@ -881,12 +898,18 @@ describe("integrations state", () => {
     const mockExists = vi.mocked(existsSync);
     const mockRead = vi.mocked(readFileSync);
     const mockWrite = vi.mocked(writeFileSync);
+    const bundledGatewaySource = resolveBundledExtensionSourcePath("dench-ai-gateway");
+    const bundledIdentitySource = resolveBundledExtensionSourcePath("dench-identity");
     const bundledExaSource = resolveBundledExtensionSourcePath("exa-search");
     const bundledApolloSource = resolveBundledExtensionSourcePath("apollo-enrichment");
+    const bundledSharedSource = resolveBundledExtensionSourcePath("shared");
     const existingPaths = new Set<string>([
       "/home/testuser/.openclaw-dench/openclaw.json",
+      bundledGatewaySource,
+      bundledIdentitySource,
       bundledExaSource,
       bundledApolloSource,
+      bundledSharedSource,
     ]);
     let openClawJson = JSON.stringify({
       plugins: {
@@ -911,13 +934,25 @@ describe("integrations state", () => {
       }
     });
 
-    const { repairOlderIntegrationsProfile } = await import("./integrations.js");
-    const result = repairOlderIntegrationsProfile();
+    const { repairManagedPluginsProfile } = await import("./integrations.js");
+    const result = repairManagedPluginsProfile();
 
     expect(result.changed).toBe(true);
-    expect(result.repairedIds).toEqual(["exa", "apollo"]);
+    expect(result.repairedIds).toEqual(["dench-ai-gateway", "dench-identity", "apollo", "exa"]);
     expect(result.repairs).toEqual(
       expect.arrayContaining([
+        expect.objectContaining({
+          id: "dench-ai-gateway",
+          assetAvailable: true,
+          assetCopied: true,
+          repaired: true,
+        }),
+        expect.objectContaining({
+          id: "dench-identity",
+          assetAvailable: true,
+          assetCopied: true,
+          repaired: true,
+        }),
         expect.objectContaining({
           id: "exa",
           assetAvailable: true,
@@ -932,21 +967,147 @@ describe("integrations state", () => {
         }),
       ]),
     );
-    expect(mockCopy).toHaveBeenCalledTimes(2);
+    expect(mockCopy).toHaveBeenCalledTimes(5);
+    expect(mockCopy).toHaveBeenCalledWith(
+      bundledSharedSource,
+      "/home/testuser/.openclaw-dench/extensions/shared",
+      { recursive: true, force: true },
+    );
 
     const writtenConfig = JSON.parse(openClawJson);
-    expect(writtenConfig.plugins.allow).toEqual(["exa-search", "apollo-enrichment"]);
-    expect(writtenConfig.plugins.load.paths).toEqual([
-      "/home/testuser/.openclaw-dench/extensions/exa-search",
-      "/home/testuser/.openclaw-dench/extensions/apollo-enrichment",
+    expect(writtenConfig.plugins.allow).toEqual([
+      "dench-ai-gateway",
+      "dench-identity",
+      "apollo-enrichment",
+      "exa-search",
     ]);
+    expect(writtenConfig.plugins.load.paths).toEqual([
+      "/home/testuser/.openclaw-dench/extensions/dench-ai-gateway",
+      "/home/testuser/.openclaw-dench/extensions/dench-identity",
+      "/home/testuser/.openclaw-dench/extensions/apollo-enrichment",
+      "/home/testuser/.openclaw-dench/extensions/exa-search",
+    ]);
+    expect(writtenConfig.plugins.entries["dench-ai-gateway"]).toEqual({
+      enabled: true,
+      config: {
+        gatewayUrl: "https://gateway.merseoriginals.com",
+      },
+    });
+    expect(writtenConfig.plugins.entries["dench-identity"]).toEqual({ enabled: true });
+    expect(writtenConfig.plugins.entries["apollo-enrichment"]).toEqual({ enabled: true });
+    expect(writtenConfig.plugins.entries["exa-search"]).toEqual({ enabled: true });
+    expect(writtenConfig.plugins.installs["dench-ai-gateway"]).toEqual({
+      source: "path",
+      installPath: "/home/testuser/.openclaw-dench/extensions/dench-ai-gateway",
+      sourcePath: bundledGatewaySource,
+      installedAt: expect.any(String),
+    });
+    expect(writtenConfig.plugins.installs["dench-identity"]).toEqual({
+      source: "path",
+      installPath: "/home/testuser/.openclaw-dench/extensions/dench-identity",
+      sourcePath: bundledIdentitySource,
+      installedAt: expect.any(String),
+    });
     expect(writtenConfig.plugins.installs["exa-search"]).toEqual({
+      source: "path",
       installPath: "/home/testuser/.openclaw-dench/extensions/exa-search",
       sourcePath: bundledExaSource,
+      installedAt: expect.any(String),
     });
     expect(writtenConfig.plugins.installs["apollo-enrichment"]).toEqual({
+      source: "path",
       installPath: "/home/testuser/.openclaw-dench/extensions/apollo-enrichment",
       sourcePath: bundledApolloSource,
+      installedAt: expect.any(String),
     });
+  });
+
+  it("does not rewrite an already repaired managed plugin profile", async () => {
+    const { cpSync, existsSync, readFileSync, writeFileSync } = await import("node:fs");
+    const mockCopy = vi.mocked(cpSync);
+    const mockExists = vi.mocked(existsSync);
+    const mockRead = vi.mocked(readFileSync);
+    const mockWrite = vi.mocked(writeFileSync);
+    const openClawJson = JSON.stringify({
+      plugins: {
+        allow: ["dench-ai-gateway", "dench-identity", "apollo-enrichment", "exa-search"],
+        load: {
+          paths: [
+            "/home/testuser/.openclaw-dench/extensions/dench-ai-gateway",
+            "/home/testuser/.openclaw-dench/extensions/dench-identity",
+            "/home/testuser/.openclaw-dench/extensions/apollo-enrichment",
+            "/home/testuser/.openclaw-dench/extensions/exa-search",
+          ],
+        },
+        entries: {
+          "dench-ai-gateway": {
+            enabled: true,
+            config: {
+              gatewayUrl: "https://gateway.merseoriginals.com",
+            },
+          },
+          "dench-identity": { enabled: true },
+          "apollo-enrichment": { enabled: true },
+          "exa-search": { enabled: true },
+        },
+        installs: {
+          "dench-ai-gateway": {
+            source: "path",
+            sourcePath: resolveBundledExtensionSourcePath("dench-ai-gateway"),
+            installPath: "/home/testuser/.openclaw-dench/extensions/dench-ai-gateway",
+            installedAt: "2026-01-01T00:00:00.000Z",
+          },
+          "dench-identity": {
+            source: "path",
+            sourcePath: resolveBundledExtensionSourcePath("dench-identity"),
+            installPath: "/home/testuser/.openclaw-dench/extensions/dench-identity",
+            installedAt: "2026-01-01T00:00:00.000Z",
+          },
+          "apollo-enrichment": {
+            source: "path",
+            sourcePath: resolveBundledExtensionSourcePath("apollo-enrichment"),
+            installPath: "/home/testuser/.openclaw-dench/extensions/apollo-enrichment",
+            installedAt: "2026-01-01T00:00:00.000Z",
+          },
+          "exa-search": {
+            source: "path",
+            sourcePath: resolveBundledExtensionSourcePath("exa-search"),
+            installPath: "/home/testuser/.openclaw-dench/extensions/exa-search",
+            installedAt: "2026-01-01T00:00:00.000Z",
+          },
+        },
+      },
+    });
+    const existingPaths = new Set([
+      "/home/testuser/.openclaw-dench/openclaw.json",
+      resolveBundledExtensionSourcePath("dench-ai-gateway"),
+      resolveBundledExtensionSourcePath("dench-identity"),
+      resolveBundledExtensionSourcePath("apollo-enrichment"),
+      resolveBundledExtensionSourcePath("exa-search"),
+      "/home/testuser/.openclaw-dench/extensions/dench-ai-gateway",
+      "/home/testuser/.openclaw-dench/extensions/dench-identity",
+      "/home/testuser/.openclaw-dench/extensions/apollo-enrichment",
+      "/home/testuser/.openclaw-dench/extensions/exa-search",
+      resolveBundledExtensionSourcePath("shared"),
+      "/home/testuser/.openclaw-dench/extensions/shared",
+    ]);
+
+    mockExists.mockImplementation((path) => existingPaths.has(String(path)));
+    mockRead.mockImplementation((path) => {
+      if (String(path).endsWith("openclaw.json")) {
+        return openClawJson as never;
+      }
+      return "" as never;
+    });
+    mockCopy.mockClear();
+    mockWrite.mockClear();
+
+    const { repairManagedPluginsProfile } = await import("./integrations.js");
+    const result = repairManagedPluginsProfile();
+
+    expect(result.changed).toBe(false);
+    expect(result.repairedIds).toEqual([]);
+    expect(mockCopy).not.toHaveBeenCalled();
+    expect(mockWrite).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/integrations.ts
+++ b/apps/web/lib/integrations.ts
@@ -59,6 +59,13 @@ export type IntegrationPluginState = {
   sourcePath: string | null;
 };
 
+export type ManagedPluginRepairId =
+  | "dench-ai-gateway"
+  | "dench-identity"
+  | "apollo"
+  | "exa"
+  | "posthog";
+
 export type IntegrationHealthIssue =
   | "missing_plugin_entry"
   | "plugin_disabled"
@@ -96,6 +103,17 @@ export type DenchIntegrationState = {
   overrideActive?: boolean;
 };
 
+export type ManagedPluginState = {
+  id: ManagedPluginRepairId;
+  pluginId: string;
+  label: string;
+  required: boolean;
+  available: boolean;
+  plugin: IntegrationPluginState;
+  healthIssues: IntegrationHealthIssue[];
+  health: DenchIntegrationState["health"];
+};
+
 export type BuiltInSearchState = {
   enabled: boolean;
   denied: boolean;
@@ -113,6 +131,7 @@ export type IntegrationsState = {
     builtIn: BuiltInSearchState;
     effectiveOwner: "exa" | "web_search" | "none";
   };
+  managedPlugins: ManagedPluginState[];
   integrations: DenchIntegrationState[];
 };
 
@@ -130,7 +149,7 @@ export type IntegrationRuntimeRefresh = {
 };
 
 export type IntegrationRepairEntry = {
-  id: "exa" | "apollo";
+  id: ManagedPluginRepairId;
   pluginId: string;
   assetAvailable: boolean;
   assetCopied: boolean;
@@ -168,9 +187,74 @@ export type DenchIntegrationToggleDraft = Partial<Record<DenchIntegrationId, boo
 const DEFAULT_GATEWAY_URL = "https://gateway.merseoriginals.com";
 const DEFAULT_FALLBACK_PROVIDER = "duckduckgo";
 const METADATA_FILENAME = ".dench-integrations.json";
+const DENCH_AI_GATEWAY_PLUGIN_ID = "dench-ai-gateway";
+const DENCH_IDENTITY_PLUGIN_ID = "dench-identity";
 const EXA_PLUGIN_ID = "exa-search";
 const APOLLO_PLUGIN_ID = "apollo-enrichment";
+const POSTHOG_PLUGIN_ID = "posthog-analytics";
 const execFileAsync = promisify(execFile);
+
+type ManagedBundledPluginSpec = {
+  id: ManagedPluginRepairId;
+  pluginId: string;
+  sourceDirName: string;
+  label: string;
+  required: boolean;
+  defaultEnabled: boolean;
+  stripConfigKeys?: string[];
+};
+
+const DENCH_MANAGED_BUNDLED_PLUGINS: ManagedBundledPluginSpec[] = [
+  {
+    id: "dench-ai-gateway",
+    pluginId: DENCH_AI_GATEWAY_PLUGIN_ID,
+    sourceDirName: DENCH_AI_GATEWAY_PLUGIN_ID,
+    label: "Dench AI Gateway",
+    required: true,
+    defaultEnabled: true,
+  },
+  {
+    id: "dench-identity",
+    pluginId: DENCH_IDENTITY_PLUGIN_ID,
+    sourceDirName: DENCH_IDENTITY_PLUGIN_ID,
+    label: "Dench Identity",
+    required: true,
+    defaultEnabled: true,
+  },
+  {
+    id: "apollo",
+    pluginId: APOLLO_PLUGIN_ID,
+    sourceDirName: APOLLO_PLUGIN_ID,
+    label: "Apollo Enrichment",
+    required: true,
+    defaultEnabled: true,
+    stripConfigKeys: ["apiKey"],
+  },
+  {
+    id: "exa",
+    pluginId: EXA_PLUGIN_ID,
+    sourceDirName: EXA_PLUGIN_ID,
+    label: "Exa Search",
+    required: true,
+    defaultEnabled: true,
+    stripConfigKeys: ["apiKey"],
+  },
+  {
+    id: "posthog",
+    pluginId: POSTHOG_PLUGIN_ID,
+    sourceDirName: POSTHOG_PLUGIN_ID,
+    label: "PostHog Analytics",
+    required: false,
+    defaultEnabled: false,
+  },
+];
+
+const REQUIRED_MANAGED_PLUGIN_IDS: ManagedPluginRepairId[] = [
+  "dench-ai-gateway",
+  "dench-identity",
+  "apollo",
+  "exa",
+];
 
 function asRecord(value: unknown): UnknownRecord | undefined {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -317,73 +401,80 @@ function removeValue(list: string[], value: string): boolean {
   return setStringList(list, next);
 }
 
-function ensurePluginRegistration(config: OpenClawConfig, pluginId: string): boolean {
-  const plugins = ensurePluginsConfig(config);
-  const allow = ensureStringList(plugins.allow);
-  plugins.allow = allow;
-  const load = ensureRecord(plugins, "load");
-  const loadPaths = ensureStringList(load.paths);
-  load.paths = loadPaths;
-  const entries = ensureRecord(plugins, "entries");
-  const installs = ensureRecord(plugins, "installs");
-
-  let changed = false;
-  const { installPath, sourcePath } = resolveBundledPluginPaths(pluginId);
-  const pluginExists = existsSync(installPath);
-
-  changed = addUnique(allow, pluginId) || changed;
-
-  if (!entries[pluginId] || !asRecord(entries[pluginId])) {
-    entries[pluginId] = { enabled: true };
-    changed = true;
+function resolveManagedBundledPluginSpec(id: ManagedPluginRepairId): ManagedBundledPluginSpec {
+  const spec = DENCH_MANAGED_BUNDLED_PLUGINS.find((plugin) => plugin.id === id);
+  if (!spec) {
+    throw new Error(`Unknown managed plugin '${id}'.`);
   }
-  const entry = asRecord(entries[pluginId]);
-  if (entry && entry.enabled !== true) {
-    entry.enabled = true;
-    changed = true;
-  }
-
-  if (pluginExists) {
-    changed = addUnique(loadPaths, installPath) || changed;
-    const install = asRecord(installs[pluginId]);
-    if (!install) {
-      installs[pluginId] = { installPath, sourcePath };
-      changed = true;
-    } else {
-      if (install.installPath !== installPath) {
-        install.installPath = installPath;
-        changed = true;
-      }
-      if (install.sourcePath !== sourcePath) {
-        install.sourcePath = sourcePath;
-        changed = true;
-      }
-    }
-  }
-
-  return changed;
+  return spec;
 }
 
-function resolveBundledPluginPaths(pluginId: string): {
+function resolveBundledPluginPaths(sourceDirName: string): {
   installPath: string;
   sourcePath: string;
 } {
   const cwdCandidates = [
-    join(process.cwd(), "extensions", pluginId),
-    join(process.cwd(), "..", "..", "extensions", pluginId),
+    join(process.cwd(), "extensions", sourceDirName),
+    join(process.cwd(), "..", "..", "extensions", sourceDirName),
   ];
   const sourcePath = cwdCandidates.find((candidate) => existsSync(candidate)) ?? cwdCandidates[0];
   return {
-    installPath: join(resolveOpenClawStateDir(), "extensions", pluginId),
+    installPath: join(resolveOpenClawStateDir(), "extensions", sourceDirName),
     sourcePath,
   };
 }
 
-function repairBundledPluginRegistration(
+function ensureSharedExtensionCopied(): boolean {
+  const sourcePath = resolveBundledPluginPaths("shared").sourcePath;
+  const installPath = join(resolveOpenClawStateDir(), "extensions", "shared");
+  if (!existsSync(sourcePath) || existsSync(installPath)) {
+    return false;
+  }
+  mkdirSync(dirname(installPath), { recursive: true });
+  cpSync(sourcePath, installPath, { recursive: true, force: true });
+  return true;
+}
+
+function ensureDenchAiGatewayConfig(config: OpenClawConfig, entry: UnknownRecord): boolean {
+  if (!entry.enabled) {
+    return false;
+  }
+  const cfg = ensureRecord(entry, "config");
+  const gatewayUrl = resolveGatewayBaseUrl(config) ?? DEFAULT_GATEWAY_URL;
+  if (cfg.gatewayUrl === gatewayUrl) {
+    return false;
+  }
+  cfg.gatewayUrl = gatewayUrl;
+  return true;
+}
+
+function stripManagedPluginConfigKeys(entry: UnknownRecord, keys: string[] | undefined): boolean {
+  if (!keys || keys.length === 0) {
+    return false;
+  }
+  const cfg = asRecord(entry.config);
+  if (!cfg) {
+    return false;
+  }
+  let changed = false;
+  for (const key of keys) {
+    if (key in cfg) {
+      delete cfg[key];
+      changed = true;
+    }
+  }
+  if (Object.keys(cfg).length === 0) {
+    delete entry.config;
+  }
+  return changed;
+}
+
+function ensureManagedBundledPlugin(
   config: OpenClawConfig,
   params: {
-    id: "exa" | "apollo";
-    pluginId: string;
+    spec: ManagedBundledPluginSpec;
+    enabled?: boolean;
+    preserveExistingDisabled?: boolean;
   },
 ): IntegrationRepairEntry & { changed: boolean } {
   const plugins = ensurePluginsConfig(config);
@@ -395,7 +486,8 @@ function repairBundledPluginRegistration(
   const entries = ensureRecord(plugins, "entries");
   const installs = ensureRecord(plugins, "installs");
 
-  const { installPath, sourcePath } = resolveBundledPluginPaths(params.pluginId);
+  const { spec } = params;
+  const { installPath, sourcePath } = resolveBundledPluginPaths(spec.sourceDirName);
   const sourceExists = existsSync(sourcePath);
   let installExists = existsSync(installPath);
   let assetCopied = false;
@@ -414,21 +506,37 @@ function repairBundledPluginRegistration(
     issues.push("source_asset_missing");
   }
 
-  const existingEntry = asRecord(entries[params.pluginId]);
-  const preservedEnabled = existingEntry?.enabled !== false;
+  const existingEntry = asRecord(entries[spec.pluginId]);
+  const nextEnabled = params.enabled ?? (
+    params.preserveExistingDisabled && existingEntry?.enabled === false
+      ? false
+      : spec.defaultEnabled
+  );
   if (!existingEntry) {
-    entries[params.pluginId] = { enabled: preservedEnabled };
+    entries[spec.pluginId] = { enabled: nextEnabled };
+    changed = true;
+  } else if (existingEntry.enabled !== nextEnabled) {
+    existingEntry.enabled = nextEnabled;
     changed = true;
   }
 
   if (installExists) {
-    changed = addUnique(allow, params.pluginId) || changed;
+    changed = addUnique(allow, spec.pluginId) || changed;
     changed = addUnique(loadPaths, installPath) || changed;
-    const install = asRecord(installs[params.pluginId]);
+    const install = asRecord(installs[spec.pluginId]);
     if (!install) {
-      installs[params.pluginId] = { installPath, sourcePath };
+      installs[spec.pluginId] = {
+        source: "path",
+        sourcePath,
+        installPath,
+        installedAt: new Date().toISOString(),
+      };
       changed = true;
     } else {
+      if (install.source !== "path") {
+        install.source = "path";
+        changed = true;
+      }
       if (install.installPath !== installPath) {
         install.installPath = installPath;
         changed = true;
@@ -438,13 +546,22 @@ function repairBundledPluginRegistration(
         changed = true;
       }
     }
+    changed = ensureSharedExtensionCopied() || changed;
   } else {
     issues.push("install_path_missing");
   }
 
+  const entry = asRecord(entries[spec.pluginId]);
+  if (entry) {
+    changed = stripManagedPluginConfigKeys(entry, spec.stripConfigKeys) || changed;
+    if (spec.pluginId === DENCH_AI_GATEWAY_PLUGIN_ID) {
+      changed = ensureDenchAiGatewayConfig(config, entry) || changed;
+    }
+  }
+
   return {
-    id: params.id,
-    pluginId: params.pluginId,
+    id: spec.id,
+    pluginId: spec.pluginId,
     assetAvailable: installExists,
     assetCopied,
     repaired: changed && installExists,
@@ -780,6 +897,36 @@ function buildHealth(enabled: boolean, issues: IntegrationHealthIssue[]): DenchI
   };
 }
 
+function buildManagedPluginState(config: OpenClawConfig, spec: ManagedBundledPluginSpec): ManagedPluginState {
+  const plugin = readPluginState(config, spec.pluginId);
+  const healthIssues: IntegrationHealthIssue[] = [];
+  if (!plugin.configured) healthIssues.push("missing_plugin_entry");
+  if (plugin.configured && !plugin.enabled) healthIssues.push("plugin_disabled");
+  if (!plugin.allowlisted) healthIssues.push("plugin_not_allowlisted");
+  if (!plugin.loadPathConfigured) healthIssues.push("plugin_load_path_missing");
+  if (!plugin.installRecorded) healthIssues.push("plugin_install_missing");
+  if (plugin.installRecorded && !plugin.installPathExists) healthIssues.push("plugin_install_path_missing");
+
+  const available =
+    plugin.configured &&
+    plugin.enabled &&
+    plugin.allowlisted &&
+    plugin.loadPathConfigured &&
+    plugin.installRecorded &&
+    plugin.installPathExists;
+
+  return {
+    id: spec.id,
+    pluginId: spec.pluginId,
+    label: spec.label,
+    required: spec.required,
+    available,
+    plugin,
+    healthIssues,
+    health: buildHealth(plugin.enabled, healthIssues),
+  };
+}
+
 function buildExaState(
   config: OpenClawConfig,
   gatewayBaseUrl: string | null,
@@ -927,6 +1074,12 @@ export function getIntegrationsState(): IntegrationsState {
   const exa = buildExaState(config, gatewayBaseUrl, auth, eligibility, builtInSearch);
   const apollo = buildApolloState(config, gatewayBaseUrl, auth, eligibility);
   const elevenlabs = buildElevenLabsState(config, gatewayBaseUrl, auth, eligibility);
+  const managedPlugins = DENCH_MANAGED_BUNDLED_PLUGINS
+    .filter((plugin) =>
+      plugin.id === "dench-ai-gateway" ||
+      plugin.id === "dench-identity"
+    )
+    .map((plugin) => buildManagedPluginState(config, plugin));
 
   return {
     denchCloud: {
@@ -948,6 +1101,7 @@ export function getIntegrationsState(): IntegrationsState {
       builtIn: builtInSearch,
       effectiveOwner: resolveEffectiveSearchOwner({ exaState: exa, builtInSearch }),
     },
+    managedPlugins,
     integrations: [exa, apollo, elevenlabs],
   };
 }
@@ -1108,7 +1262,10 @@ export function applyDenchIntegrationToggleDraft(params: {
   switch (id) {
     case "exa": {
       if (enabled) {
-        changed = ensurePluginRegistration(config, EXA_PLUGIN_ID) || changed;
+        changed = ensureManagedBundledPlugin(config, {
+          spec: resolveManagedBundledPluginSpec("exa"),
+          enabled: true,
+        }).changed || changed;
         changed = setPluginEnabled(config, EXA_PLUGIN_ID, true) || changed;
         changed = setWebSearchPolicy(config, { enabled: false, denied: true }) || changed;
       } else {
@@ -1128,7 +1285,10 @@ export function applyDenchIntegrationToggleDraft(params: {
     }
     case "apollo": {
       if (enabled) {
-        changed = ensurePluginRegistration(config, APOLLO_PLUGIN_ID) || changed;
+        changed = ensureManagedBundledPlugin(config, {
+          spec: resolveManagedBundledPluginSpec("apollo"),
+          enabled: true,
+        }).changed || changed;
         changed = setPluginEnabled(config, APOLLO_PLUGIN_ID, true) || changed;
       } else {
         changed = setPluginEnabled(config, APOLLO_PLUGIN_ID, false) || changed;
@@ -1185,12 +1345,14 @@ export function applyDenchIntegrationToggleDraft(params: {
   };
 }
 
-export function repairOlderIntegrationsProfile(): IntegrationsRepairResult {
+export function ensureDefaultManagedPluginsInstalled(): IntegrationsRepairResult {
   const config = readOpenClawConfigForIntegrations();
-  const repairs = [
-    repairBundledPluginRegistration(config, { id: "exa", pluginId: EXA_PLUGIN_ID }),
-    repairBundledPluginRegistration(config, { id: "apollo", pluginId: APOLLO_PLUGIN_ID }),
-  ];
+  const repairs = REQUIRED_MANAGED_PLUGIN_IDS.map((id) =>
+    ensureManagedBundledPlugin(config, {
+      spec: resolveManagedBundledPluginSpec(id),
+      enabled: true,
+    })
+  );
   const changed = repairs.some((repair) => repair.changed);
 
   if (changed) {
@@ -1206,6 +1368,9 @@ export function repairOlderIntegrationsProfile(): IntegrationsRepairResult {
     state: getIntegrationsState(),
   };
 }
+
+export const repairManagedPluginsProfile = ensureDefaultManagedPluginsInstalled;
+export const repairOlderIntegrationsProfile = ensureDefaultManagedPluginsInstalled;
 
 export function setExaIntegrationEnabled(enabled: boolean): IntegrationToggleResult {
   const config = readOpenClawConfigForIntegrations();


### PR DESCRIPTION
## Summary
- Add an idempotent managed-plugin installer for Dench-owned bundled plugins so required runtime plugins can be copied, registered, allowlisted, and loaded from the profile state dir.
- Wire Settings saves, integration toggles, and the repair endpoint through the installer before gateway refreshes.
- Surface required background plugin health in integration state and extend tests around repair, install records, shared assets, config preservation, and idempotency.

## Test plan
- `pnpm --dir apps/web test lib/integrations.test.ts app/api/integrations/repair/route.test.ts 'app/api/integrations/[id]/toggle/route.test.ts' app/api/integrations/route.test.ts app/components/integrations/dench-integrations-section.test.tsx app/components/integrations/integrations-panel.test.tsx lib/dench-cloud-settings.test.ts app/api/settings/cloud/route.test.ts`
- Runtime repair endpoint check on local web server confirmed managed plugin health for `dench-ai-gateway` and `dench-identity`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how bundled plugins are copied/registered into the on-disk `openclaw.json` profile and triggers gateway restarts, which can affect runtime behavior and user profiles if the installer logic is wrong.
> 
> **Overview**
> Introduces a **managed bundled plugin installer** in `lib/integrations.ts` that can copy bundled extensions into the profile state dir, register/allowlist/load them, record installs with `source`/`installedAt`, ensure the `shared` asset is present, and scrub sensitive/stale config keys.
> 
> Extends `IntegrationsState` with `managedPlugins` health/availability (currently reporting `dench-ai-gateway` and `dench-identity`), and updates the UI (`DenchIntegrationsSection`) to prompt repair when required managed plugins are missing and to display repaired plugin names.
> 
> Replaces the repair endpoint implementation to call `repairManagedPluginsProfile` (aliased from the new installer) and calls `ensureDefaultManagedPluginsInstalled()` when saving a Dench Cloud API key, with broad test updates/expansions covering repair behavior, idempotency, and config/install record changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73374c9a4a539711a7a3660955f597b5c80ac4b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->