### PR TITLE
fix(workspace): keep table header (incl. + Add Column) visible when table is empty

### DIFF
--- a/apps/web/app/components/workspace/data-table.tsx
+++ b/apps/web/app/components/workspace/data-table.tsx
@@ -710,25 +710,6 @@ export function DataTable<TData, TValue>({
 			>
 				{loading ? (
 					<LoadingSkeleton columnCount={allColumns.length} />
-				) : data.length === 0 ? (
-					<div className="flex flex-col items-center justify-center py-24 gap-4">
-						<div
-							className="rounded-full p-4 mb-2 backdrop-blur-sm"
-							style={{ background: "var(--color-glass)", border: "1px solid var(--color-border)", boxShadow: "var(--shadow-sm)" }}
-						>
-							<svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ color: "var(--color-text-muted)" }}>
-								<circle cx="11" cy="11" r="8" /><path d="m21 21-4.3-4.3" />
-							</svg>
-						</div>
-						<div className="text-center">
-							<h3 className="text-base font-semibold mb-1" style={{ color: "var(--color-text)" }}>No results found</h3>
-							<p className="text-sm max-w-xs" style={{ color: "var(--color-text-muted)" }}>
-								{globalFilter
-									? "Try adjusting your search or filter criteria."
-									: "No data available yet. Create your first entry to get started."}
-							</p>
-						</div>
-					</div>
 				) : (
 					<DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
 						<table
@@ -860,16 +841,23 @@ export function DataTable<TData, TValue>({
 									</tr>
 								))}
 							</thead>
-							<DataTableBody
-								table={table}
-								activeRowId={activeRowId}
-								getRowId={getRowId}
-								enableRowSelection={enableRowSelection}
-								stickyFirstColumn={stickyFirstColumn}
-								isScrolled={isScrolled}
-								onRowClick={onRowClick}
-								getFirstDataColumnFaviconUrl={getFirstDataColumnFaviconUrl}
-							/>
+							{data.length === 0 ? (
+								<EmptyTableBody
+									columnCount={table.getVisibleLeafColumns().length}
+									isFiltered={Boolean(globalFilter)}
+								/>
+							) : (
+								<DataTableBody
+									table={table}
+									activeRowId={activeRowId}
+									getRowId={getRowId}
+									enableRowSelection={enableRowSelection}
+									stickyFirstColumn={stickyFirstColumn}
+									isScrolled={isScrolled}
+									onRowClick={onRowClick}
+									getFirstDataColumnFaviconUrl={getFirstDataColumnFaviconUrl}
+								/>
+							)}
 						</table>
 					</DndContext>
 				)}
@@ -1179,6 +1167,79 @@ const DataTableBody = React.memo(DataTableBodyInner, (prev, next) => {
 	}
 	return false;
 });
+
+/** Empty-state body. Rendered in place of `<DataTableBody/>` when there are
+ * no rows. Lives inside the same `<table>` so the column headers (including
+ * the "+ Add Column" affordance and sort/reorder controls) stay visible and
+ * reachable from the empty state — instead of swapping the entire table out
+ * for a centered "No data" message, which strands the user with no way to
+ * configure their schema or add their first entry.
+ *
+ * The inner content is `position: sticky; left: 0` with `inline-flex` so it
+ * shrink-wraps to its content size and anchors to the left edge of the
+ * visible scroll container. Without this, a `<td colSpan>` row spans the
+ * full table width — which can be much larger than the viewport for wide
+ * schemas — and the centered content would render off-screen. Sticky-left
+ * keeps the message reachable regardless of how wide the table is. */
+function EmptyTableBody({
+	columnCount,
+	isFiltered,
+}: {
+	columnCount: number;
+	isFiltered: boolean;
+}) {
+	const safeColSpan = Math.max(columnCount, 1);
+	return (
+		<tbody>
+			<tr>
+				<td colSpan={safeColSpan} className="p-0 border-0">
+					<div
+						className="flex flex-col items-center gap-4 py-24 px-12"
+						style={{ position: "sticky", left: 0, display: "inline-flex" }}
+					>
+						<div
+							className="rounded-full p-4 mb-2 backdrop-blur-sm"
+							style={{
+								background: "var(--color-glass)",
+								border: "1px solid var(--color-border)",
+								boxShadow: "var(--shadow-sm)",
+							}}
+						>
+							<svg
+								width="32"
+								height="32"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="1.5"
+								style={{ color: "var(--color-text-muted)" }}
+							>
+								<circle cx="11" cy="11" r="8" />
+								<path d="m21 21-4.3-4.3" />
+							</svg>
+						</div>
+						<div className="text-center">
+							<h3
+								className="text-base font-semibold mb-1"
+								style={{ color: "var(--color-text)" }}
+							>
+								No results found
+							</h3>
+							<p
+								className="text-sm max-w-xs"
+								style={{ color: "var(--color-text-muted)" }}
+							>
+								{isFiltered
+									? "Try adjusting your search or filter criteria."
+									: "No data available yet. Create your first entry to get started."}
+							</p>
+						</div>
+					</div>
+				</td>
+			</tr>
+		</tbody>
+	);
+}
 
 /* ─── Sub-components ─── */
 


### PR DESCRIPTION
## Summary

When a table had no rows, the entire `<table>` was replaced with a centered "No results" message — which also removed the `<thead>` and, with it, the `+ Add Column` affordance. Users on a brand-new (empty) table had no way to add their first column from the UI. The control was hidden at the exact moment it was most needed.

## What changed

- `<table>` + `<thead>` are now always rendered. Only the `<tbody>` swaps.
- New `EmptyTableBody` component renders a single `<tr><td colSpan={N}>` with the empty-state visual when `data.length === 0`.
- Inner empty-state content uses `position: sticky; left: 0` + `display: inline-flex` so it shrink-wraps and anchors to the left edge of the **scroll container** — without that, a `colSpan` row covers the entire (often very wide) table and the centered message renders off-screen for any schema wider than the viewport.
- Filter-aware copy preserved: "Try adjusting your search or filter criteria." vs. "No data available yet. Create your first entry to get started."

## Why this approach (vs. embedding an Add Column button inside the empty state)

Keeping the header always-mounted is the more fundamental fix:
- Preserves all existing affordances (sort, reorder, resize, filter chips, **and** Add Column) without duplication.
- Single source of truth for column controls — no risk of the empty-state button drifting out of sync with the real header.
- Empty state becomes a true tbody row, not a special-case overlay.

## Test plan

- [x] Visual: empty + no filter → message + "Create your first entry…" copy renders, header (incl. `+`) visible
- [x] Visual: empty + active filter → "Try adjusting your search…" copy renders, header visible
- [x] Visual: wide schema (15 columns, table wider than viewport) → empty-state message stays anchored to visible scroll-area left edge (heading_left within viewport, confirmed via DOM measurement)
- [x] Visual: populated table (27 rows) → no empty state, all rows + headers render normally
- [x] `tsc` — zero new errors in `data-table.tsx` (pre-existing test errors unchanged)
- [x] `oxlint` on `data-table.tsx` — zero new errors (15 pre-existing errors unchanged)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that alters empty-state rendering within the table; main risk is minor layout/sticky positioning quirks in very wide tables.
> 
> **Overview**
> Ensures the workspace `DataTable` always renders the `<table>` and `<thead>` (including `+ Add Column` and header controls) even when `data.length === 0`.
> 
> Replaces the previous full-table swap to a centered empty message with a new `EmptyTableBody` that conditionally renders a single-row `<tbody>` inside the table (filter-aware copy preserved) and uses sticky-left positioning to keep the empty-state content visible on horizontally-scrollable/wide schemas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c4bca4d1c234701408321a71d688dc8267e53ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->