### PR TITLE
fix(crm): fill company favicon tile edge-to-edge

### DIFF
--- a/apps/web/app/components/crm/company-favicon.tsx
+++ b/apps/web/app/components/crm/company-favicon.tsx
@@ -9,6 +9,16 @@ import { useState } from "react";
  * letter monogram if the image errors.
  *
  * Sizes match `PersonAvatar` for visual consistency in mixed lists.
+ *
+ * Visual model:
+ *   When a favicon is available, the image fills the rounded container
+ *   edge-to-edge (object-fit: cover) so the tile reads as the company's
+ *   logo, not as a small icon framed by a gray padding ring. Source
+ *   resolution is requested at 128px so retina rendering stays crisp
+ *   even at the largest size (xl=64px → 128 device px).
+ *   When no favicon is available (no domain, or fetch failed), we fall
+ *   back to a centered letter monogram against a subtle surface color
+ *   so the tile still has visual weight in mixed lists.
  */
 export function CompanyFavicon({
   domain,
@@ -27,7 +37,7 @@ export function CompanyFavicon({
 
   const cleanedDomain = domain?.trim().toLowerCase().replace(/^https?:\/\//, "").replace(/\/.*$/, "");
   const faviconUrl = cleanedDomain
-    ? `https://www.google.com/s2/favicons?sz=64&domain_url=${encodeURIComponent(cleanedDomain)}`
+    ? `https://www.google.com/s2/favicons?sz=128&domain_url=${encodeURIComponent(cleanedDomain)}`
     : null;
   const initial = (name ?? cleanedDomain ?? "?").charAt(0).toUpperCase();
 
@@ -39,7 +49,7 @@ export function CompanyFavicon({
       style={{
         width: px,
         height: px,
-        background: "var(--color-surface-hover)",
+        background: showImg ? "transparent" : "var(--color-surface-hover)",
         border: "1px solid var(--color-border)",
         color: "var(--color-text)",
         fontSize: fontPx,
@@ -52,12 +62,17 @@ export function CompanyFavicon({
         <img
           src={faviconUrl ?? undefined}
           alt=""
-          width={Math.round(px * 0.65)}
-          height={Math.round(px * 0.65)}
+          width={px}
+          height={px}
           decoding="async"
           loading="lazy"
           onError={() => setImgFailed(true)}
-          style={{ objectFit: "contain" }}
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            display: "block",
+          }}
         />
       ) : (
         initial


### PR DESCRIPTION
CompanyFavicon used to render the logo at ~65% of the tile, sitting on a gray surface — leaving a visible gray padding ring. The image now fills the rounded container edge-to-edge (object-fit: cover), the gray background only renders for the monogram fallback, and source resolution bumps to sz=128 for crisp retina rendering at xl=64.

Re-creating as a merge-commit PR (previously squash-merged as #229 and reverted).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change to `CompanyFavicon` rendering and favicon fetch size; potential impact is limited to visual presentation and slightly increased image bandwidth.
> 
> **Overview**
> Updates `CompanyFavicon` so the favicon image fills the entire rounded tile (`object-fit: cover`, 100% width/height) instead of being inset, and only shows the gray background when falling back to the monogram.
> 
> Bumps the Google s2 favicon request size from `sz=64` to `sz=128` to improve sharpness on larger/retina displays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2c29836a7adb4aea6d1502f77366aa2347ea27d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->