### PR TITLE
feat(workspace): allow enrichment on any table

### DIFF
--- a/apps/web/app/components/workspace/column-header-menu.tsx
+++ b/apps/web/app/components/workspace/column-header-menu.tsx
@@ -244,6 +244,21 @@ export function InlineRenameInput({
 /* ─── Add Column Popover ─── */
 
 type AddColumnField = { id: string; name: string; type: string };
+type EnrichmentCategory = "people" | "company";
+type EnrichmentColumnOption = {
+	label: string;
+	key: string;
+	fieldType: string;
+	apolloPath: string;
+	category: EnrichmentCategory;
+};
+type EnrichmentColumnGroup = {
+	category: EnrichmentCategory;
+	label: string;
+	columns: EnrichmentColumnOption[];
+	inputFields: AddColumnField[];
+	defaultInputField: string;
+};
 
 export type EnrichmentStartPayload = {
 	fieldId: string;
@@ -289,15 +304,9 @@ export function AddColumnPopover({
 	const [error, setError] = useState<string | null>(null);
 
 	// Enrichment state
-	const [selectedEnrichCol, setSelectedEnrichCol] = useState<{
-		label: string; key: string; fieldType: string; apolloPath: string;
-	} | null>(null);
+	const [selectedEnrichCol, setSelectedEnrichCol] = useState<EnrichmentColumnOption | null>(null);
 	const [enrichInputField, setEnrichInputField] = useState<string>("");
-	const [enrichCategory, setEnrichCategory] = useState<"people" | "company" | null>(null);
-	const [enrichColumns, setEnrichColumns] = useState<Array<{
-		label: string; key: string; fieldType: string; apolloPath: string;
-	}>>([]);
-	const [eligibleInputFields, setEligibleInputFields] = useState<AddColumnField[]>([]);
+	const [enrichGroups, setEnrichGroups] = useState<EnrichmentColumnGroup[]>([]);
 	const [enrichScope, setEnrichScope] = useState<EnrichmentStartPayload["scope"]>("all");
 	const [scopeMenuOpen, setScopeMenuOpen] = useState(false);
 
@@ -331,18 +340,21 @@ export function AddColumnPopover({
 	// Load enrichment columns lazily
 	useEffect(() => {
 		if (!enrichmentAvailable) return;
-		import("@/lib/enrichment-columns").then(({ detectEnrichmentCategory, getEnrichmentColumns, autoDetectInputField, getEligibleInputFields }) => {
-			const cat = detectEnrichmentCategory(objectName);
-			setEnrichCategory(cat);
-			if (cat) {
-				setEnrichColumns(getEnrichmentColumns(cat));
-				const currentFields = fieldsRef.current;
-				if (currentFields) {
-					setEligibleInputFields(getEligibleInputFields(cat, currentFields));
-					const autoInput = autoDetectInputField(cat, currentFields);
-					if (autoInput) setEnrichInputField(autoInput.name);
-				}
-			}
+		import("@/lib/enrichment-columns").then(({ getAvailableEnrichmentCategories, getEnrichmentColumns, autoDetectInputField, getEligibleInputFields }) => {
+			const currentFields = fieldsRef.current ?? [];
+			const groups = getAvailableEnrichmentCategories(objectName, currentFields).map((category) => {
+				const inputFields = getEligibleInputFields(category, currentFields);
+				const autoInput = autoDetectInputField(category, currentFields);
+				return {
+					category,
+					label: category === "people" ? "People enrichment" : "Company enrichment",
+					columns: getEnrichmentColumns(category).map((column) => ({ ...column, category })),
+					inputFields,
+					defaultInputField: autoInput?.name ?? "",
+				};
+			});
+			setEnrichGroups(groups);
+			setEnrichInputField(groups.find((group) => group.defaultInputField)?.defaultInputField ?? "");
 		});
 	}, [enrichmentAvailable, objectName]);
 
@@ -432,12 +444,12 @@ export function AddColumnPopover({
 	}, [name, type, enumInput, objectName, handleClose, onCreated]);
 
 	const handleEnrichCreate = useCallback(async () => {
-		if (!selectedEnrichCol || !enrichCategory || !enrichInputField) return;
+		if (!selectedEnrichCol || !enrichInputField) return;
 		setSaving(true);
 		setError(null);
 		try {
 			const { buildEnrichmentMeta } = await import("@/lib/enrichment-columns");
-			const meta = buildEnrichmentMeta(enrichCategory, selectedEnrichCol, enrichInputField);
+			const meta = buildEnrichmentMeta(selectedEnrichCol.category, selectedEnrichCol, enrichInputField);
 			const existingOutputField = fieldsRef.current?.find(
 				(field) => field.name.toLowerCase() === selectedEnrichCol.label.toLowerCase(),
 			);
@@ -458,7 +470,7 @@ export function AddColumnPopover({
 					fieldId: existingOutputField.id,
 					fieldName: existingOutputField.name,
 					apolloPath: selectedEnrichCol.apolloPath,
-					category: enrichCategory,
+					category: selectedEnrichCol.category,
 					inputFieldName: enrichInputField,
 					scope: enrichScope,
 				});
@@ -492,7 +504,7 @@ export function AddColumnPopover({
 					fieldId: result.fieldId,
 					fieldName: selectedEnrichCol.label,
 					apolloPath: selectedEnrichCol.apolloPath,
-					category: enrichCategory,
+					category: selectedEnrichCol.category,
 					inputFieldName: enrichInputField,
 					scope: enrichScope,
 				});
@@ -502,9 +514,13 @@ export function AddColumnPopover({
 		} finally {
 			setSaving(false);
 		}
-	}, [selectedEnrichCol, enrichCategory, enrichInputField, enrichScope, objectName, handleClose, onCreated]);
+	}, [selectedEnrichCol, enrichInputField, enrichScope, objectName, handleClose, onCreated]);
 
-	const showEnrichment = enrichmentAvailable && enrichCategory && enrichColumns.length > 0;
+	const showEnrichment = enrichmentAvailable && enrichGroups.some((group) => group.columns.length > 0);
+	const selectedGroup = selectedEnrichCol
+		? enrichGroups.find((group) => group.category === selectedEnrichCol.category)
+		: null;
+	const selectedInputFields = selectedGroup?.inputFields ?? [];
 	const selectedOutputExists = selectedEnrichCol
 		? fieldsRef.current?.some((field) => field.name.toLowerCase() === selectedEnrichCol.label.toLowerCase()) === true
 		: false;
@@ -574,7 +590,7 @@ export function AddColumnPopover({
 										}}
 									>
 										<option value="">Select input column...</option>
-										{eligibleInputFields.map((f) => (
+										{selectedInputFields.map((f) => (
 											<option key={f.id} value={f.name}>{f.name}</option>
 										))}
 									</select>
@@ -720,21 +736,36 @@ export function AddColumnPopover({
 											<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z" /></svg>
 											Enrichment
 										</div>
-										<div className="grid grid-cols-2 gap-0.5">
-											{enrichColumns.map((col) => (
-												<button
-													key={col.key}
-													type="button"
-													onClick={() => setSelectedEnrichCol(col)}
-													className="flex items-center gap-2 px-2.5 py-1.5 rounded-xl text-xs transition-all text-left hover:opacity-80"
-													style={{
-														color: "var(--color-text)",
-														background: "transparent",
-													}}
-												>
-													<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ color: "var(--color-warning, #f59e0b)" }}><path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z" /></svg>
-													{col.label}
-												</button>
+										<div className="space-y-2">
+											{enrichGroups.map((group) => (
+												<div key={group.category}>
+													{enrichGroups.length > 1 && (
+														<div className="text-[10px] font-medium uppercase tracking-wider px-1 mb-1" style={{ color: "var(--color-text-muted)" }}>
+															{group.label}
+														</div>
+													)}
+													<div className="grid grid-cols-2 gap-0.5">
+														{group.columns.map((col) => (
+															<button
+																key={`${col.category}:${col.key}`}
+																type="button"
+																onClick={() => {
+																	setSelectedEnrichCol(col);
+																	setEnrichInputField(group.defaultInputField);
+																	setScopeMenuOpen(false);
+																}}
+																className="flex items-center gap-2 px-2.5 py-1.5 rounded-xl text-xs transition-all text-left hover:opacity-80"
+																style={{
+																	color: "var(--color-text)",
+																	background: "transparent",
+																}}
+															>
+																<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ color: "var(--color-warning, #f59e0b)" }}><path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z" /></svg>
+																{col.label}
+															</button>
+														))}
+													</div>
+												</div>
 											))}
 										</div>
 									</div>

--- a/apps/web/lib/enrichment-columns.test.ts
+++ b/apps/web/lib/enrichment-columns.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getEligibleInputFields } from "./enrichment-columns";
+import { getAvailableEnrichmentCategories, getEligibleInputFields } from "./enrichment-columns";
 
 describe("getEligibleInputFields", () => {
 	it("limits people enrichment inputs to email and LinkedIn fields", () => {
@@ -30,5 +30,30 @@ describe("getEligibleInputFields", () => {
 			"website",
 			"linkedin",
 		]);
+	});
+
+	it("preserves object-name category detection for built-in people and company tables", () => {
+		expect(getAvailableEnrichmentCategories("people", [])).toEqual(["people"]);
+		expect(getAvailableEnrichmentCategories("companies", [])).toEqual(["company"]);
+	});
+
+	it("makes enrichment available on generic tables based on identifier columns", () => {
+		expect(getAvailableEnrichmentCategories("investors", [
+			{ id: "email", name: "Email", type: "email" },
+		])).toEqual(["people"]);
+
+		expect(getAvailableEnrichmentCategories("accounts_list", [
+			{ id: "domain", name: "Domain", type: "text" },
+		])).toEqual(["company"]);
+	});
+
+	it("shows both enrichment categories on generic tables when LinkedIn is ambiguous or no identifiers exist yet", () => {
+		expect(getAvailableEnrichmentCategories("pipeline", [
+			{ id: "linkedin", name: "LinkedIn URL", type: "url" },
+		])).toEqual(["people", "company"]);
+
+		expect(getAvailableEnrichmentCategories("custom_table", [
+			{ id: "notes", name: "Notes", type: "text" },
+		])).toEqual(["people", "company"]);
 	});
 });

--- a/apps/web/lib/enrichment-columns.ts
+++ b/apps/web/lib/enrichment-columns.ts
@@ -5,6 +5,8 @@
 
 export type EnrichmentCategory = "people" | "company";
 
+export const ENRICHMENT_CATEGORIES: EnrichmentCategory[] = ["people", "company"];
+
 export type EnrichmentColumnDef = {
 	label: string;
 	key: string;
@@ -110,6 +112,19 @@ export function getEligibleInputFields(
 	fields: FieldCandidate[],
 ): FieldCandidate[] {
 	return fields.filter((field) => isEligibleInputField(category, field));
+}
+
+export function getAvailableEnrichmentCategories(
+	objectName: string,
+	fields: FieldCandidate[],
+): EnrichmentCategory[] {
+	const detected = detectEnrichmentCategory(objectName);
+	if (detected) return [detected];
+
+	const categoriesWithInputs = ENRICHMENT_CATEGORIES.filter(
+		(category) => getEligibleInputFields(category, fields).length > 0,
+	);
+	return categoriesWithInputs.length > 0 ? categoriesWithInputs : ENRICHMENT_CATEGORIES;
 }
 
 export function autoDetectInputField(


### PR DESCRIPTION
## Summary

- Makes the enrichment add-column flow available outside the built-in People and Companies tables.
- Keeps object-name detection for People/Companies so their existing UX stays focused.
- For generic tables, derives available enrichment categories from identifier columns (`Email`, `LinkedIn`, `Domain`/`Website`) and falls back to both People and Company enrichment if the table has no identifiers yet.

## Verification

- `npx tsc --noEmit`
- `npx vitest run lib/enrichment-columns.test.ts 'app/api/workspace/objects/[name]/enrich/route.test.ts'`

## Merge order

This PR is stacked on #233 and should be merged after #233 so main lands the enrichment fixes in the same order they were built.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands enrichment availability and changes how enrichment category/input fields are chosen, which could lead to incorrect enrichment metadata or UX confusion if category detection/heuristics misfire.
> 
> **Overview**
> Enables the *add-column enrichment* flow on non-`people`/`companies` tables by introducing `getAvailableEnrichmentCategories`, which falls back to showing both People and Company enrichment when no clear identifier columns exist.
> 
> Updates the `AddColumnPopover` enrichment UI to support multiple enrichment groups (People/Company), tie each enrichment column to its category, and switch the eligible input-column dropdown based on the selected enrichment option. Adds tests covering the new category-availability heuristics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cef1d256e7439374560d56ad43ff6d1f89dafe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->