### PR TITLE
fix(crm): let empty-name people/companies add a name from the profile heading

### DIFF
--- a/apps/web/app/components/crm/company-profile.tsx
+++ b/apps/web/app/components/crm/company-profile.tsx
@@ -10,6 +10,7 @@ import { formatDayLabel, formatRelativeDate } from "./format-relative-date";
 import { EnrichButton } from "./enrich-button";
 import { ProfileThreadList } from "./inbox/profile-thread-list";
 import { EventListItem } from "./event-list-item";
+import { EditableTitleHeading } from "./editable-title-heading";
 
 // ---------------------------------------------------------------------------
 // API response shape (mirrors apps/web/app/api/crm/companies/[id]/route.ts)
@@ -129,6 +130,29 @@ export function CompanyProfile({
     void load();
   }, [load]);
 
+  // See PersonProfile for the rationale — optimistic local update keeps the
+  // header from re-skeletoning during a one-field save.
+  const handleSaveName = useCallback(
+    async (newName: string) => {
+      const res = await fetch(
+        `/api/workspace/objects/company/entries/${encodeURIComponent(companyId)}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ fields: { "Company Name": newName } }),
+        },
+      );
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      setData((prev) =>
+        prev ? { ...prev, company: { ...prev.company, name: newName } } : prev,
+      );
+    },
+    [companyId],
+  );
+
   if (loading && !data) {
     return (
       <div className="flex h-full flex-col" style={{ background: "var(--color-background)" }}>
@@ -156,7 +180,13 @@ export function CompanyProfile({
 
   return (
     <div className="flex h-full min-h-0 flex-col" style={{ background: "var(--color-background)" }}>
-      <CompanyHeader data={data} tab={tab} onTabChange={setTab} onBackToList={onBackToList} />
+      <CompanyHeader
+        data={data}
+        tab={tab}
+        onTabChange={setTab}
+        onBackToList={onBackToList}
+        onSaveName={handleSaveName}
+      />
       <div className="flex-1 min-h-0 overflow-y-auto">
         <div className="mx-auto w-full max-w-4xl px-6 py-6">
           {tab === "overview" && <OverviewTab data={data} />}
@@ -184,14 +214,15 @@ function CompanyHeader({
   tab,
   onTabChange,
   onBackToList,
+  onSaveName,
 }: {
   data: CompanyResponse;
   tab: Tab;
   onTabChange: (t: Tab) => void;
   onBackToList?: () => void;
+  onSaveName: (newName: string) => Promise<void>;
 }) {
   const { company } = data;
-  const displayName = company.name?.trim() || company.domain || "Unknown company";
   return (
     <header
       className="shrink-0 px-6 pt-4 pb-0"
@@ -211,9 +242,7 @@ function CompanyHeader({
         <CompanyFavicon domain={company.domain} name={company.name} size="xl" />
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-            <h1 className="font-instrument text-3xl tracking-tight truncate" style={{ color: "var(--color-text)" }}>
-              {displayName}
-            </h1>
+            <EditableTitleHeading name={company.name} saveName={onSaveName} />
             <ConnectionStrengthChip score={company.strength_score} />
           </div>
           <div

--- a/apps/web/app/components/crm/editable-title-heading.tsx
+++ b/apps/web/app/components/crm/editable-title-heading.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Inline-editable heading for CRM Person / Company detail pages.
+ *
+ * Behavior:
+ *   - When `name` is non-empty: renders the original h1 markup unchanged.
+ *     This is intentional — issue #7 was "let me ADD a name when one is
+ *     missing", not "let me edit existing names from the heading". Keeping
+ *     the populated case visually identical avoids regressing established
+ *     muscle memory for users who do already have names set.
+ *   - When `name` is empty/whitespace: renders a clickable button with a
+ *     pen icon and italic "Add a name" prompt. Click (or Enter / Space)
+ *     swaps it for an inline input styled identically to the heading.
+ *     Save on Enter or blur; cancel on Escape; empty submit cancels.
+ *     Errors render as a small inline message next to the input rather
+ *     than blocking the page.
+ *
+ * The save handler is supplied by the parent because both callers
+ * (Person, Company) hit the same workspace PATCH endpoint
+ * `/api/workspace/objects/{name}/entries/{id}` but with different field
+ * names — "Full Name" vs "Company Name". Parents are also responsible
+ * for updating their local state on success so the heading reflects the
+ * new value without a full skeleton-inducing reload.
+ */
+export function EditableTitleHeading({
+  name,
+  saveName,
+}: {
+  name: string | null;
+  saveName: (newName: string) => Promise<void>;
+}) {
+  const trimmed = name?.trim() ?? "";
+  const isEmpty = trimmed.length === 0;
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
+
+  const beginEdit = useCallback(() => {
+    setDraft("");
+    setError(null);
+    setEditing(true);
+  }, []);
+
+  const cancelEdit = useCallback(() => {
+    setEditing(false);
+    setDraft("");
+    setError(null);
+  }, []);
+
+  const commit = useCallback(async () => {
+    const next = draft.trim();
+    if (!next) {
+      cancelEdit();
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await saveName(next);
+      setEditing(false);
+      setDraft("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save name.");
+    } finally {
+      setSaving(false);
+    }
+  }, [draft, cancelEdit, saveName]);
+
+  if (editing) {
+    return (
+      <div className="flex flex-1 items-center gap-3 min-w-0">
+        <input
+          ref={inputRef}
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={() => {
+            void commit();
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              void commit();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              cancelEdit();
+            }
+          }}
+          disabled={saving}
+          placeholder="Add a name"
+          aria-label="Name"
+          className="font-instrument text-3xl tracking-tight w-full min-w-0"
+          style={{
+            color: "var(--color-text)",
+            background: "transparent",
+            border: "none",
+            outline: "none",
+            padding: 0,
+          }}
+        />
+        {error && (
+          <span
+            className="text-[12px] shrink-0"
+            style={{ color: "var(--color-error)" }}
+            role="alert"
+          >
+            {error}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  if (isEmpty) {
+    return (
+      <button
+        type="button"
+        onClick={beginEdit}
+        title="Add a name"
+        aria-label="Add a name"
+        className="font-instrument text-3xl tracking-tight inline-flex items-center gap-2 cursor-pointer hover:opacity-80 transition-opacity outline-none focus-visible:ring-2 rounded-sm"
+        style={{
+          color: "var(--color-text-muted)",
+          background: "transparent",
+          border: "none",
+          padding: 0,
+        }}
+      >
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M12 20h9" />
+          <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z" />
+        </svg>
+        <span style={{ fontStyle: "italic" }}>Add a name</span>
+      </button>
+    );
+  }
+
+  return (
+    <h1
+      className="font-instrument text-3xl tracking-tight truncate"
+      style={{ color: "var(--color-text)" }}
+    >
+      {trimmed}
+    </h1>
+  );
+}

--- a/apps/web/app/components/crm/person-profile.tsx
+++ b/apps/web/app/components/crm/person-profile.tsx
@@ -11,6 +11,7 @@ import { EnrichButton } from "./enrich-button";
 import { ProfileThreadList } from "./inbox/profile-thread-list";
 import { EventListItem } from "./event-list-item";
 import { ActivityTimeline } from "./activity-timeline";
+import { EditableTitleHeading } from "./editable-title-heading";
 
 // ---------------------------------------------------------------------------
 // API response shape (mirrors apps/web/app/api/crm/people/[id]/route.ts)
@@ -140,6 +141,31 @@ export function PersonProfile({
     void load();
   }, [load]);
 
+  // Persist a new name when the heading was empty and the user filled it in.
+  // We optimistically write the new value to local `data` so the heading,
+  // avatar initials, and downstream subtitle copy update immediately —
+  // calling `load()` would flicker the entire page through a skeleton state.
+  const handleSaveName = useCallback(
+    async (newName: string) => {
+      const res = await fetch(
+        `/api/workspace/objects/people/entries/${encodeURIComponent(personId)}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ fields: { "Full Name": newName } }),
+        },
+      );
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      setData((prev) =>
+        prev ? { ...prev, person: { ...prev.person, name: newName } } : prev,
+      );
+    },
+    [personId],
+  );
+
   if (loading && !data) {
     return (
       <div className="flex h-full flex-col" style={{ background: "var(--color-background)" }}>
@@ -176,6 +202,7 @@ export function PersonProfile({
         onTabChange={setTab}
         onOpenCompany={onOpenCompany}
         onBackToList={onBackToList}
+        onSaveName={handleSaveName}
       />
       <div className="flex-1 min-h-0 overflow-y-auto">
         <div className="mx-auto w-full max-w-4xl px-6 py-6">
@@ -214,14 +241,19 @@ function PersonHeader({
   onTabChange,
   onOpenCompany,
   onBackToList,
+  onSaveName,
 }: {
   data: PersonResponse;
   tab: Tab;
   onTabChange: (t: Tab) => void;
   onOpenCompany?: (id: string) => void;
   onBackToList?: () => void;
+  onSaveName: (newName: string) => Promise<void>;
 }) {
   const { person, company, derived_website } = data;
+  // Avatar still uses the email/Unknown fallback so an empty-name person
+  // gets a recognizable monogram from their email rather than a "?" tile —
+  // the heading itself swaps to the "Add a name" affordance independently.
   const displayName = person.name?.trim() || person.email || "Unknown contact";
   const website = company?.website || derived_website;
 
@@ -256,12 +288,7 @@ function PersonHeader({
         />
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-            <h1
-              className="font-instrument text-3xl tracking-tight truncate"
-              style={{ color: "var(--color-text)" }}
-            >
-              {displayName}
-            </h1>
+            <EditableTitleHeading name={person.name} saveName={onSaveName} />
             <ConnectionStrengthChip score={person.strength_score} />
           </div>
           <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[13px]">


### PR DESCRIPTION
## Summary
- Pairs with the previous Open-button fix for empty rows: now empty-name People/Companies can be **opened** AND **named** without leaving the detail page.
- Adds a shared `EditableTitleHeading` rendered only when the name is empty — populated entries keep their existing static `<h1>` byte-for-byte, so users with names set see no behavior change.
- Empty state is a pen-icon button + italic "Add a name" prompt. Click → inline input styled identically to the heading. Enter/blur save, Escape or whitespace-only submit cancel.
- Save reuses the workspace PATCH endpoint (`/api/workspace/objects/{name}/entries/{id}`) with the right field name (`Full Name` / `Company Name`). On success the parent does an optimistic local update — no skeleton flash for a one-field save.

## Why this way
- **Only when empty**, per the request — touching populated headings would change muscle memory for the common case.
- **One shared component** rather than duplicating identical h1 markup + edit logic across the two profiles.
- **Optimistic local update** beats `load()` here: the heading, avatar initials, and subtitle copy refresh instantly without re-running the full skeleton.

## Test plan
- [x] Empty-name Person profile → "Add a name" button visible
- [x] Click → inline input → type "Empty Test Person" → Enter → backend persists, h1 shows new name, avatar initials update
- [x] Empty-name Company profile → "Add a name" → save "Acme Test Co" → persists end-to-end
- [x] Escape from input → returns to button cleanly
- [x] Whitespace-only Enter → returns to button cleanly
- [x] Populated profile (Patrick Collison) → static h1, no edit affordance shown
- [x] `tsc --noEmit` clean
- [x] No new lint errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change that adds a narrow PATCH-on-save flow for a single field; main risk is incorrect field names/endpoints or error handling causing save failures for empty-name records.
> 
> **Overview**
> Adds an inline "Add a name" affordance to CRM Person and Company profile headers when the record’s name is missing, using a shared `EditableTitleHeading` component (Enter/blur saves, Escape cancels, inline error display).
> 
> Both profiles now wire a `PATCH` save handler to the workspace objects endpoint (`Full Name` for people, `Company Name` for companies) and optimistically update local state on success to avoid reloading/skeleton flicker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c7a21610b1a86f29e332b12ff0cb6fe4986c51c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->