### PR TITLE
feat(telemetry): add posthog events for mcp settings add/remove

### DIFF
--- a/apps/web/app/api/settings/mcp/route.test.ts
+++ b/apps/web/app/api/settings/mcp/route.test.ts
@@ -20,16 +20,22 @@ vi.mock("@/lib/mcp-servers", () => {
   };
 });
 
+vi.mock("@/lib/telemetry", () => ({
+  trackServer: vi.fn(),
+}));
+
 const {
   addMcpServer,
   listMcpServers,
   McpServerError,
   removeMcpServer,
 } = await import("@/lib/mcp-servers");
+const { trackServer } = await import("@/lib/telemetry");
 
 const mockedAddMcpServer = vi.mocked(addMcpServer);
 const mockedListMcpServers = vi.mocked(listMcpServers);
 const mockedRemoveMcpServer = vi.mocked(removeMcpServer);
+const mockedTrackServer = vi.mocked(trackServer);
 
 describe("MCP settings API", () => {
   beforeEach(() => {
@@ -120,6 +126,11 @@ describe("MCP settings API", () => {
       transport: "streamable-http",
       hasAuth: true,
     });
+    expect(mockedTrackServer).toHaveBeenCalledWith("mcp_server_added", {
+      key: "acme",
+      transport: "streamable-http",
+      has_auth: true,
+    });
   });
 
   it("POST returns helper validation errors", async () => {
@@ -140,6 +151,7 @@ describe("MCP settings API", () => {
     await expect(response.json()).resolves.toMatchObject({
       error: "MCP server 'acme' already exists.",
     });
+    expect(mockedTrackServer).not.toHaveBeenCalled();
   });
 
   it("DELETE validates key type", async () => {
@@ -166,6 +178,9 @@ describe("MCP settings API", () => {
     expect(response.status).toBe(200);
     expect(mockedRemoveMcpServer).toHaveBeenCalledWith("acme");
     expect(body).toEqual({ key: "acme" });
+    expect(mockedTrackServer).toHaveBeenCalledWith("mcp_server_removed", {
+      key: "acme",
+    });
   });
 
   it("DELETE returns helper not-found errors", async () => {
@@ -183,5 +198,6 @@ describe("MCP settings API", () => {
     await expect(response.json()).resolves.toMatchObject({
       error: "MCP server 'missing' was not found.",
     });
+    expect(mockedTrackServer).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/settings/mcp/route.ts
+++ b/apps/web/app/api/settings/mcp/route.ts
@@ -4,6 +4,7 @@ import {
   McpServerError,
   removeMcpServer,
 } from "@/lib/mcp-servers";
+import { trackServer } from "@/lib/telemetry";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -68,6 +69,11 @@ export async function POST(req: Request) {
       transport: body.transport,
       authToken: body.authToken,
     });
+    trackServer("mcp_server_added", {
+      key: server.key,
+      transport: server.transport,
+      has_auth: server.hasAuth,
+    });
     return Response.json({ server }, { status: 201 });
   } catch (err) {
     if (err instanceof McpServerError) {
@@ -94,6 +100,7 @@ export async function DELETE(req: Request) {
 
   try {
     removeMcpServer(body.key);
+    trackServer("mcp_server_removed", { key: body.key });
     return Response.json({ key: body.key });
   } catch (err) {
     if (err instanceof McpServerError) {


### PR DESCRIPTION
## What

Adds PostHog telemetry for the two state-changing MCP actions in settings:

| Event | Trigger | Properties |
| --- | --- | --- |
| \`mcp_server_added\` | \`POST /api/settings/mcp\` succeeds | \`{ key, transport, has_auth }\` |
| \`mcp_server_removed\` | \`DELETE /api/settings/mcp\` succeeds | \`{ key }\` |

## Why

We had **zero** signal on MCP server adoption — we couldn't tell who's configuring remote endpoints, which transports they use, or whether they're auth'ed. These two events close that gap so we can:
- track MCP feature adoption
- understand transport / auth posture
- spot churn (added → removed) on individual servers

## Design (production-grade, not a patch)

- **Server-side only** via the existing \`trackServer\` helper in \`apps/web/lib/telemetry.ts\` — matches every other state-change event in this app (\`workspace_created\`, \`onboarding_toolkit_connected\`, etc.).
- **Naming**: snake_case \`{noun}_{past-tense-verb}\`, matching repo convention.
- **Captured after** the source-of-truth file write succeeds — never on validation or helper-error paths (consistent with how no other route tracks failures).
- **Privacy**: \`key\` is the user-typed identifier (analogous to \`toolkit\` in \`onboarding_toolkit_connected\`). The full \`url\` and the auth token are deliberately excluded; \`has_auth\` is a boolean.
- **No new abstractions / helpers** — would be premature given the existing scattered idiom; a single place to grep all MCP events is more valuable here.

## Files

- \`apps/web/app/api/settings/mcp/route.ts\` — two \`trackServer\` calls in the success branches
- \`apps/web/app/api/settings/mcp/route.test.ts\` — asserts events fire on success and **don't** fire on validation / helper-error paths

## Verification

- [x] \`npx vitest run app/api/settings/mcp/route.test.ts\` → 8/8 passing
- [x] Surrounding routes still green: \`onboarding\` + \`settings\` suites → 24/24
- [x] \`oxlint\` on touched files → 0 warnings, 0 errors
- [x] \`tsc --noEmit\`: zero new errors in touched files (pre-existing errors in unrelated test files only)
- [x] End-to-end trace: dialog → POST → \`addMcpServer\` writes config → \`trackServer\` → 201; trash → DELETE → \`removeMcpServer\` removes from config → \`trackServer\` → 200
- [x] No PII / tokens / URLs leaked

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only emits telemetry on successful `POST`/`DELETE` operations and adds test coverage to ensure no events fire on validation or helper-error paths.
> 
> **Overview**
> Adds server-side telemetry to the MCP settings API by calling `trackServer` after successful `POST /api/settings/mcp` and `DELETE /api/settings/mcp` operations.
> 
> Tests are updated to mock `@/lib/telemetry` and assert `mcp_server_added` (with `{ key, transport, has_auth }`) and `mcp_server_removed` (with `{ key }`) fire only on success and *not* on validation/helper-error responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ae2d059c2bf197b5aadcacbe76538138977a132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->