### PR TITLE
fix(workspace): scope table filter/search per-table and persist across visits

### DIFF
--- a/apps/web/app/api/composio/disconnect/route.test.ts
+++ b/apps/web/app/api/composio/disconnect/route.test.ts
@@ -175,7 +175,7 @@ describe("Composio disconnect API", () => {
   });
 
   it("rejects requests without an api key (403)", async () => {
-    mockedResolveComposioApiKey.mockReturnValue(undefined);
+    mockedResolveComposioApiKey.mockReturnValue(null);
     const response = await POST(makeRequest({ connection_id: "conn_xxx" }));
     expect(response.status).toBe(403);
     expect(mockedDisconnectComposioApp).not.toHaveBeenCalled();
@@ -184,7 +184,7 @@ describe("Composio disconnect API", () => {
   it("rejects ineligible Dench Cloud profile (403)", async () => {
     mockedResolveComposioEligibility.mockReturnValue({
       eligible: false,
-      lockReason: "primary_provider_mismatch",
+      lockReason: "primary_provider_mismatch" as never,
       lockBadge: "external",
     });
     const response = await POST(makeRequest({ connection_id: "conn_xxx" }));

--- a/apps/web/app/api/composio/status/route.test.ts
+++ b/apps/web/app/api/composio/status/route.test.ts
@@ -47,7 +47,7 @@ const mockStatus = {
 describe("Composio status API", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockedGetComposioMcpHealth.mockResolvedValue(mockStatus);
+    mockedGetComposioMcpHealth.mockResolvedValue(mockStatus as never);
   });
 
   it("GET returns the current Composio MCP health", async () => {

--- a/apps/web/app/api/web-sessions/web-sessions.test.ts
+++ b/apps/web/app/api/web-sessions/web-sessions.test.ts
@@ -169,7 +169,7 @@ describe("Web Sessions API", () => {
       // Should write at least the index.json and the empty .jsonl
       expect(mockWrite).toHaveBeenCalled();
       // Verify that one of the calls is to the jsonl file
-      const calls = mockWrite.mock.calls.map((c) => String(c[0]));
+      const calls = vi.mocked(mockWrite).mock.calls.map((c) => String(c[0]));
       expect(calls.some((c) => c.endsWith(".jsonl"))).toBe(true);
     });
   });

--- a/apps/web/app/api/workspace/tree-browse.test.ts
+++ b/apps/web/app/api/workspace/tree-browse.test.ts
@@ -113,9 +113,9 @@ describe("Workspace Tree & Browse API", () => {
           return Promise.resolve([
             makeDirent("knowledge", true),
             makeDirent("readme.md", false),
-          ] as unknown as Dirent[]);
+          ] as unknown as never[]);
         }
-        return Promise.resolve([] as unknown as Dirent[]);
+        return Promise.resolve([] as unknown as never[]);
       });
 
       const { GET } = await import("./tree/route.js");
@@ -147,9 +147,9 @@ describe("Workspace Tree & Browse API", () => {
           return Promise.resolve([
             makeDirent("IDENTITY.md", false),
             makeDirent("notes.md", false),
-          ] as unknown as Dirent[]);
+          ] as unknown as never[]);
         }
-        return Promise.resolve([] as unknown as Dirent[]);
+        return Promise.resolve([] as unknown as never[]);
       });
 
       const { GET } = await import("./tree/route.js");
@@ -169,19 +169,19 @@ describe("Workspace Tree & Browse API", () => {
         if (String(dir) === "/ws") {
           return Promise.resolve([
             makeDirent("skills", true),
-          ] as unknown as Dirent[]);
+          ] as unknown as never[]);
         }
         if (String(dir) === "/ws/skills") {
           return Promise.resolve([
             makeDirent("alpha", true),
-          ] as unknown as Dirent[]);
+          ] as unknown as never[]);
         }
         if (String(dir) === "/ws/skills/alpha") {
           return Promise.resolve([
             makeDirent("SKILL.md", false),
-          ] as unknown as Dirent[]);
+          ] as unknown as never[]);
         }
-        return Promise.resolve([] as unknown as Dirent[]);
+        return Promise.resolve([] as unknown as never[]);
       });
 
       const { GET } = await import("./tree/route.js");
@@ -220,9 +220,9 @@ describe("Workspace Tree & Browse API", () => {
             makeDirent("opportunity", true),
             makeDirent("secret", true),
             makeDirent("email_thread", true),
-          ] as unknown as Dirent[]);
+          ] as unknown as never[]);
         }
-        return Promise.resolve([] as unknown as Dirent[]);
+        return Promise.resolve([] as unknown as never[]);
       });
 
       const { GET } = await import("./tree/route.js");
@@ -259,7 +259,7 @@ describe("Workspace Tree & Browse API", () => {
       vi.mocked(duckdbQueryAllAsync).mockReturnValue(duckdbGate);
 
       const { readdir: mockReaddir } = await import("node:fs/promises");
-      vi.mocked(mockReaddir).mockResolvedValue([] as unknown as Dirent[]);
+      vi.mocked(mockReaddir).mockResolvedValue([] as unknown as never[]);
 
       const { GET } = await import("./tree/route.js");
       const req = new Request("http://localhost/api/workspace/tree");
@@ -285,7 +285,7 @@ describe("Workspace Tree & Browse API", () => {
       vi.mocked(mockReaddir).mockReturnValue([
         makeDirent("file.txt", false),
         makeDirent("subfolder", true),
-      ] as unknown as Dirent[]);
+      ] as unknown as never[]);
       vi.mocked(mockStat).mockReturnValue({ isDirectory: () => false, size: 100 } as never);
 
       const { GET } = await import("./browse/route.js");
@@ -320,7 +320,7 @@ describe("Workspace Tree & Browse API", () => {
       vi.mocked(mockExists).mockReturnValue(true);
       vi.mocked(mockReaddir).mockReturnValue([
         makeDirent("doc.md", false),
-      ] as unknown as Dirent[]);
+      ] as unknown as never[]);
 
       const { GET } = await import("./suggest-files/route.js");
       const req = new Request("http://localhost/api/workspace/suggest-files?q=doc");
@@ -340,9 +340,9 @@ describe("Workspace Tree & Browse API", () => {
           return [
             makeDirent("IDENTITY.md", false),
             makeDirent("doc.md", false),
-          ] as unknown as Dirent[];
+          ] as unknown as never[];
         }
-        return [] as unknown as Dirent[];
+        return [] as unknown as never[];
       });
 
       const { GET } = await import("./suggest-files/route.js");
@@ -416,9 +416,9 @@ describe("Workspace Tree & Browse API", () => {
       vi.mocked(mockExists).mockReturnValue(true);
       vi.mocked(mockReaddir).mockImplementation((dir) => {
         if (String(dir) === "/ws") {
-          return [makeDirent("readme.md", false)] as unknown as Dirent[];
+          return [makeDirent("readme.md", false)] as unknown as never[];
         }
-        return [] as unknown as Dirent[];
+        return [] as unknown as never[];
       });
 
       const { GET } = await import("./search-index/route.js");

--- a/apps/web/app/components/chat-message.test.tsx
+++ b/apps/web/app/components/chat-message.test.tsx
@@ -217,7 +217,7 @@ describe("ChatMessage", () => {
             },
             errorText:
               "Validation failed for tool \"composio_call_tool\": execution_ref is required.",
-          }],
+          } as never],
         }}
       />,
     );
@@ -255,7 +255,7 @@ describe("ChatMessage", () => {
               tool_router_session_id: "trs_posthog_123",
               error: "Gateway rejected the bridge invocation.",
             },
-          }],
+          } as never],
         }}
       />,
     );

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -40,6 +40,7 @@ import { ChatPanel, type ChatPanelHandle, type SubagentSpawnInfo } from "../comp
 import { EntryDetailPanel } from "../components/workspace/entry-detail-panel";
 import { useSearchIndex } from "@/lib/search-index";
 import { parseWorkspaceLink, isWorkspaceLink, parseUrlState, buildUrl, serializeUrlState, type WorkspaceUrlState } from "@/lib/workspace-links";
+import { loadTableViewState, saveTableViewState, TABLE_VIEW_URL_KEYS } from "@/lib/table-view-state";
 import {
   type WorkspaceTabsState,
   type ContentTab,
@@ -1722,22 +1723,13 @@ function WorkspacePageInner() {
         run: cronRun,
       },
     });
-    // Preserve object-view params (managed by ObjectView's own URL effect).
+    // Object-view state (search / filters / sort / view / cols / page) is
+    // intentionally NOT preserved across tab/path changes. It now lives in
+    // per-table localStorage (`lib/table-view-state.ts`), not the URL —
+    // otherwise switching from table A to table B would carry A's filter to B.
+    // The URL stays focused on navigation (path / entry / chat / browse / …).
     const current = new URLSearchParams(window.location.search);
-    const objectViewKeys = ["viewType", "view", "filters", "search", "sort", "page", "pageSize", "cols"];
     const merged: Partial<WorkspaceUrlState> = { ...projected };
-    if (projected.path) {
-      // Only carry object-view params when there's an active path; they don't
-      // make sense on a chat-only URL.
-      const u = parseUrlState(current);
-      for (const k of objectViewKeys) {
-        const key = k as keyof WorkspaceUrlState;
-        const value = u[key];
-        if (value != null && value !== false && (Array.isArray(value) ? value.length > 0 : true)) {
-          (merged as Record<string, unknown>)[k] = value;
-        }
-      }
-    }
     const nextQs = serializeUrlState(merged);
     const currentQs = current.toString();
     if (nextQs !== currentQs) {
@@ -3028,29 +3020,67 @@ function ObjectView({
   };
   const [updatingDisplayField, setUpdatingDisplayField] = useState(false);
 
-  // Read initial URL state once for this object view.
-  const initialUrlState = useMemo(() => parseUrlState(searchParams), []);  // eslint-disable-line react-hooks/exhaustive-deps
+  // Resolve the initial view state for this table.
+  //
+  // View state (search/filters/sort/view/viewType/cols/page) is now scoped
+  // per-table and persisted in localStorage rather than the URL — switching
+  // tables must NOT carry one table's filter to the next. We still read the
+  // URL on first mount so deep-link `?path=A&search=foo` style URLs work
+  // once: if localStorage has nothing for this table, the URL becomes the
+  // initial state. Subsequent state changes flow into localStorage and the
+  // view-state URL params are stripped (see effect below).
+  //
+  // ObjectView is keyed by `data.object.name` upstream, so this useMemo
+  // runs once per table (a new mount on every table switch).
+  const initialState = useMemo(() => {
+    const stored = loadTableViewState(data.object.name);
+    if (
+      stored.search !== undefined ||
+      stored.filters !== undefined ||
+      stored.sort !== undefined ||
+      stored.view !== undefined ||
+      stored.viewType !== undefined ||
+      stored.cols !== undefined ||
+      stored.page !== undefined ||
+      stored.pageSize !== undefined
+    ) {
+      return stored;
+    }
+    const url = parseUrlState(searchParams);
+    return {
+      view: url.view ?? undefined,
+      viewType: url.viewType ?? undefined,
+      filters: url.filters ?? undefined,
+      search: url.search ?? undefined,
+      sort: url.sort ?? undefined,
+      page: url.page ?? undefined,
+      pageSize: url.pageSize ?? undefined,
+      cols: url.cols ?? undefined,
+    };
+  // Initial state — frozen at mount, deliberately ignores prop/url changes.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data.object.name]);
 
   // --- View type state ---
   const [currentViewType, setCurrentViewType] = useState<ViewType>(
-    () => initialUrlState.viewType ?? resolveViewType(undefined, undefined, data.object.default_view),
+    () => initialState.viewType ?? resolveViewType(undefined, undefined, data.object.default_view),
   );
   const [viewSettings, setViewSettings] = useState<ViewTypeSettings>(
     () => data.viewSettings ?? {},
   );
 
   // --- Filter state ---
-  const [filters, setFilters] = useState<FilterGroup>(() => initialUrlState.filters ?? emptyFilterGroup());
+  const [filters, setFilters] = useState<FilterGroup>(() => initialState.filters ?? emptyFilterGroup());
   const [savedViews, setSavedViews] = useState<SavedView[]>(data.savedViews ?? []);
-  const [activeViewName, setActiveViewName] = useState<string | undefined>(initialUrlState.view ?? data.activeView);
+  const [activeViewName, setActiveViewName] = useState<string | undefined>(initialState.view ?? data.activeView);
 
   // --- Server-side pagination state ---
-  const [serverPage, setServerPage] = useState(initialUrlState.page ?? data.page ?? 1);
-  const [serverPageSize, setServerPageSize] = useState(initialUrlState.pageSize ?? data.pageSize ?? 100);
+  const [serverPage, setServerPage] = useState(initialState.page ?? data.page ?? 1);
+  const [serverPageSize, setServerPageSize] = useState(initialState.pageSize ?? data.pageSize ?? 100);
   const [totalCount, setTotalCount] = useState(data.totalCount ?? data.entries.length);
   const [entries, setEntries] = useState(data.entries);
-  const [serverSearch, setServerSearch] = useState(initialUrlState.search ?? "");
-  const [sortRules, _setSortRules] = useState<SortRule[] | undefined>(initialUrlState.sort ?? undefined);
+  const [serverSearch, setServerSearch] = useState(initialState.search ?? "");
+  const [sortRules, _setSortRules] = useState<SortRule[] | undefined>(initialState.sort ?? undefined);
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasActiveServerQuery =
     filters.rules.length > 0 ||
@@ -3058,20 +3088,20 @@ function ObjectView({
     serverSearch.trim().length > 0;
 
   // Column visibility: maps field IDs to boolean (false = hidden)
-  const [viewColumns, setViewColumns] = useState<string[] | undefined>(initialUrlState.cols ?? undefined);
+  const [viewColumns, setViewColumns] = useState<string[] | undefined>(initialState.cols ?? undefined);
   // Column widths: maps field name to pixel width (persisted in view_settings / saved views)
   const [columnWidths, setColumnWidths] = useState<Record<string, number> | undefined>(
     () => data.viewSettings?.column_widths,
   );
 
   // --- Unified toolbar state (lifted up so the controls live above the view) ---
-  const [globalFilter, setGlobalFilter] = useState<string>(initialUrlState.search ?? "");
+  const [globalFilter, setGlobalFilter] = useState<string>(initialState.search ?? "");
   const [stickyFirstColumn, setStickyFirstColumn] = useState(true);
   const [showAddModal, setShowAddModal] = useState(false);
 
-  // Sync object view state to URL params (additive — preserves path/entry/browse params).
-  // Skip the initial render to avoid overwriting URL params that haven't been
-  // read yet or that the shell-level effect is still propagating.
+  // Persist this table's view state to localStorage and clean any stale
+  // view-state params out of the URL. Skip the first run so we don't
+  // immediately re-write storage with the just-loaded values.
   const objectViewMounted = useRef(false);
   useEffect(() => {
     if (!objectViewMounted.current) {
@@ -3079,26 +3109,32 @@ function ObjectView({
       return;
     }
 
-    const current = new URLSearchParams(window.location.search);
-    const next = new URLSearchParams(current);
-
-    for (const k of ["viewType", "view", "filters", "search", "sort", "page", "pageSize", "cols"]) {
-      next.delete(k);
-    }
-
     const defaultVt = resolveViewType(undefined, undefined, data.object.default_view);
-    if (currentViewType !== defaultVt) next.set("viewType", currentViewType);
-    if (activeViewName) next.set("view", activeViewName);
-    if (filters.rules.length > 0) next.set("filters", btoa(JSON.stringify(filters)));
-    if (serverSearch) next.set("search", serverSearch);
-    if (sortRules && sortRules.length > 0) next.set("sort", btoa(JSON.stringify(sortRules)));
-    if (serverPage > 1) next.set("page", String(serverPage));
-    if (serverPageSize !== 100) next.set("pageSize", String(serverPageSize));
-    if (viewColumns && viewColumns.length > 0) next.set("cols", viewColumns.join(","));
+    saveTableViewState(data.object.name, {
+      viewType: currentViewType !== defaultVt ? currentViewType : undefined,
+      view: activeViewName,
+      filters: filters.rules.length > 0 ? filters : undefined,
+      search: serverSearch || undefined,
+      sort: sortRules && sortRules.length > 0 ? sortRules : undefined,
+      page: serverPage > 1 ? serverPage : undefined,
+      pageSize: serverPageSize !== 100 ? serverPageSize : undefined,
+      cols: viewColumns && viewColumns.length > 0 ? viewColumns : undefined,
+    });
 
-    const nextQs = next.toString();
-    if (nextQs !== current.toString()) {
-      router.replace(nextQs ? `/?${nextQs}` : "/", { scroll: false });
+    // Strip view-state params from the URL so the URL stops being a stale
+    // source of truth — once the user has interacted, localStorage is
+    // authoritative and the URL is purely navigational.
+    const current = new URLSearchParams(window.location.search);
+    let dirty = false;
+    for (const k of TABLE_VIEW_URL_KEYS) {
+      if (current.has(k)) {
+        current.delete(k);
+        dirty = true;
+      }
+    }
+    if (dirty) {
+      const qs = current.toString();
+      router.replace(qs ? `/?${qs}` : "/", { scroll: false });
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentViewType, activeViewName, filters, serverSearch, sortRules, serverPage, serverPageSize, viewColumns]);

--- a/apps/web/lib/table-view-state.ts
+++ b/apps/web/lib/table-view-state.ts
@@ -1,0 +1,112 @@
+/**
+ * Per-table view state — search, filters, sort, view selection, column
+ * visibility, page size, etc. — keyed by object name and persisted in
+ * localStorage.
+ *
+ * Why this exists: previously these params lived in the URL as a single
+ * global slot. When the user switched tables, the URL preserved them
+ * (`workspace-content.tsx`'s shell-level URL effect intentionally carried
+ * "object-view params" across path changes), so the new table inherited the
+ * previous table's filter / search. View state is fundamentally a property
+ * of *a table*, not *the URL*: each table should remember its own view, and
+ * coming back to a table should restore exactly what you left it on.
+ *
+ * Trade-off: we lose `?search=foo&path=A` style shareable URLs (filters
+ * become a personal, per-device preference, not a piece of shared state).
+ * That matches user mental model — filters are "how I'm looking at this
+ * table right now", not "what URL describes this view to others". For
+ * one-off deep links we still consult the URL on first mount when
+ * localStorage has no entry for that table (`hydrateFromUrl` in the
+ * caller), so a freshly-followed `?search=…` link still works once.
+ */
+
+import type { FilterGroup, SortRule, ViewType } from "./object-filters";
+
+const STORAGE_KEY = "dench:table-view-state:v1";
+
+export type TableViewState = {
+	view?: string;
+	viewType?: ViewType;
+	filters?: FilterGroup;
+	search?: string;
+	sort?: SortRule[];
+	page?: number;
+	pageSize?: number;
+	cols?: string[];
+};
+
+type Bag = Record<string, TableViewState>;
+
+function readBag(): Bag {
+	if (typeof window === "undefined") return {};
+	try {
+		const raw = window.localStorage.getItem(STORAGE_KEY);
+		if (!raw) return {};
+		const parsed = JSON.parse(raw);
+		return typeof parsed === "object" && parsed != null ? (parsed as Bag) : {};
+	} catch {
+		return {};
+	}
+}
+
+function writeBag(bag: Bag): void {
+	if (typeof window === "undefined") return;
+	try {
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify(bag));
+	} catch {
+		// Quota / disabled storage — silently no-op; in-memory state still works.
+	}
+}
+
+/** True if `s` has no meaningful view customizations (so we can skip storing). */
+function isEmptyState(s: TableViewState): boolean {
+	return (
+		!s.view &&
+		!s.viewType &&
+		!(s.filters && s.filters.rules.length > 0) &&
+		!(s.search && s.search.length > 0) &&
+		!(s.sort && s.sort.length > 0) &&
+		!s.page &&
+		!s.pageSize &&
+		!(s.cols && s.cols.length > 0)
+	);
+}
+
+export function loadTableViewState(objectName: string): TableViewState {
+	if (!objectName) return {};
+	return readBag()[objectName] ?? {};
+}
+
+export function saveTableViewState(
+	objectName: string,
+	state: TableViewState,
+): void {
+	if (!objectName) return;
+	const bag = readBag();
+	if (isEmptyState(state)) {
+		if (objectName in bag) {
+			delete bag[objectName];
+			writeBag(bag);
+		}
+		return;
+	}
+	bag[objectName] = state;
+	writeBag(bag);
+}
+
+/**
+ * Strip view-state query params from a URL string. Used after hydrating from
+ * a deep link so the URL stops being a (now-stale) source of truth for view
+ * state — subsequent navigations / table switches won't carry inherited
+ * filters from the URL.
+ */
+export const TABLE_VIEW_URL_KEYS = [
+	"viewType",
+	"view",
+	"filters",
+	"search",
+	"sort",
+	"page",
+	"pageSize",
+	"cols",
+] as const;

--- a/apps/web/lib/workspace-chat-isolation.test.ts
+++ b/apps/web/lib/workspace-chat-isolation.test.ts
@@ -183,7 +183,7 @@ describe("workspace-scoped chat session isolation", () => {
     });
     mockReaddir.mockReturnValue([
       makeDirent("workspace-dev"),
-    ] as unknown as Dirent[]);
+    ] as unknown as never[]);
 
     const wsDir = workspaceDir("dev");
     mockExists.mockImplementation((p) => String(p) === wsDir);
@@ -207,7 +207,7 @@ describe("workspace-scoped chat session isolation", () => {
     mockReaddir.mockReturnValue([
       makeDirent("workspace-alpha"),
       makeDirent("workspace-beta"),
-    ] as unknown as Dirent[]);
+    ] as unknown as never[]);
 
     const alphaDir = workspaceDir("alpha");
     const betaDir = workspaceDir("beta");
@@ -237,7 +237,7 @@ describe("workspace-scoped chat session isolation", () => {
     mockReaddir.mockReturnValue([
       makeDirent("workspace-work"),
       makeDirent("workspace-personal"),
-    ] as unknown as Dirent[]);
+    ] as unknown as never[]);
 
     const workDir = workspaceDir("work");
     const personalDir = workspaceDir("personal");
@@ -258,7 +258,7 @@ describe("workspace-scoped chat session isolation", () => {
     mockReadFile.mockImplementation(() => {
       throw new Error("ENOENT");
     });
-    mockReaddir.mockReturnValue([] as unknown as Dirent[]);
+    mockReaddir.mockReturnValue([] as unknown as never[]);
     mockExists.mockReturnValue(false);
 
     expect(resolveWebChatDir()).toBe(chatDir("default"));
@@ -279,7 +279,7 @@ describe("workspace-scoped chat session isolation", () => {
     mockReaddir.mockReturnValue([
       makeDirent("workspace-dev"),
       makeDirent("workspace-staging"),
-    ] as unknown as Dirent[]);
+    ] as unknown as never[]);
 
     const devDir = workspaceDir("dev");
     const stagingDir = workspaceDir("staging");
@@ -304,7 +304,7 @@ describe("workspace-scoped chat session isolation", () => {
     });
     mockReaddir.mockReturnValue([
       makeDirent("workspace-work"),
-    ] as unknown as Dirent[]);
+    ] as unknown as never[]);
 
     const wsDir = workspaceDir("work");
     mockExists.mockImplementation((p) => String(p) === wsDir);
@@ -322,7 +322,7 @@ describe("workspace-scoped chat session isolation", () => {
     const rootDir = workspaceDir("default");
     mockReaddir.mockReturnValue([
       makeDirent("workspace"),
-    ] as unknown as Dirent[]);
+    ] as unknown as never[]);
     mockExists.mockImplementation((p) => String(p) === rootDir);
 
     setUIActiveProfile("default");
@@ -343,7 +343,7 @@ describe("workspace-scoped chat session isolation", () => {
     });
     mockReaddir.mockReturnValue([
       makeDirent("workspace-dev"),
-    ] as unknown as Dirent[]);
+    ] as unknown as never[]);
 
     const devDir = workspaceDir("dev");
     mockExists.mockImplementation((p) => String(p) === devDir);
@@ -353,7 +353,7 @@ describe("workspace-scoped chat session isolation", () => {
 
     clearUIActiveProfileCache();
     mockExists.mockReturnValue(false);
-    mockReaddir.mockReturnValue([] as unknown as Dirent[]);
+    mockReaddir.mockReturnValue([] as unknown as never[]);
 
     expect(resolveWebChatDir()).toBe(chatDir("default"));
   });

--- a/apps/web/lib/workspace-profiles.test.ts
+++ b/apps/web/lib/workspace-profiles.test.ts
@@ -215,7 +215,7 @@ describe("workspace (flat workspace model)", () => {
         await importWorkspace();
       mockReaddir.mockReturnValue([
         makeDirent("workspace-dev", true),
-      ] as unknown as Dirent[]);
+      ] as unknown as never[]);
       mockReadFile.mockReturnValue(
         JSON.stringify({ activeWorkspace: "dev" }) as never,
       );
@@ -232,7 +232,7 @@ describe("workspace (flat workspace model)", () => {
       mockReaddir.mockReturnValue([
         makeDirent("workspace-memory-ws", true),
         makeDirent("workspace-file-ws", true),
-      ] as unknown as Dirent[]);
+      ] as unknown as never[]);
       mockReadFile.mockReturnValue(
         JSON.stringify({ activeWorkspace: "file-ws" }) as never,
       );
@@ -250,7 +250,7 @@ describe("workspace (flat workspace model)", () => {
         makeDirent("workspace-beta", true),
         makeDirent("workspace-alpha", true),
         makeDirent("unrelated-dir", true),
-      ] as unknown as Dirent[]);
+      ] as unknown as never[]);
       // scanWorkspaceNames sorts alphabetically, so "alpha" comes first
       expect(getActiveWorkspaceName()).toBe("alpha");
     });
@@ -266,7 +266,7 @@ describe("workspace (flat workspace model)", () => {
       mockReaddir.mockReturnValue([
         makeDirent("workspace-envws", true),
         makeDirent("workspace-memory", true),
-      ] as unknown as Dirent[]);
+      ] as unknown as never[]);
       mockReadFile.mockReturnValue(
         JSON.stringify({ activeWorkspace: "persisted" }) as never,
       );
@@ -285,7 +285,7 @@ describe("workspace (flat workspace model)", () => {
       mockReaddir.mockReturnValue([
         makeDirent("workspace", true),
         makeDirent("workspace-memory", true),
-      ] as unknown as Dirent[]);
+      ] as unknown as never[]);
       mockReadFile.mockReturnValue(
         JSON.stringify({ activeWorkspace: "persisted" }) as never,
       );
@@ -336,7 +336,7 @@ describe("workspace (flat workspace model)", () => {
       mockReaddir.mockReturnValue([
         makeDirent("workspace-in-memory", true),
         makeDirent("workspace-from-file", true),
-      ] as unknown as Dirent[]);
+      ] as unknown as never[]);
 
       mockReadFile.mockReturnValue(
         JSON.stringify({ activeWorkspace: "from-file" }) as never,
@@ -358,7 +358,7 @@ describe("workspace (flat workspace model)", () => {
       mockReadFile.mockImplementation(() => {
         throw new Error("ENOENT");
       });
-      mockReaddir.mockReturnValue([] as unknown as Dirent[]);
+      mockReaddir.mockReturnValue([] as unknown as never[]);
       const workspaces = discoverWorkspaces();
       expect(workspaces).toHaveLength(0);
     });
@@ -374,7 +374,7 @@ describe("workspace (flat workspace model)", () => {
         makeDirent("workspace-beta", true),
         makeDirent("some-other-dir", true),
         makeDirent("config.json", false),
-      ] as unknown as Dirent[]);
+      ] as unknown as never[]);
       mockExists.mockImplementation((p) => {
         const s = String(p);
         return (
@@ -399,7 +399,7 @@ describe("workspace (flat workspace model)", () => {
       });
       mockReaddir.mockReturnValue([
         makeDirent("workspace", true),
-      ] as unknown as Dirent[]);
+      ] as unknown as never[]);
       mockExists.mockImplementation((p) => String(p) === join(STATE_DIR, "workspace"));
 
       const workspaces = discoverWorkspaces();
@@ -419,7 +419,7 @@ describe("workspace (flat workspace model)", () => {
         makeDirent("workspace", true),
         makeDirent("workspace-main", true),
         makeDirent("workspace-chat-slot-main-1", true),
-      ] as unknown as Dirent[]);
+      ] as unknown as never[]);
       mockExists.mockImplementation((p) => {
         const s = String(p);
         return (
@@ -442,7 +442,7 @@ describe("workspace (flat workspace model)", () => {
       mockReaddir.mockReturnValue([
         makeDirent("workspace", true),
         makeDirent("workspace-dench", true),
-      ] as unknown as Dirent[]);
+      ] as unknown as never[]);
       mockExists.mockImplementation((p) => {
         const s = String(p);
         return s === join(STATE_DIR, "workspace") || s === join(STATE_DIR, "workspace-dench");
@@ -469,7 +469,7 @@ describe("workspace (flat workspace model)", () => {
         makeDirent("workspace", true),
         makeDirent("workspace-dench", true),
         makeDirent("workspace-kumareth", true),
-      ] as unknown as Dirent[]);
+      ] as unknown as never[]);
       mockExists.mockImplementation((p) => {
         const s = String(p);
         return (
@@ -496,7 +496,7 @@ describe("workspace (flat workspace model)", () => {
       mockReaddir.mockReturnValue([
         makeDirent("workspace-beta", true),
         makeDirent("workspace-alpha", true),
-      ] as unknown as Dirent[]);
+      ] as unknown as never[]);
       mockExists.mockImplementation((p) => {
         const s = String(p);
         return (
@@ -524,7 +524,7 @@ describe("workspace (flat workspace model)", () => {
       mockReaddir.mockReturnValue([
         makeDirent("workspace-alpha", true),
         makeDirent("workspace-beta", true),
-      ] as unknown as Dirent[]);
+      ] as unknown as never[]);
       mockExists.mockImplementation((p) => {
         const s = String(p);
         return (
@@ -556,7 +556,7 @@ describe("workspace (flat workspace model)", () => {
       } = await importWorkspace();
       mockReaddir.mockReturnValue([
         makeDirent("workspace-dev", true),
-      ] as unknown as Dirent[]);
+      ] as unknown as never[]);
       mockReadFile.mockReturnValue(JSON.stringify({}) as never);
       setUIActiveWorkspace("dev");
       const wsDir = join(STATE_DIR, "workspace-dev");
@@ -576,7 +576,7 @@ describe("workspace (flat workspace model)", () => {
       mockReaddir.mockReturnValue([
         makeDirent("workspace-work", true),
         makeDirent("workspace-personal", true),
-      ] as unknown as Dirent[]);
+      ] as unknown as never[]);
       mockReadFile.mockReturnValue(JSON.stringify({}) as never);
 
       setUIActiveWorkspace("work");
@@ -601,7 +601,7 @@ describe("workspace (flat workspace model)", () => {
       mockReadFile.mockImplementation(() => {
         throw new Error("ENOENT");
       });
-      mockReaddir.mockReturnValue([] as unknown as Dirent[]);
+      mockReaddir.mockReturnValue([] as unknown as never[]);
       expect(resolveWebChatDir()).toBe(
         join(STATE_DIR, "workspace", ".openclaw", "web-chat"),
       );
@@ -621,7 +621,7 @@ describe("workspace (flat workspace model)", () => {
       } = await importWorkspace();
       mockReaddir.mockReturnValue([
         makeDirent("workspace-dev", true),
-      ] as unknown as Dirent[]);
+      ] as unknown as never[]);
       mockReadFile.mockReturnValue(JSON.stringify({}) as never);
       setUIActiveWorkspace("dev");
       const wsDir = join(STATE_DIR, "workspace-dev");
@@ -631,7 +631,7 @@ describe("workspace (flat workspace model)", () => {
 
     it("returns null when no workspace dirs exist", async () => {
       const { resolveWorkspaceRoot, mockReadFile, mockReaddir } = await importWorkspace();
-      mockReaddir.mockReturnValue([] as unknown as Dirent[]);
+      mockReaddir.mockReturnValue([] as unknown as never[]);
       mockReadFile.mockImplementation(() => {
         throw new Error("ENOENT");
       });

--- a/apps/web/lib/workspace.test.ts
+++ b/apps/web/lib/workspace.test.ts
@@ -144,9 +144,9 @@ describe("workspace utilities", () => {
       const { resolveWorkspaceRoot, mockExists, mockReaddir } = await importWorkspace();
       mockReaddir.mockImplementation((dir, _opts) => {
         if (String(dir) === STATE_DIR) {
-          return [makeDirent("workspace-test", true)] as unknown as Dirent[];
+          return [makeDirent("workspace-test", true)] as unknown as never[];
         }
-        return [] as unknown as Dirent[];
+        return [] as unknown as never[];
       });
       mockExists.mockImplementation((p) => String(p) === WS_DIR);
       expect(resolveWorkspaceRoot()).toBe(WS_DIR);
@@ -168,9 +168,9 @@ describe("workspace utilities", () => {
           return [
             makeDirent("workspace-fromenv", true),
             makeDirent("workspace-other", true),
-          ] as unknown as Dirent[];
+          ] as unknown as never[];
         }
-        return [] as unknown as Dirent[];
+        return [] as unknown as never[];
       });
       mockExists.mockReturnValue(true);
       expect(resolveWorkspaceRoot()).toBe(envWs);
@@ -182,9 +182,9 @@ describe("workspace utilities", () => {
       const fallbackWs = join(STATE_DIR, "workspace-fallback");
       mockReaddir.mockImplementation((dir, _opts) => {
         if (String(dir) === STATE_DIR) {
-          return [makeDirent("workspace-fallback", true)] as unknown as Dirent[];
+          return [makeDirent("workspace-fallback", true)] as unknown as never[];
         }
-        return [] as unknown as Dirent[];
+        return [] as unknown as never[];
       });
       mockExists.mockImplementation((p) => String(p) === fallbackWs);
       expect(resolveWorkspaceRoot()).toBe(fallbackWs);
@@ -196,9 +196,9 @@ describe("workspace utilities", () => {
       const rootWorkspace = join(STATE_DIR, "workspace");
       mockReaddir.mockImplementation((dir, _opts) => {
         if (String(dir) === STATE_DIR) {
-          return [makeDirent("workspace", true)] as unknown as Dirent[];
+          return [makeDirent("workspace", true)] as unknown as never[];
         }
-        return [] as unknown as Dirent[];
+        return [] as unknown as never[];
       });
       mockExists.mockImplementation((p) => String(p) === rootWorkspace);
       expect(resolveWorkspaceRoot()).toBe(rootWorkspace);
@@ -214,7 +214,7 @@ describe("workspace utilities", () => {
       mockReadFile.mockImplementation(() => {
         throw new Error("ENOENT");
       });
-      mockReaddir.mockReturnValue([] as unknown as Dirent[]);
+      mockReaddir.mockReturnValue([] as unknown as never[]);
       expect(resolveWebChatDir()).toBe(
         join(STATE_DIR, "workspace", ".openclaw", "web-chat"),
       );
@@ -291,9 +291,9 @@ describe("workspace utilities", () => {
       });
       mockReaddir.mockImplementation((dir) => {
         if (String(dir) === "/ws") {
-          return [makeDirent("sub", true)] as unknown as Dirent[];
+          return [makeDirent("sub", true)] as unknown as never[];
         }
-        return [] as unknown as Dirent[];
+        return [] as unknown as never[];
       });
       const result = discoverDuckDBPaths("/ws");
       expect(result).toEqual([
@@ -309,9 +309,9 @@ describe("workspace utilities", () => {
       );
       mockReaddir.mockImplementation((dir) => {
         if (String(dir) === "/ws") {
-          return [makeDirent(".hidden", true)] as unknown as Dirent[];
+          return [makeDirent(".hidden", true)] as unknown as never[];
         }
-        return [] as unknown as Dirent[];
+        return [] as unknown as never[];
       });
       expect(discoverDuckDBPaths("/ws")).toEqual([]);
     });
@@ -325,9 +325,9 @@ describe("workspace utilities", () => {
             makeDirent("tmp", true),
             makeDirent("exports", true),
             makeDirent("node_modules", true),
-          ] as unknown as Dirent[];
+          ] as unknown as never[];
         }
-        return [] as unknown as Dirent[];
+        return [] as unknown as never[];
       });
       expect(discoverDuckDBPaths("/ws")).toEqual([]);
     });
@@ -346,9 +346,9 @@ describe("workspace utilities", () => {
       mockExists.mockReturnValue(false);
       mockReaddir.mockImplementation((dir) => {
         if (String(dir) === "/ws") {
-          return [makeDirent("somefile.txt", false)] as unknown as Dirent[];
+          return [makeDirent("somefile.txt", false)] as unknown as never[];
         }
-        return [] as unknown as Dirent[];
+        return [] as unknown as never[];
       });
       expect(discoverDuckDBPaths("/ws")).toEqual([]);
     });
@@ -379,9 +379,9 @@ describe("workspace utilities", () => {
       });
       mockReaddir.mockImplementation((dir) => {
         if (String(dir) === WS_DIR) {
-          return [makeDirent("sub", true)] as unknown as Dirent[];
+          return [makeDirent("sub", true)] as unknown as never[];
         }
-        return [] as unknown as Dirent[];
+        return [] as unknown as never[];
       });
       expect(duckdbPath()).toBe(nestedDb);
     });
@@ -595,9 +595,9 @@ describe("workspace utilities", () => {
       });
       mockReaddir.mockImplementation((dir) => {
         if (String(dir) === WS_DIR) {
-          return [makeDirent("sub", true)] as unknown as Dirent[];
+          return [makeDirent("sub", true)] as unknown as never[];
         }
-        return [] as unknown as Dirent[];
+        return [] as unknown as never[];
       });
       let callCount = 0;
       mockExecFileSync.mockImplementation(() => {
@@ -620,8 +620,8 @@ describe("workspace utilities", () => {
         return s === WS_DIR || s === rootDb || s === subDb || s === bin;
       });
       mockReaddir.mockImplementation((dir) => {
-        if (String(dir) === WS_DIR) {return [makeDirent("sub", true)] as unknown as Dirent[];}
-        return [] as unknown as Dirent[];
+        if (String(dir) === WS_DIR) {return [makeDirent("sub", true)] as unknown as never[];}
+        return [] as unknown as never[];
       });
       let callCount = 0;
       mockExecFileSync.mockImplementation(() => {
@@ -651,8 +651,8 @@ describe("workspace utilities", () => {
         return s === WS_DIR || s === rootDb || s === subDb || s === bin;
       });
       mockReaddir.mockImplementation((dir) => {
-        if (String(dir) === WS_DIR) {return [makeDirent("sub", true)] as unknown as Dirent[];}
-        return [] as unknown as Dirent[];
+        if (String(dir) === WS_DIR) {return [makeDirent("sub", true)] as unknown as never[];}
+        return [] as unknown as never[];
       });
       let callCount = 0;
       mockExecFileSync.mockImplementation(() => {


### PR DESCRIPTION
## Problem

Adding a filter or search to one table and then switching tables carried that filter/search to the next table — you had to manually clear it. There was also no memory: coming back to a table you'd been working in dropped your filter on the floor.

## Root cause

View state (`search`, `filters`, `sort`, `view`, `viewType`, `cols`, `page`, `pageSize`) lived in a single global URL slot. The shell's URL effect explicitly **preserved** these "object-view params" across path changes (so a table switch reused them on the new table), and `ObjectView` initialized from URL on every fresh mount. There was no per-table identity in the persistence model.

## Fix

View state is now scoped per-table and persisted in localStorage, keyed by object name. The shell stops carrying view-state across path changes; the URL becomes navigation-only.

- New `apps/web/lib/table-view-state.ts` with `loadTableViewState(name)` / `saveTableViewState(name, state)`.
- `ObjectView` reads its initial state from localStorage on mount; if localStorage has nothing for that table it falls back to URL once (so `?path=A&search=foo` deep links still work the first time).
- The URL-sync effect was replaced with a localStorage-sync effect that also strips stale view-state params from the URL after first interaction.
- Shell-level URL preservation (`workspace-content.tsx` ~L1727) no longer carries `viewType / view / filters / search / sort / page / pageSize / cols` across tab/path changes.

## Verification

Manually verified via headless browser at `localhost:3100`:

1. Set `Search Companies...` to `TABLE_FILTER_X` → localStorage gets `{"company":{"search":"TABLE_FILTER_X"}}`, URL stays `?path=company` (no stale param).
2. Switch to people → People search input is empty (no carry-over).
3. Set people search to `PEOPLE_X` → localStorage gets independent `{"company":{...},"people":{"search":"PEOPLE_X"}}`.
4. Switch back to companies → Filter restored to `TABLE_FILTER_X`.

Both requirements satisfied: scoped per-table, persisted across visits.

## Pre-existing TS cleanup (one-time)

Fixes ~58 pre-existing `tsc --noEmit` errors:
- 50× `Dirent<string>[]` vs `Dirent<NonSharedBuffer>[]` in test mocks (Node `readdir` typing change) — replaced `as unknown as Dirent[]` casts with `as unknown as never[]`.
- `vi.mocked(...).mock` access in `web-sessions.test.ts`.
- Discriminated-union literal mismatches in `chat-message.test.tsx` and composio route tests.

`tsc --noEmit` is now clean. All 190 URL/tabs/links tests still pass.

## Trade-off

We lose `?path=A&search=foo` style **shareable** URLs — filters are now a personal per-device preference, not a piece of shared state. This matches user mental model ("this is how _I_ look at this table", not "this is what the URL describes to others"). Deep links continue to work for first-time loads.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how object-table view state is persisted (URL → per-table localStorage) and actively strips view params from the URL, which can affect deep links and navigation behavior. Also includes broad TypeScript test-typing adjustments but with low functional impact.
> 
> **Overview**
> **Scopes object/table view state per table and persists it across visits.** Table search/filters/sort/view/columns/pagination are now loaded/saved via a new `lib/table-view-state.ts` localStorage bag keyed by object name, so switching tables no longer carries one table’s view state into another.
> 
> **Shifts the URL to navigation-only.** `workspace-content.tsx` stops preserving object-view query params across tab/path changes, and the object-view effect now strips `TABLE_VIEW_URL_KEYS` from the URL after interaction to prevent stale params from becoming a source of truth.
> 
> Includes a small TS cleanup pass across tests (mock typing/casts and a couple of union literal tweaks) to satisfy stricter type checking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37275bac06c82521c18c9423f28ded4cbaf8ff52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->