### PR TITLE
fix(workspace): replace relation pills with elegant favicon+link rows

### DIFF
--- a/apps/web/app/api/workspace/objects/[name]/entries/[id]/route.ts
+++ b/apps/web/app/api/workspace/objects/[name]/entries/[id]/route.ts
@@ -5,6 +5,7 @@ import {
 	discoverDuckDBPaths,
 	parseRelationValue,
 } from "@/lib/workspace";
+import { buildGoogleFaviconUrl } from "@/lib/workspace-cell-format";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -177,8 +178,13 @@ export async function GET(
 			: undefined,
 	}));
 
-	// Resolve relation labels for this entry
+	// Resolve relation labels (and favicons) for this entry. Favicons mirror
+	// `relationLabels` shape: relationFaviconUrls[fieldName][entryId] = url.
+	// Sparse — only populated when the related entry has a URL field with a
+	// usable host. Lets the detail panel/modal render related entries with
+	// the same elegant icon+name link UI as the table cell.
 	const relationLabels: Record<string, Record<string, string>> = {};
+	const relationFaviconUrls: Record<string, Record<string, string>> = {};
 	const relatedObjectNames: Record<string, string> = {};
 
 	const relationFields = fields.filter(
@@ -198,6 +204,7 @@ export async function GET(
 		const val = entry[rf.name];
 		if (val == null || val === "") {
 			relationLabels[rf.name] = {};
+			relationFaviconUrls[rf.name] = {};
 			continue;
 		}
 
@@ -212,6 +219,7 @@ export async function GET(
 		const ids = parseRelationValue(valStr);
 		if (ids.length === 0) {
 			relationLabels[rf.name] = {};
+			relationFaviconUrls[rf.name] = {};
 			continue;
 		}
 
@@ -243,6 +251,27 @@ export async function GET(
 			}
 		}
 		relationLabels[rf.name] = labelMap;
+
+		const urlRows = q<{ entry_id: string; value: string }>(dbFile,
+			`SELECT e.id as entry_id, ef.value
+       FROM entries e
+       JOIN entry_fields ef ON ef.entry_id = e.id
+       JOIN fields f ON f.id = ef.field_id
+       WHERE e.id IN (${idList})
+       AND f.object_id = '${sqlEscape(relObj.id)}'
+       AND f.type = 'url'
+       ORDER BY f.sort_order`,
+		);
+		const faviconMap: Record<string, string> = {};
+		for (const row of urlRows) {
+			if (faviconMap[row.entry_id]) {continue;}
+			const v = (row.value ?? "").trim();
+			if (!v) {continue;}
+			const href = /^https?:\/\//i.test(v) ? v : `https://${v}`;
+			const fav = buildGoogleFaviconUrl(href);
+			if (fav) {faviconMap[row.entry_id] = fav;}
+		}
+		relationFaviconUrls[rf.name] = faviconMap;
 	}
 
 	// Enrich fields with related object names
@@ -264,6 +293,7 @@ export async function GET(
 		fields: enrichedFields,
 		entry,
 		relationLabels,
+		relationFaviconUrls,
 		reverseRelations,
 		effectiveDisplayField,
 	});

--- a/apps/web/app/api/workspace/objects/[name]/route.ts
+++ b/apps/web/app/api/workspace/objects/[name]/route.ts
@@ -11,6 +11,7 @@ import {
   readObjectYamlIcon,
 } from "@/lib/workspace";
 import { deserializeFilters, buildWhereClause, buildOrderByClause, type FieldMeta } from "@/lib/object-filters";
+import { buildGoogleFaviconUrl } from "@/lib/workspace-cell-format";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -182,9 +183,17 @@ async function resolveRelationLabels(
   entries: Record<string, unknown>[],
 ): Promise<{
   labels: Record<string, Record<string, string>>;
+  faviconUrls: Record<string, Record<string, string>>;
   relatedObjectNames: Record<string, string>;
 }> {
   const labels: Record<string, Record<string, string>> = {};
+  // Mirror of `labels`, but mapping entry_id -> favicon URL when the related
+  // entry has a URL field with a usable host. Lets the client render relation
+  // cells as elegant icon+name links (instead of opaque pills) without an
+  // extra round-trip per related entry. Sparse — entries without a URL field
+  // simply have no entry here, and the client falls back to a letter
+  // monogram.
+  const faviconUrls: Record<string, Record<string, string>> = {};
   const relatedObjectNames: Record<string, string> = {};
 
   const relationFields = fields.filter(
@@ -225,6 +234,7 @@ async function resolveRelationLabels(
 
     if (entryIds.size === 0) {
       labels[rf.name] = {};
+      faviconUrls[rf.name] = {};
       continue;
     }
 
@@ -250,9 +260,35 @@ async function resolveRelationLabels(
     }
 
     labels[rf.name] = labelMap;
+
+    // Pull URL-typed field values for the same set of related entries and
+    // pick the first usable one per entry, mirroring the client-side
+    // `computeEntryFaviconUrl` heuristic. Prefer fields in declared
+    // sort_order so the "primary" URL (typically domain/website) wins over
+    // a secondary one (e.g. linkedin).
+    const urlRows = await q<{ entry_id: string; value: string; sort_order: number }>(dbFile,
+      `SELECT e.id as entry_id, ef.value, COALESCE(f.sort_order, 999999) as sort_order
+       FROM entries e
+       JOIN entry_fields ef ON ef.entry_id = e.id
+       JOIN fields f ON f.id = ef.field_id
+       WHERE e.id IN (${idList})
+       AND f.object_id = '${sqlEscape(relObj.id)}'
+       AND f.type = 'url'
+       ORDER BY f.sort_order`,
+    );
+    const faviconMap: Record<string, string> = {};
+    for (const row of urlRows) {
+      if (faviconMap[row.entry_id]) {continue;}
+      const v = (row.value ?? "").trim();
+      if (!v) {continue;}
+      const href = /^https?:\/\//i.test(v) ? v : `https://${v}`;
+      const fav = buildGoogleFaviconUrl(href);
+      if (fav) {faviconMap[row.entry_id] = fav;}
+    }
+    faviconUrls[rf.name] = faviconMap;
   }
 
-  return { labels, relatedObjectNames };
+  return { labels, faviconUrls, relatedObjectNames };
 }
 
 type ReverseRelation = {
@@ -533,7 +569,7 @@ export async function GET(
     enum_colors: f.enum_colors ? tryParseJson(f.enum_colors) : undefined,
   }));
 
-  const { labels: relationLabels, relatedObjectNames } =
+  const { labels: relationLabels, faviconUrls: relationFaviconUrls, relatedObjectNames } =
     await resolveRelationLabels(dbFile, fields, entries);
 
   const enrichedFields = parsedFields.map((f) => ({
@@ -560,6 +596,7 @@ export async function GET(
     statuses,
     entries,
     relationLabels,
+    relationFaviconUrls,
     reverseRelations,
     effectiveDisplayField,
     savedViews,

--- a/apps/web/app/components/workspace/entry-detail-modal.tsx
+++ b/apps/web/app/components/workspace/entry-detail-modal.tsx
@@ -8,6 +8,7 @@ import { parseTagsValue } from "@/lib/parse-tags";
 import { displayObjectName, displayObjectNameSingular } from "@/lib/object-display-name";
 import { UrlFavicon } from "./url-favicon";
 import { LinkOpenButton } from "./link-open-button";
+import { RelationLink } from "./relation-link";
 
 
 function safeString(val: unknown): string {
@@ -54,6 +55,10 @@ type EntryDetailData = {
   fields: Field[];
   entry: Record<string, unknown>;
   relationLabels?: Record<string, Record<string, string>>;
+  /** Per-relation-field map of related-entry-id -> favicon URL (sparse).
+   * Same shape as `relationLabels`. Powers the elegant icon+name link UI in
+   * `RelationLink`; missing entries fall back to a letter monogram. */
+  relationFaviconUrls?: Record<string, Record<string, string>>;
   reverseRelations?: ReverseRelation[];
   effectiveDisplayField?: string;
 };
@@ -179,11 +184,13 @@ function RelationChips({
   value,
   field,
   relationLabels,
+  relationFaviconUrls,
   onNavigateEntry,
 }: {
   value: unknown;
   field: Field;
   relationLabels?: Record<string, Record<string, string>>;
+  relationFaviconUrls?: Record<string, Record<string, string>>;
   onNavigateEntry?: (
     objectName: string,
     entryId: string,
@@ -191,15 +198,16 @@ function RelationChips({
   ) => void;
 }) {
   const fieldLabels = relationLabels?.[field.name];
+  const fieldFaviconUrls = relationFaviconUrls?.[field.name];
   const ids = value == null ? [] : parseRelationValue(String(value));
   if (ids.length === 0) {return <EmptyValue />;}
 
   return (
-    <span className="flex items-center gap-1.5 flex-wrap">
+    <span className="flex items-center gap-x-3 gap-y-1.5 flex-wrap">
       {ids.map((id) => {
         const label = fieldLabels?.[id] ?? id;
         const handleClick = field.related_object_name && onNavigateEntry
-          ? (e: React.MouseEvent<HTMLButtonElement>) => {
+          ? (e: React.MouseEvent) => {
             e.stopPropagation();
             onNavigateEntry(
               field.related_object_name!,
@@ -209,23 +217,13 @@ function RelationChips({
           }
           : undefined;
         return (
-          <button
-            type="button"
+          <RelationLink
             key={id}
+            label={label}
+            faviconUrl={fieldFaviconUrls?.[id]}
             onClick={handleClick}
-            className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium ${handleClick ? "cursor-pointer hover:opacity-80" : ""}`}
-            style={{
-              background: "rgba(96, 165, 250, 0.1)",
-              color: "#60a5fa",
-              border: "1px solid rgba(96, 165, 250, 0.2)",
-            }}
-            title={handleClick ? `Open ${label}` : label}
-          >
-            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="flex-shrink-0" style={{ opacity: 0.5 }}>
-              <path d="M7 7h10v10" /><path d="M7 17 17 7" />
-            </svg>
-            <span className="truncate max-w-[200px]">{label}</span>
-          </button>
+            maxLabelWidth={220}
+          />
         );
       })}
     </span>
@@ -421,12 +419,14 @@ function FieldValue({
   field,
   members,
   relationLabels,
+  relationFaviconUrls,
   onNavigateEntry,
 }: {
   value: unknown;
   field: Field;
   members?: Array<{ id: string; name: string }>;
   relationLabels?: Record<string, Record<string, string>>;
+  relationFaviconUrls?: Record<string, Record<string, string>>;
   onNavigateEntry?: (
     objectName: string,
     entryId: string,
@@ -456,6 +456,7 @@ function FieldValue({
           value={value}
           field={field}
           relationLabels={relationLabels}
+          relationFaviconUrls={relationFaviconUrls}
           onNavigateEntry={onNavigateEntry}
         />
       );
@@ -798,6 +799,7 @@ export function EntryDetailModal({
                             field={field}
                             members={members}
                             relationLabels={data.relationLabels}
+                            relationFaviconUrls={data.relationFaviconUrls}
                             onNavigateEntry={onNavigateEntry}
                           />
                         </div>

--- a/apps/web/app/components/workspace/entry-detail-panel.tsx
+++ b/apps/web/app/components/workspace/entry-detail-panel.tsx
@@ -13,6 +13,7 @@ import { ConfirmDialog } from "./confirm-dialog";
 import { useToast } from "./toast";
 import { UrlFavicon } from "./url-favicon";
 import { LinkOpenButton } from "./link-open-button";
+import { RelationLink } from "./relation-link";
 import { LinkPreviewWrapper } from "./workspace-link";
 
 function safeString(val: unknown): string {
@@ -53,6 +54,10 @@ type EntryDetailData = {
   fields: Field[];
   entry: Record<string, unknown>;
   relationLabels?: Record<string, Record<string, string>>;
+  /** Per-relation-field map of related-entry-id -> favicon URL (sparse).
+   * Lets us render relation values as elegant icon+name links instead of
+   * pills. Same shape as `relationLabels`. */
+  relationFaviconUrls?: Record<string, Record<string, string>>;
   reverseRelations?: ReverseRelation[];
   effectiveDisplayField?: string;
 };
@@ -168,10 +173,11 @@ function UserBadge({ value, members }: { value: unknown; members?: Array<{ id: s
 }
 
 function RelationChips({
-  value, field, relationLabels, onNavigateEntry,
+  value, field, relationLabels, relationFaviconUrls, onNavigateEntry,
 }: {
   value: unknown; field: Field;
   relationLabels?: Record<string, Record<string, string>>;
+  relationFaviconUrls?: Record<string, Record<string, string>>;
   onNavigateEntry?: (
     objectName: string,
     entryId: string,
@@ -179,14 +185,15 @@ function RelationChips({
   ) => void;
 }) {
   const fieldLabels = relationLabels?.[field.name];
+  const fieldFaviconUrls = relationFaviconUrls?.[field.name];
   const ids = value == null ? [] : parseRelationValue(String(value));
   if (ids.length === 0) return <EmptyValue />;
   return (
-    <span className="flex items-center gap-1 flex-wrap">
+    <span className="flex items-center gap-x-3 gap-y-1 flex-wrap">
       {ids.map((id) => {
         const label = fieldLabels?.[id] ?? id;
         const handleClick = field.related_object_name && onNavigateEntry
-          ? (e: React.MouseEvent<HTMLButtonElement>) => {
+          ? (e: React.MouseEvent) => {
               e.stopPropagation();
               onNavigateEntry(
                 field.related_object_name!,
@@ -196,14 +203,13 @@ function RelationChips({
             }
           : undefined;
         return (
-          <button type="button" key={id} onClick={handleClick}
-            className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-medium ${handleClick ? "cursor-pointer hover:opacity-80" : ""}`}
-            style={{ background: "rgba(96, 165, 250, 0.1)", color: "#60a5fa", border: "1px solid rgba(96, 165, 250, 0.2)" }}
-            title={handleClick ? `Open ${label}` : label}
-          >
-            <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: 0.5 }}><path d="M7 7h10v10" /><path d="M7 17 17 7" /></svg>
-            <span className="truncate max-w-[180px]">{label}</span>
-          </button>
+          <RelationLink
+            key={id}
+            label={label}
+            faviconUrl={fieldFaviconUrls?.[id]}
+            onClick={handleClick}
+            maxLabelWidth={220}
+          />
         );
       })}
     </span>
@@ -302,11 +308,12 @@ function EmptyValue() {
 }
 
 function FieldValue({
-  value, field, members, relationLabels, onNavigateEntry,
+  value, field, members, relationLabels, relationFaviconUrls, onNavigateEntry,
 }: {
   value: unknown; field: Field;
   members?: Array<{ id: string; name: string }>;
   relationLabels?: Record<string, Record<string, string>>;
+  relationFaviconUrls?: Record<string, Record<string, string>>;
   onNavigateEntry?: (
     objectName: string,
     entryId: string,
@@ -321,7 +328,7 @@ function FieldValue({
       return <span style={{ color: isTrue ? "#22c55e" : "var(--color-text-muted)" }}>{isTrue ? "Yes" : "No"}</span>;
     }
     case "user": return <UserBadge value={value} members={members} />;
-    case "relation": return <RelationChips value={value} field={field} relationLabels={relationLabels} onNavigateEntry={onNavigateEntry} />;
+    case "relation": return <RelationChips value={value} field={field} relationLabels={relationLabels} relationFaviconUrls={relationFaviconUrls} onNavigateEntry={onNavigateEntry} />;
     case "tags": return <TagsBadges value={value} />;
     default: return <FormattedFieldValue value={value} fieldType={field.type} mode="detail" showUrlFavicon linkInteractionMode="button" />;
   }
@@ -721,7 +728,7 @@ export function EntryDetailPanel({
                               }}
                               title={!["user"].includes(field.type) ? "Click to edit" : undefined}
                             >
-                              <FieldValue value={value} field={field} members={members} relationLabels={data.relationLabels} onNavigateEntry={onNavigateEntry} />
+                              <FieldValue value={value} field={field} members={members} relationLabels={data.relationLabels} relationFaviconUrls={data.relationFaviconUrls} onNavigateEntry={onNavigateEntry} />
                             </div>
                           )}
                         </div>

--- a/apps/web/app/components/workspace/object-table.tsx
+++ b/apps/web/app/components/workspace/object-table.tsx
@@ -17,6 +17,7 @@ import { parseEnrichmentMeta } from "@/lib/enrichment-columns";
 import { UrlFavicon } from "./url-favicon";
 import { LinkOpenButton } from "./link-open-button";
 import { LinkPreviewWrapper } from "./workspace-link";
+import { RelationLink } from "./relation-link";
 
 /* ─── Types ─── */
 
@@ -56,6 +57,12 @@ type ObjectTableProps = {
 	entries: Record<string, unknown>[];
 	members?: Array<{ id: string; name: string }>;
 	relationLabels?: Record<string, Record<string, string>>;
+	/** Favicon URL per related entry, keyed by relation field name then entry
+	 * id (mirrors `relationLabels` shape). Sparse — only set when the related
+	 * entry has a URL field with a usable host. Used by `RelationCell` to
+	 * render the elegant icon+name link UI; missing entries fall back to a
+	 * letter monogram. */
+	relationFaviconUrls?: Record<string, Record<string, string>>;
 	reverseRelations?: ReverseRelation[];
 	onNavigateToObject?: (objectName: string) => void;
 	/**
@@ -219,11 +226,14 @@ function UserCell({ value, members }: { value: unknown; members?: Array<{ id: st
 }
 
 function RelationCell({
-	value, field, fieldLabels, onNavigateObject, onNavigateEntry,
+	value, field, fieldLabels, fieldFaviconUrls, onNavigateObject, onNavigateEntry,
 }: {
 	value: unknown; field: Field;
 	/** Labels for THIS field only (already narrowed). */
 	fieldLabels?: Record<string, string>;
+	/** Favicon URLs for THIS field only (already narrowed). Sparse — fall
+	 * back to a letter monogram in the icon when an entry has no URL. */
+	fieldFaviconUrls?: Record<string, string>;
 	onNavigateObject?: (objectName: string) => void;
 	onNavigateEntry?: (
 		objectName: string,
@@ -233,31 +243,36 @@ function RelationCell({
 }) {
 	const ids = value == null ? [] : parseRelationValue(String(value));
 	if (ids.length === 0) {return <span style={{ color: "var(--color-text-muted)", opacity: 0.5 }}>--</span>;}
+	const canNavigate =
+		!!field.related_object_name && !!(onNavigateEntry || onNavigateObject);
 	return (
-		<span className="flex items-center gap-1 flex-wrap">
-			{ids.map((id) => (
-				<span
-					key={id}
-					onClick={(e) => {
-						if (!field.related_object_name) {return;}
-						if (!onNavigateEntry && !onNavigateObject) {return;}
-						e.stopPropagation();
-						if (onNavigateEntry) {
-							onNavigateEntry(
-								field.related_object_name,
-								id,
-								field.related_object_id,
-							);
-							return;
+		<span className="flex items-center gap-x-3 gap-y-1 flex-wrap">
+			{ids.map((id) => {
+				const label = fieldLabels?.[id] ?? id;
+				const handleClick = canNavigate
+					? (e: React.MouseEvent) => {
+							e.stopPropagation();
+							if (onNavigateEntry) {
+								onNavigateEntry(
+									field.related_object_name!,
+									id,
+									field.related_object_id,
+								);
+								return;
+							}
+							onNavigateObject?.(field.related_object_name!);
 						}
-						onNavigateObject?.(field.related_object_name);
-					}}
-					className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-medium ${field.related_object_name && (onNavigateEntry || onNavigateObject) ? "cursor-pointer" : ""}`}
-					style={{ background: "var(--color-chip-document)", color: "var(--color-chip-document-text)", border: "1px solid var(--color-border)" }}
-				>
-					<span className="truncate max-w-[180px]">{fieldLabels?.[id] ?? id}</span>
-				</span>
-			))}
+					: undefined;
+				return (
+					<RelationLink
+						key={id}
+						label={label}
+						faviconUrl={fieldFaviconUrls?.[id]}
+						onClick={handleClick}
+						maxLabelWidth={180}
+					/>
+				);
+			})}
 		</span>
 	);
 }
@@ -437,6 +452,9 @@ type EditableCellProps = {
 	 * parent's full relationLabels map so non-relation cells don't bust their
 	 * memo when the unrelated parts of the map change. */
 	fieldRelationLabels?: Record<string, string>;
+	/** Favicon URLs for THIS field only — same shape/narrowing as
+	 * `fieldRelationLabels`. Pre-narrowed for the same memo reason. */
+	fieldRelationFaviconUrls?: Record<string, string>;
 	onNavigateObject?: (objectName: string) => void;
 	onNavigateEntry?: (
 		objectName: string,
@@ -459,6 +477,7 @@ function EditableCellInner({
 	field,
 	members,
 	fieldRelationLabels,
+	fieldRelationFaviconUrls,
 	onNavigateObject,
 	onNavigateEntry,
 	onLocalValueChange,
@@ -633,6 +652,7 @@ function EditableCellInner({
 					value={initialValue}
 					field={field}
 					fieldLabels={fieldRelationLabels}
+					fieldFaviconUrls={fieldRelationFaviconUrls}
 					onNavigateObject={onNavigateObject}
 					onNavigateEntry={onNavigateEntry}
 				/>
@@ -738,6 +758,7 @@ export function ObjectTable({
 	entries,
 	members,
 	relationLabels,
+	relationFaviconUrls,
 	reverseRelations,
 	onNavigateToObject,
 	onNavigateToEntry,
@@ -1023,6 +1044,9 @@ export function ObjectTable({
 			const fieldRelationLabels = field.type === "relation"
 				? relationLabels?.[field.name]
 				: undefined;
+			const fieldRelationFaviconUrls = field.type === "relation"
+				? relationFaviconUrls?.[field.name]
+				: undefined;
 			return {
 				id: field.id,
 				accessorKey: field.name,
@@ -1102,6 +1126,7 @@ export function ObjectTable({
 							field={field}
 							members={members}
 							fieldRelationLabels={fieldRelationLabels}
+							fieldRelationFaviconUrls={fieldRelationFaviconUrls}
 							onNavigateObject={onNavigateToObject}
 							onNavigateEntry={onNavigateToEntry}
 							onLocalValueChange={updateLocalEntryField}
@@ -1236,7 +1261,7 @@ export function ObjectTable({
 		// `onEntryClick` and `updateLocalEntryField` are read inside the `cell`
 		// closures and were missing from the original deps (stale-closure bug);
 		// they're included now.
-	}, [dataFields, actionFields, activeReverseRelations, objectName, members, relationLabels, onNavigateToObject, onNavigateToEntry, onEntryClick, onRefresh, updateLocalEntryField, showToast, renamingFieldId, handleRenameColumn, handleDeleteColumn, handleMoveColumn, enrichmentProgress, handleReEnrich, enrichedCellIds, openMenuFieldId]);
+	}, [dataFields, actionFields, activeReverseRelations, objectName, members, relationLabels, relationFaviconUrls, onNavigateToObject, onNavigateToEntry, onEntryClick, onRefresh, updateLocalEntryField, showToast, renamingFieldId, handleRenameColumn, handleDeleteColumn, handleMoveColumn, enrichmentProgress, handleReEnrich, enrichedCellIds, openMenuFieldId]);
 
 	// Add entry handler — delegates to parent when provided, otherwise opens local modal.
 	const handleAdd = useCallback(() => {

--- a/apps/web/app/components/workspace/relation-link.tsx
+++ b/apps/web/app/components/workspace/relation-link.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Elegant icon + name link for a related entry. Replaces the legacy
+ * "blue-pill" relation chip across the workspace (table cells, detail panel,
+ * detail modal) so every relation reference looks the same and reads as a
+ * proper link.
+ *
+ * Why a single component: previously each surface had its own ad-hoc pill
+ * markup (different padding, colors, hover, click handling). Visually they
+ * were "almost the same" in different places, and they all hid the fact
+ * that relations are *navigation* — clicking should open the related
+ * entry. Centralizing it here makes the affordance honest (cursor pointer,
+ * underline-on-hover, accent text) and removes the pill background that
+ * made small companies hard to read.
+ *
+ * Icon resolution:
+ *   1. If `faviconUrl` is provided AND loads, show it (server pre-computes
+ *      this from the related entry's first URL field — see
+ *      `resolveRelationLabels`).
+ *   2. On image error / missing URL, fall back to a single-letter monogram
+ *      derived from `label`. This keeps the layout stable and avoids a
+ *      second network round-trip for unfaviconable entries (people,
+ *      internal records, etc).
+ *
+ * The component itself renders one item; callers wrap multiple in a
+ * flex/wrap container.
+ */
+export function RelationLink({
+	label,
+	faviconUrl,
+	onClick,
+	maxLabelWidth = 200,
+}: {
+	label: string;
+	faviconUrl?: string;
+	onClick?: (e: React.MouseEvent) => void;
+	/** Pixel cap on the label before truncation. Cells use a smaller cap so
+	 * cell-level horizontal overflow doesn't blow out the column. */
+	maxLabelWidth?: number;
+}) {
+	const isClickable = !!onClick;
+	const Tag = isClickable ? "button" : "span";
+
+	return (
+		<Tag
+			type={isClickable ? "button" : undefined}
+			onClick={onClick}
+			title={isClickable ? `Open ${label}` : label}
+			className={`inline-flex items-center gap-1.5 max-w-full text-left ${
+				isClickable
+					? "cursor-pointer hover:underline focus:outline-hidden focus-visible:underline"
+					: ""
+			}`}
+			style={{
+				color: isClickable
+					? "var(--color-accent)"
+					: "var(--color-text)",
+				background: "transparent",
+				border: "none",
+				padding: 0,
+				font: "inherit",
+			}}
+		>
+			<RelationIcon faviconUrl={faviconUrl} label={label} />
+			<span
+				className="truncate"
+				style={{ maxWidth: maxLabelWidth }}
+			>
+				{label}
+			</span>
+		</Tag>
+	);
+}
+
+/**
+ * 16x16 leading icon. Renders the favicon when one is supplied and loads
+ * cleanly; otherwise renders a letter monogram on a muted tile.
+ *
+ * The image-error fallback is the important bit: Google's s2 favicon
+ * service returns a generic "?" tile for unknown domains, but it can also
+ * 404 outright on private domains. Without this fallback we'd show a
+ * broken-image glyph next to the company name.
+ */
+function RelationIcon({
+	faviconUrl,
+	label,
+}: {
+	faviconUrl?: string;
+	label: string;
+}) {
+	const [imgFailed, setImgFailed] = useState(false);
+	const initial = (label?.trim().charAt(0) ?? "?").toUpperCase();
+	const showImg = !!faviconUrl && !imgFailed;
+
+	return (
+		<span
+			aria-hidden="true"
+			className="inline-flex items-center justify-center shrink-0 rounded-[3px] overflow-hidden"
+			style={{
+				width: 16,
+				height: 16,
+				background: showImg
+					? "transparent"
+					: "var(--color-surface-hover)",
+				border: showImg ? "none" : "1px solid var(--color-border)",
+				color: "var(--color-text-muted)",
+				fontSize: 9,
+				fontWeight: 600,
+				lineHeight: 1,
+			}}
+		>
+			{showImg ? (
+				// eslint-disable-next-line @next/next/no-img-element
+				<img
+					src={faviconUrl}
+					alt=""
+					width={16}
+					height={16}
+					decoding="async"
+					loading="lazy"
+					onError={() => setImgFailed(true)}
+					style={{
+						width: 16,
+						height: 16,
+						objectFit: "contain",
+					}}
+				/>
+			) : (
+				initial
+			)}
+		</span>
+	);
+}

--- a/apps/web/app/workspace/content-state.ts
+++ b/apps/web/app/workspace/content-state.ts
@@ -48,6 +48,7 @@ export type ObjectData = {
   }>;
   entries: Record<string, unknown>[];
   relationLabels?: Record<string, Record<string, string>>;
+  relationFaviconUrls?: Record<string, Record<string, string>>;
   reverseRelations?: ReverseRelation[];
   effectiveDisplayField?: string;
   savedViews?: SavedView[];

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -3808,6 +3808,7 @@ function ObjectView({
             entries={filteredEntries}
             members={members}
             relationLabels={data.relationLabels}
+            relationFaviconUrls={data.relationFaviconUrls}
             reverseRelations={data.reverseRelations}
             onNavigateToObject={onNavigateToObject}
             onNavigateToEntry={onOpenEntry}

--- a/apps/web/lib/workspace-cell-format.ts
+++ b/apps/web/lib/workspace-cell-format.ts
@@ -196,7 +196,7 @@ function normalizeUrl(raw: string): string | null {
 	return null;
 }
 
-function buildGoogleFaviconUrl(href: string): string | undefined {
+export function buildGoogleFaviconUrl(href: string): string | undefined {
 	try {
 		const url = new URL(href);
 		if (url.protocol !== "http:" && url.protocol !== "https:") {


### PR DESCRIPTION
## Summary

Relation references (People → Company, etc.) used to render as a colored pill across three different surfaces — table cell, entry detail panel, entry detail modal — each with its own ad-hoc styling. The pill made the affordance wrong: these are navigation, not tags. This PR replaces every relation pill with a single shared `RelationLink` component: small favicon + name in accent color, underline-on-hover, click opens the related entry.

## What changed

- **New shared component**: `apps/web/app/components/workspace/relation-link.tsx` — icon + name, link-styled, no pill background. Falls back to a letter monogram tile when no favicon is available so layout stays stable.
- **Server**: `resolveRelationLabels` now also pre-computes a Google s2 favicon URL per related entry by reading the entry's first url-typed field. Threaded through both:
  - `apps/web/app/api/workspace/objects/[name]/route.ts`
  - `apps/web/app/api/workspace/objects/[name]/entries/[id]/route.ts`
  as `relationFaviconUrls`.
- **Client**: `relationFaviconUrls` flows API response → `object-table` `RelationCell`, `entry-detail-panel` `RelationChips`, `entry-detail-modal` `RelationChips`. Memoized along the path so click churn on the table does not refetch.

## Verification

- Browser-tested in dev: People → "Plaid" renders as Plaid favicon + "Plaid" in accent color, clicking opens the Plaid company page in a new tab.
- Same elegant style applies in the entry detail panel header (Person profile card shows favicon next to "Plaid plaid.com").
- TypeScript: `tsc --noEmit` clean, 0 new lint errors introduced.

## Test plan

- [x] Open People → confirm Company column shows favicon + name (no pill background)
- [x] Click a company name → opens the company detail tab
- [x] Open a person's detail panel → confirm relation chip in header uses same icon+name style
- [x] Confirm fallback: a relation with no URL field renders a letter monogram tile

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes workspace API response shape and relation rendering across multiple UI surfaces, plus adds extra DuckDB queries per relation field to fetch URL values for favicon generation.
> 
> **Overview**
> **Relations now render as consistent icon+text links** instead of pill chips by introducing a shared `RelationLink` component and using it in the table, entry detail panel, and entry detail modal.
> 
> The workspace object and entry-detail APIs now also return `relationFaviconUrls` alongside `relationLabels`, computed server-side by scanning related entries’ `url` fields and generating Google s2 favicon URLs (with `buildGoogleFaviconUrl` exported for reuse).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84159d7aefa7be4e50b12f0e8135589696e6bce5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->