### PR TITLE
fix(workspace): tighten enrichment column controls

### DIFF
--- a/apps/web/app/api/workspace/objects/[name]/enrich/route.test.ts
+++ b/apps/web/app/api/workspace/objects/[name]/enrich/route.test.ts
@@ -42,8 +42,8 @@ describe("workspace enrichment route", () => {
       if (sql.includes("SELECT id FROM objects WHERE name")) {
         return [{ id: "obj_1" }] as never;
       }
-      if (sql.includes("SELECT id, name FROM fields")) {
-        return [{ id: "input_1", name: "email" }] as never;
+      if (sql.includes("SELECT id, name, type FROM fields")) {
+        return [{ id: "input_1", name: "email", type: "email" }] as never;
       }
       if (sql.includes("SELECT id FROM fields WHERE id")) {
         return [{ id: "field_1" }] as never;
@@ -97,8 +97,8 @@ describe("workspace enrichment route", () => {
       if (sql.includes("SELECT id FROM objects WHERE name")) {
         return [{ id: "obj_1" }] as never;
       }
-      if (sql.includes("SELECT id, name FROM fields")) {
-        return [{ id: "input_1", name: "LinkedIn URL" }] as never;
+      if (sql.includes("SELECT id, name, type FROM fields")) {
+        return [{ id: "input_1", name: "LinkedIn URL", type: "url" }] as never;
       }
       if (sql.includes("SELECT id FROM fields WHERE id")) {
         return [{ id: "field_1" }] as never;
@@ -150,8 +150,8 @@ describe("workspace enrichment route", () => {
       if (sql.includes("SELECT id FROM objects WHERE name")) {
         return [{ id: "obj_1" }] as never;
       }
-      if (sql.includes("SELECT id, name FROM fields")) {
-        return [{ id: "input_1", name: "website" }] as never;
+      if (sql.includes("SELECT id, name, type FROM fields")) {
+        return [{ id: "input_1", name: "website", type: "url" }] as never;
       }
       if (sql.includes("SELECT id FROM fields WHERE id")) {
         return [{ id: "field_1" }] as never;
@@ -227,8 +227,8 @@ describe("workspace enrichment route", () => {
       if (sql.includes("SELECT id FROM objects WHERE name")) {
         return [{ id: "obj_1" }] as never;
       }
-      if (sql.includes("SELECT id, name FROM fields")) {
-        return [{ id: "input_1", name: "email" }] as never;
+      if (sql.includes("SELECT id, name, type FROM fields")) {
+        return [{ id: "input_1", name: "email", type: "email" }] as never;
       }
       if (sql.includes("SELECT id FROM fields WHERE id")) {
         return [{ id: "field_1" }] as never;

--- a/apps/web/app/api/workspace/objects/[name]/enrich/route.ts
+++ b/apps/web/app/api/workspace/objects/[name]/enrich/route.ts
@@ -7,7 +7,11 @@ import {
 	getIntegrationsState,
 	resolveDenchGatewayCredentials,
 } from "@/lib/integrations";
-import { extractApolloValue, extractDomain } from "@/lib/enrichment-columns";
+import {
+	extractApolloValue,
+	extractDomain,
+	isEligibleInputField,
+} from "@/lib/enrichment-columns";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -99,12 +103,15 @@ export async function POST(
 	const objectId = objects[0].id;
 
 	// Resolve the input field ID by name
-	const inputFields = duckdbQueryOnFile<{ id: string; name: string }>(
+	const inputFields = duckdbQueryOnFile<{ id: string; name: string; type: string }>(
 		dbFile,
-		`SELECT id, name FROM fields WHERE object_id = '${sqlEscape(objectId)}' AND name = '${sqlEscape(inputFieldName)}'`,
+		`SELECT id, name, type FROM fields WHERE object_id = '${sqlEscape(objectId)}' AND name = '${sqlEscape(inputFieldName)}'`,
 	);
 	if (inputFields.length === 0) {
 		return Response.json({ error: `Input field '${inputFieldName}' not found.` }, { status: 404 });
+	}
+	if (!isEligibleInputField(category, inputFields[0])) {
+		return Response.json({ error: `Input field '${inputFieldName}' is not supported for ${category} enrichment.` }, { status: 400 });
 	}
 	const inputFieldId = inputFields[0].id;
 

--- a/apps/web/app/api/workspace/objects/[name]/fields/[fieldId]/route.ts
+++ b/apps/web/app/api/workspace/objects/[name]/fields/[fieldId]/route.ts
@@ -17,8 +17,8 @@ function sqlEscape(s: string): string {
 
 /**
  * PATCH /api/workspace/objects/[name]/fields/[fieldId]
- * Rename a field.
- * Body: { name: string }
+ * Update field metadata.
+ * Body: { name?: string, default_value?: string | null }
  */
 export async function PATCH(
 	req: Request,
@@ -44,15 +44,22 @@ export async function PATCH(
 	}
 
 	const body = await req.json();
-	const newName: string = body.name;
+	const newName = typeof body.name === "string" ? body.name.trim() : null;
+	const hasDefaultValue = Object.prototype.hasOwnProperty.call(body, "default_value");
+	const defaultValue: unknown = body.default_value;
 
 	if (
-		!newName ||
-		typeof newName !== "string" ||
-		newName.trim().length === 0
+		(!newName || newName.length === 0)
+		&& !hasDefaultValue
 	) {
 		return Response.json(
-			{ error: "Name is required" },
+			{ error: "Name or default_value is required" },
+			{ status: 400 },
+		);
+	}
+	if (hasDefaultValue && defaultValue !== null && typeof defaultValue !== "string") {
+		return Response.json(
+			{ error: "default_value must be a string or null" },
 			{ status: 400 },
 		);
 	}
@@ -80,19 +87,29 @@ export async function PATCH(
 		);
 	}
 
-	// Check for duplicate name
-	const duplicateCheck = duckdbQueryOnFile<{ cnt: number }>(dbFile,
-		`SELECT COUNT(*) as cnt FROM fields WHERE object_id = '${sqlEscape(objectId)}' AND name = '${sqlEscape(newName.trim())}' AND id != '${sqlEscape(fieldId)}'`,
-	);
-	if (duplicateCheck[0]?.cnt > 0) {
-		return Response.json(
-			{ error: "A field with that name already exists" },
-			{ status: 409 },
+	if (newName && newName.length > 0) {
+		// Check for duplicate name
+		const duplicateCheck = duckdbQueryOnFile<{ cnt: number }>(dbFile,
+			`SELECT COUNT(*) as cnt FROM fields WHERE object_id = '${sqlEscape(objectId)}' AND name = '${sqlEscape(newName)}' AND id != '${sqlEscape(fieldId)}'`,
 		);
+		if (duplicateCheck[0]?.cnt > 0) {
+			return Response.json(
+				{ error: "A field with that name already exists" },
+				{ status: 409 },
+			);
+		}
+	}
+
+	const updates: string[] = [];
+	if (newName && newName.length > 0) {
+		updates.push(`name = '${sqlEscape(newName)}'`);
+	}
+	if (hasDefaultValue) {
+		updates.push(defaultValue === null ? "default_value = NULL" : `default_value = '${sqlEscape(defaultValue as string)}'`);
 	}
 
 	const ok = duckdbExecOnFile(dbFile,
-		`UPDATE fields SET name = '${sqlEscape(newName.trim())}' WHERE id = '${sqlEscape(fieldId)}'`,
+		`UPDATE fields SET ${updates.join(", ")} WHERE id = '${sqlEscape(fieldId)}'`,
 	);
 
 	if (!ok) {

--- a/apps/web/app/components/workspace/column-header-menu.tsx
+++ b/apps/web/app/components/workspace/column-header-menu.tsx
@@ -443,6 +443,16 @@ export function AddColumnPopover({
 			);
 
 			if (existingOutputField) {
+				const metaRes = await fetch(`/api/workspace/objects/${encodeURIComponent(objectName)}/fields/${encodeURIComponent(existingOutputField.id)}`, {
+					method: "PATCH",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ default_value: JSON.stringify(meta) }),
+				});
+				if (!metaRes.ok) {
+					const data = await metaRes.json().catch(() => ({ error: "Failed" }));
+					setError(data.error ?? "Failed to mark existing field as enrichment");
+					return;
+				}
 				handleClose();
 				onEnrichmentStartRef.current?.({
 					fieldId: existingOutputField.id,

--- a/apps/web/app/components/workspace/column-header-menu.tsx
+++ b/apps/web/app/components/workspace/column-header-menu.tsx
@@ -254,6 +254,20 @@ export type EnrichmentStartPayload = {
 	scope: "all" | "empty" | number;
 };
 
+const ENRICH_SCOPE_OPTIONS: Array<{
+	value: EnrichmentStartPayload["scope"];
+	label: string;
+	buttonLabel: string;
+}> = [
+	{ value: "all", label: "Enrich all", buttonLabel: "all" },
+	{ value: "empty", label: "Enrich empty", buttonLabel: "empty" },
+	{ value: 10, label: "Enrich top 10", buttonLabel: "top 10" },
+];
+
+function enrichScopeButtonLabel(scope: EnrichmentStartPayload["scope"]): string {
+	return ENRICH_SCOPE_OPTIONS.find((option) => option.value === scope)?.buttonLabel ?? "all";
+}
+
 export function AddColumnPopover({
 	objectName,
 	onCreated,
@@ -284,6 +298,8 @@ export function AddColumnPopover({
 		label: string; key: string; fieldType: string; apolloPath: string;
 	}>>([]);
 	const [eligibleInputFields, setEligibleInputFields] = useState<AddColumnField[]>([]);
+	const [enrichScope, setEnrichScope] = useState<EnrichmentStartPayload["scope"]>("all");
+	const [scopeMenuOpen, setScopeMenuOpen] = useState(false);
 
 	// Self-contained enrichment availability check so parent re-renders
 	// don't remount this component (which resets the popover open state).
@@ -346,12 +362,15 @@ export function AddColumnPopover({
 		setEnumInput("");
 		setError(null);
 		setSelectedEnrichCol(null);
+		setEnrichScope("all");
+		setScopeMenuOpen(false);
 	}, []);
 
 	const handleClose = useCallback(() => {
 		setOpen(false);
 		setError(null);
 		setSelectedEnrichCol(null);
+		setScopeMenuOpen(false);
 	}, []);
 
 	useEffect(() => {
@@ -431,7 +450,7 @@ export function AddColumnPopover({
 					apolloPath: selectedEnrichCol.apolloPath,
 					category: enrichCategory,
 					inputFieldName: enrichInputField,
-					scope: "all",
+					scope: enrichScope,
 				});
 				return;
 			}
@@ -465,7 +484,7 @@ export function AddColumnPopover({
 					apolloPath: selectedEnrichCol.apolloPath,
 					category: enrichCategory,
 					inputFieldName: enrichInputField,
-					scope: "all",
+					scope: enrichScope,
 				});
 			}
 		} catch {
@@ -473,9 +492,12 @@ export function AddColumnPopover({
 		} finally {
 			setSaving(false);
 		}
-	}, [selectedEnrichCol, enrichCategory, enrichInputField, objectName, handleClose, onCreated]);
+	}, [selectedEnrichCol, enrichCategory, enrichInputField, enrichScope, objectName, handleClose, onCreated]);
 
 	const showEnrichment = enrichmentAvailable && enrichCategory && enrichColumns.length > 0;
+	const selectedOutputExists = selectedEnrichCol
+		? fieldsRef.current?.some((field) => field.name.toLowerCase() === selectedEnrichCol.label.toLowerCase()) === true
+		: false;
 
 	return (
 		<>
@@ -553,7 +575,7 @@ export function AddColumnPopover({
 										Will enrich using &ldquo;{enrichInputField}&rdquo; column
 									</div>
 								)}
-								{fieldsRef.current?.some((field) => field.name.toLowerCase() === selectedEnrichCol.label.toLowerCase()) && (
+								{selectedOutputExists && (
 									<div className="flex items-center gap-1.5 text-xs px-1" style={{ color: "var(--color-accent)" }}>
 										<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6 9 17l-5-5" /></svg>
 										Existing &ldquo;{selectedEnrichCol.label}&rdquo; column will be enriched
@@ -572,16 +594,64 @@ export function AddColumnPopover({
 								>
 									Cancel
 								</button>
-								<button
-									type="button"
-									onClick={() => void handleEnrichCreate()}
-									disabled={saving || !enrichInputField}
-									className="px-3 py-1.5 text-xs font-medium rounded-lg transition-colors disabled:opacity-40 flex items-center gap-1.5"
-									style={{ background: "var(--color-accent)", color: "white" }}
-								>
-									<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z" /></svg>
-									{saving ? "Creating..." : "Create & Enrich All"}
-								</button>
+								<div className="relative inline-flex rounded-lg overflow-visible">
+									<button
+										type="button"
+										onClick={() => void handleEnrichCreate()}
+										disabled={saving || !enrichInputField}
+										className="px-3 py-1.5 text-xs font-medium rounded-l-lg transition-colors disabled:opacity-40 flex items-center gap-1.5"
+										style={{ background: "var(--color-accent)", color: "white" }}
+									>
+										<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z" /></svg>
+										{saving ? "Enriching..." : `${selectedOutputExists ? "Enrich" : "Create & Enrich"} ${enrichScopeButtonLabel(enrichScope)}`}
+									</button>
+									<button
+										type="button"
+										aria-label="Choose enrichment scope"
+										aria-expanded={scopeMenuOpen}
+										onClick={() => setScopeMenuOpen((isOpen) => !isOpen)}
+										disabled={saving || !enrichInputField}
+										className="px-2 py-1.5 text-xs font-medium rounded-r-lg transition-colors disabled:opacity-40"
+										style={{
+											background: "var(--color-accent)",
+											color: "white",
+											borderLeft: "1px solid rgba(255,255,255,0.24)",
+										}}
+									>
+										<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="m6 9 6 6 6-6" /></svg>
+									</button>
+									{scopeMenuOpen && (
+										<div
+											className="absolute right-0 bottom-full mb-1 w-36 rounded-xl p-1 text-xs"
+											style={{
+												background: "var(--color-bg)",
+												color: "var(--color-text)",
+												border: "1px solid var(--color-border)",
+												boxShadow: "0 8px 24px rgba(0,0,0,0.16)",
+											}}
+										>
+											{ENRICH_SCOPE_OPTIONS.map((option) => (
+												<button
+													key={String(option.value)}
+													type="button"
+													onClick={() => {
+														setEnrichScope(option.value);
+														setScopeMenuOpen(false);
+													}}
+													className="w-full flex items-center justify-between px-2 py-1.5 rounded-lg text-left hover:opacity-80"
+													style={{
+														background: enrichScope === option.value ? "var(--color-surface-hover)" : "transparent",
+													}}
+												>
+													<span>{option.label}</span>
+													{enrichScope === option.value && (
+														<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6 9 17l-5-5" /></svg>
+													)}
+												</button>
+											))}
+										</div>
+									)}
+								</div>
 							</div>
 						</>
 					) : (

--- a/apps/web/app/components/workspace/column-header-menu.tsx
+++ b/apps/web/app/components/workspace/column-header-menu.tsx
@@ -283,6 +283,7 @@ export function AddColumnPopover({
 	const [enrichColumns, setEnrichColumns] = useState<Array<{
 		label: string; key: string; fieldType: string; apolloPath: string;
 	}>>([]);
+	const [eligibleInputFields, setEligibleInputFields] = useState<AddColumnField[]>([]);
 
 	// Self-contained enrichment availability check so parent re-renders
 	// don't remount this component (which resets the popover open state).
@@ -314,13 +315,14 @@ export function AddColumnPopover({
 	// Load enrichment columns lazily
 	useEffect(() => {
 		if (!enrichmentAvailable) return;
-		import("@/lib/enrichment-columns").then(({ detectEnrichmentCategory, getEnrichmentColumns, autoDetectInputField }) => {
+		import("@/lib/enrichment-columns").then(({ detectEnrichmentCategory, getEnrichmentColumns, autoDetectInputField, getEligibleInputFields }) => {
 			const cat = detectEnrichmentCategory(objectName);
 			setEnrichCategory(cat);
 			if (cat) {
 				setEnrichColumns(getEnrichmentColumns(cat));
 				const currentFields = fieldsRef.current;
 				if (currentFields) {
+					setEligibleInputFields(getEligibleInputFields(cat, currentFields));
 					const autoInput = autoDetectInputField(cat, currentFields);
 					if (autoInput) setEnrichInputField(autoInput.name);
 				}
@@ -524,7 +526,7 @@ export function AddColumnPopover({
 										}}
 									>
 										<option value="">Select input column...</option>
-										{(fields ?? []).map((f) => (
+										{eligibleInputFields.map((f) => (
 											<option key={f.id} value={f.name}>{f.name}</option>
 										))}
 									</select>

--- a/apps/web/app/components/workspace/column-header-menu.tsx
+++ b/apps/web/app/components/workspace/column-header-menu.tsx
@@ -419,6 +419,22 @@ export function AddColumnPopover({
 		try {
 			const { buildEnrichmentMeta } = await import("@/lib/enrichment-columns");
 			const meta = buildEnrichmentMeta(enrichCategory, selectedEnrichCol, enrichInputField);
+			const existingOutputField = fieldsRef.current?.find(
+				(field) => field.name.toLowerCase() === selectedEnrichCol.label.toLowerCase(),
+			);
+
+			if (existingOutputField) {
+				handleClose();
+				onEnrichmentStartRef.current?.({
+					fieldId: existingOutputField.id,
+					fieldName: existingOutputField.name,
+					apolloPath: selectedEnrichCol.apolloPath,
+					category: enrichCategory,
+					inputFieldName: enrichInputField,
+					scope: "all",
+				});
+				return;
+			}
 
 			const body: Record<string, unknown> = {
 				name: selectedEnrichCol.label,
@@ -535,6 +551,12 @@ export function AddColumnPopover({
 									<div className="flex items-center gap-1.5 text-xs px-1" style={{ color: "var(--color-text-muted)" }}>
 										<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z" /></svg>
 										Will enrich using &ldquo;{enrichInputField}&rdquo; column
+									</div>
+								)}
+								{fieldsRef.current?.some((field) => field.name.toLowerCase() === selectedEnrichCol.label.toLowerCase()) && (
+									<div className="flex items-center gap-1.5 text-xs px-1" style={{ color: "var(--color-accent)" }}>
+										<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6 9 17l-5-5" /></svg>
+										Existing &ldquo;{selectedEnrichCol.label}&rdquo; column will be enriched
 									</div>
 								)}
 								{error && (

--- a/apps/web/lib/enrichment-columns.test.ts
+++ b/apps/web/lib/enrichment-columns.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { getEligibleInputFields } from "./enrichment-columns";
+
+describe("getEligibleInputFields", () => {
+	it("limits people enrichment inputs to email and LinkedIn fields", () => {
+		const fields = [
+			{ id: "name", name: "Full Name", type: "text" },
+			{ id: "email", name: "Email", type: "email" },
+			{ id: "linkedin", name: "LinkedIn URL", type: "url" },
+			{ id: "company", name: "Company", type: "text" },
+		];
+
+		expect(getEligibleInputFields("people", fields).map((field) => field.id)).toEqual([
+			"email",
+			"linkedin",
+		]);
+	});
+
+	it("limits company enrichment inputs to domain, website, and LinkedIn fields", () => {
+		const fields = [
+			{ id: "name", name: "Company Name", type: "text" },
+			{ id: "domain", name: "Domain", type: "text" },
+			{ id: "website", name: "Website", type: "url" },
+			{ id: "linkedin", name: "LinkedIn URL", type: "url" },
+			{ id: "industry", name: "Industry", type: "text" },
+		];
+
+		expect(getEligibleInputFields("company", fields).map((field) => field.id)).toEqual([
+			"domain",
+			"website",
+			"linkedin",
+		]);
+	});
+});

--- a/apps/web/lib/enrichment-columns.ts
+++ b/apps/web/lib/enrichment-columns.ts
@@ -88,27 +88,50 @@ export function getInputDefs(category: EnrichmentCategory): EnrichmentInputDef[]
 // Auto-detect an input column from existing fields
 // ---------------------------------------------------------------------------
 
-type FieldCandidate = { id: string; name: string; type: string };
+export type FieldCandidate = { id: string; name: string; type: string };
+
+export function isEligibleInputField(
+	category: EnrichmentCategory,
+	field: FieldCandidate,
+): boolean {
+	if (category === "people") {
+		return field.type === "email" || /^e[-_]?mail/i.test(field.name) || /linkedin/i.test(field.name);
+	}
+
+	return (
+		/domain|website/i.test(field.name)
+		|| /linkedin/i.test(field.name)
+		|| (/^url$/i.test(field.name) && field.type === "url")
+	);
+}
+
+export function getEligibleInputFields(
+	category: EnrichmentCategory,
+	fields: FieldCandidate[],
+): FieldCandidate[] {
+	return fields.filter((field) => isEligibleInputField(category, field));
+}
 
 export function autoDetectInputField(
 	category: EnrichmentCategory,
 	fields: FieldCandidate[],
 ): FieldCandidate | null {
+	const eligibleFields = getEligibleInputFields(category, fields);
 	if (category === "people") {
-		const emailField = fields.find(
+		const emailField = eligibleFields.find(
 			(f) => f.type === "email" || /^e[-_]?mail/i.test(f.name),
 		);
 		if (emailField) return emailField;
-		const linkedinField = fields.find(
+		const linkedinField = eligibleFields.find(
 			(f) => /linkedin/i.test(f.name),
 		);
 		if (linkedinField) return linkedinField;
 	} else {
-		const domainField = fields.find(
-			(f) => /website|domain|^url$/i.test(f.name) || (f.type === "url" && !/linkedin|twitter|facebook/i.test(f.name)),
+		const domainField = eligibleFields.find(
+			(f) => /website|domain|^url$/i.test(f.name),
 		);
 		if (domainField) return domainField;
-		const linkedinField = fields.find(
+		const linkedinField = eligibleFields.find(
 			(f) => /linkedin/i.test(f.name),
 		);
 		if (linkedinField) return linkedinField;


### PR DESCRIPTION
## Summary

- Restricts enrichment input-column choices to supported identifiers by object type: people use Email/LinkedIn, companies use Domain/Website/LinkedIn.
- Reuses an existing output column when the selected enrichment output already exists, instead of failing with the duplicate-column error.
- Adds a split Enrich action with scope choices: all rows, empty rows, or top 10.

## Commits

- `fix(workspace): restrict enrichment input columns`
- `fix(workspace): enrich existing output columns`
- `feat(workspace): add enrichment scope split button`

## Verification

- `npx tsc --noEmit`
- `npx vitest run lib/enrichment-columns.test.ts 'app/api/workspace/objects/[name]/enrich/route.test.ts'`
- Browser sanity check on People table: input select only showed `Email Address` and `LinkedIn URL`; selecting existing `Full Name` switched the action to `Enrich top 10`; split menu showed `Enrich all`, `Enrich empty`, and `Enrich top 10`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes enrichment input validation and updates the `PATCH /fields/[fieldId]` API to allow partial metadata updates, which can affect enrichment runs and field configuration writes.
> 
> **Overview**
> Tightens enrichment safety and UX by **restricting selectable/allowed enrichment input columns** to supported identifiers per category (people: email/LinkedIn; company: domain/website/LinkedIn), enforced in both the UI and the `/enrich` API.
> 
> Enhancement creation now **reuses an existing output column** (case-insensitive name match) by PATCHing its `default_value` enrichment metadata instead of failing on duplicate creation, and the UI adds a **split-button scope selector** (`all`, `empty`, `top 10`) that is forwarded to enrichment runs.
> 
> Extends `PATCH /api/workspace/objects/[name]/fields/[fieldId]` from rename-only to **partial field metadata updates** (`name` and/or `default_value`), with validation and conditional duplicate-name checks; tests are updated/added for the new eligibility filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85f934440606e979333119b804a8c720f34f4a06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->