### PR TITLE
fix(crm): make company chips clickable in company profile meetings tab

### DIFF
--- a/apps/web/app/components/crm/company-profile.tsx
+++ b/apps/web/app/components/crm/company-profile.tsx
@@ -87,7 +87,7 @@ const TABS: ReadonlyArray<{ id: Tab; label: string; count: (d: CompanyResponse) 
 export function CompanyProfile({
   companyId,
   onOpenPerson,
-  onOpenCompany: _onOpenCompany,
+  onOpenCompany,
   onBackToList,
 }: {
   companyId: string;
@@ -95,7 +95,6 @@ export function CompanyProfile({
   onOpenCompany?: (id: string) => void;
   onBackToList?: () => void;
 }) {
-  void _onOpenCompany;
   const [data, setData] = useState<CompanyResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -163,7 +162,13 @@ export function CompanyProfile({
           {tab === "overview" && <OverviewTab data={data} />}
           {tab === "team" && <TeamTab data={data} onOpenPerson={onOpenPerson} />}
           {tab === "emails" && <EmailsTab data={data} onOpenPerson={onOpenPerson} />}
-          {tab === "meetings" && <MeetingsTab data={data} onOpenPerson={onOpenPerson} />}
+          {tab === "meetings" && (
+            <MeetingsTab
+              data={data}
+              onOpenPerson={onOpenPerson}
+              onOpenCompany={onOpenCompany}
+            />
+          )}
         </div>
       </div>
     </div>
@@ -376,9 +381,11 @@ function EmailsTab({
 function MeetingsTab({
   data,
   onOpenPerson,
+  onOpenCompany,
 }: {
   data: CompanyResponse;
   onOpenPerson?: (id: string) => void;
+  onOpenCompany?: (id: string) => void;
 }) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
@@ -411,6 +418,7 @@ function MeetingsTab({
                   setExpandedId((prev) => (prev === event.id ? null : event.id))
                 }
                 onOpenPerson={onOpenPerson}
+                onOpenCompany={onOpenCompany}
               />
             ))}
           </ul>


### PR DESCRIPTION
## Summary

In a company profile's **Meetings** tab, expanding a meeting reveals attending people and associated companies. Person rows were clickable, but **company rows did nothing** — they appeared interactive but the click was a no-op.

Root cause: `CompanyProfile` was discarding the `onOpenCompany` prop (aliased to `_onOpenCompany` and voided). Because that callback never reached the `EventListItem` → `EventDetailBody` → `CompanyChip` chain, `CompanyChip` rendered as `disabled` (its `disabled` prop is `!onOpenCompany`).

`PersonProfile`'s Calendar tab was already forwarding both callbacks correctly; this PR makes `CompanyProfile` do the same.

## Diff scope

- `apps/web/app/components/crm/company-profile.tsx`
  - Stop aliasing `onOpenCompany` to `_onOpenCompany` and stop the `void` discard.
  - Forward `onOpenCompany` from `CompanyProfile` → `MeetingsTab` → `EventListItem`.

11 lines added, 3 changed in a single file. No other places needed updating — `ActivityTimeline` was already threading the prop correctly.

## End-to-end trace (post-fix)

1. `workspace-content.tsx` already passes `onOpenCompany={(id) => onOpenEntry("company", id)}` to `<CompanyProfile>`.
2. `CompanyProfile` now keeps the prop and forwards it to `MeetingsTab`.
3. `MeetingsTab` forwards it to `EventListItem`.
4. `EventListItem` (unchanged) forwards it to `EventDetailBody`.
5. `EventDetailBody` (unchanged) renders `<CompanyChip onOpenCompany={...} />`.
6. `CompanyChip`'s button is now enabled (`disabled={!onOpenCompany}` is `false`); clicking fires `onOpenCompany(company.id)` → workspace navigates to that company.

## Test plan

- [ ] Open a company profile that has at least one meeting with another associated company.
- [ ] Switch to the **Meetings** tab.
- [ ] Expand a meeting row.
- [ ] Click the company chip in the expanded panel — should navigate to that company's profile.
- [ ] Verify person chips still navigate (regression check).
- [ ] Repeat the same in the **Person profile → Meetings tab** to confirm no regression there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small prop-threading change in a single UI component to re-enable an existing click handler, with no data/model or security impact.
> 
> **Overview**
> Fixes a UI regression where *company chips* shown in expanded meeting details on the Company Profile **Meetings** tab appeared clickable but did nothing.
> 
> `CompanyProfile` now preserves and passes `onOpenCompany` through `MeetingsTab` to `EventListItem`, enabling `CompanyChip` to be interactive when the callback is provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef5b66cb051955f48e8b46dd5f220ba9d01333cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->