### PR TITLE
fix(crm): fill company favicon tile edge-to-edge

### DIFF
--- a/apps/web/app/components/crm/company-favicon.tsx
+++ b/apps/web/app/components/crm/company-favicon.tsx
@@ -9,6 +9,16 @@ import { useState } from "react";
  * letter monogram if the image errors.
  *
  * Sizes match `PersonAvatar` for visual consistency in mixed lists.
+ *
+ * Visual model:
+ *   When a favicon is available, the image fills the rounded container
+ *   edge-to-edge (object-fit: cover) so the tile reads as the company's
+ *   logo, not as a small icon framed by a gray padding ring. Source
+ *   resolution is requested at 128px so retina rendering stays crisp
+ *   even at the largest size (xl=64px → 128 device px).
+ *   When no favicon is available (no domain, or fetch failed), we fall
+ *   back to a centered letter monogram against a subtle surface color
+ *   so the tile still has visual weight in mixed lists.
  */
 export function CompanyFavicon({
   domain,
@@ -27,7 +37,7 @@ export function CompanyFavicon({
 
   const cleanedDomain = domain?.trim().toLowerCase().replace(/^https?:\/\//, "").replace(/\/.*$/, "");
   const faviconUrl = cleanedDomain
-    ? `https://www.google.com/s2/favicons?sz=64&domain_url=${encodeURIComponent(cleanedDomain)}`
+    ? `https://www.google.com/s2/favicons?sz=128&domain_url=${encodeURIComponent(cleanedDomain)}`
     : null;
   const initial = (name ?? cleanedDomain ?? "?").charAt(0).toUpperCase();
 
@@ -39,7 +49,7 @@ export function CompanyFavicon({
       style={{
         width: px,
         height: px,
-        background: "var(--color-surface-hover)",
+        background: showImg ? "transparent" : "var(--color-surface-hover)",
         border: "1px solid var(--color-border)",
         color: "var(--color-text)",
         fontSize: fontPx,
@@ -52,12 +62,17 @@ export function CompanyFavicon({
         <img
           src={faviconUrl ?? undefined}
           alt=""
-          width={Math.round(px * 0.65)}
-          height={Math.round(px * 0.65)}
+          width={px}
+          height={px}
           decoding="async"
           loading="lazy"
           onError={() => setImgFailed(true)}
-          style={{ objectFit: "contain" }}
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            display: "block",
+          }}
         />
       ) : (
         initial


### PR DESCRIPTION
## Issue

On the company profile page (and anywhere `CompanyFavicon` renders), the logo sat at ~65% of the tile's size on a gray surface. This left a visible gray padding ring around the favicon — it read more like a hosted thumbnail than the company's own logo.

## Fix

- Image now fills the rounded container edge-to-edge (`width/height: 100%`, `object-fit: cover`).
- Gray background (`--color-surface-hover`) is only rendered for the monogram fallback, where the letter still needs a backdrop.
- Source bumped from `sz=64` → `sz=128` so retina rendering stays crisp at xl=64px.

## Verification

Confirmed via headless browser on `comp_stripe_001` profile (xl=64): tile measures 64×64, image measures 62×62 (the 1px border accounts for the 2px), `object-fit: cover`, `background: rgba(0,0,0,0)`. Stripe favicon fills the rounded square — no gray ring.

Confirmed monogram fallback on a no-domain test company: image absent, letter rendered, background still `rgba(231, 229, 228, 0.65)` (the soft surface tone).

`pnpm tsc --noEmit` clean. `oxlint` clean. `company-favicon.test.tsx` 3/3 passing.

## Demo

Before: favicon at 65% on a gray-surface ring.
After: favicon fills the rounded container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that tweaks favicon rendering and fallback styling; main impact is minor visual/layout differences for company tiles.
> 
> **Overview**
> Updates `CompanyFavicon` so fetched favicons render **edge-to-edge** in the tile (`object-fit: cover`, full-size image) instead of being inset.
> 
> Requests higher-resolution favicons (`sz=128`) for crisper retina rendering and only applies the gray surface background when falling back to the monogram (transparent when an image is shown).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85e6619c2403f166c3d89c1f8bf8882eb5679163. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->