### PR TITLE
fix: limit Composio app connections

### DIFF
--- a/apps/web/app/api/composio/connect/route.test.ts
+++ b/apps/web/app/api/composio/connect/route.test.ts
@@ -2,11 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { POST } from "./route";
 
 const {
+  fetchComposioConnectionsMock,
   initiateComposioConnectMock,
   resolveComposioApiKeyMock,
   resolveComposioEligibilityMock,
   resolveComposioGatewayUrlMock,
 } = vi.hoisted(() => ({
+  fetchComposioConnectionsMock: vi.fn(),
   initiateComposioConnectMock: vi.fn(),
   resolveComposioApiKeyMock: vi.fn(),
   resolveComposioEligibilityMock: vi.fn(),
@@ -14,6 +16,7 @@ const {
 }));
 
 vi.mock("@/lib/composio", () => ({
+  fetchComposioConnections: fetchComposioConnectionsMock,
   initiateComposioConnect: initiateComposioConnectMock,
   resolveComposioApiKey: resolveComposioApiKeyMock,
   resolveComposioEligibility: resolveComposioEligibilityMock,
@@ -33,6 +36,7 @@ describe("Composio connect API", () => {
       lockBadge: null,
     });
     resolveComposioGatewayUrlMock.mockReturnValue("https://gateway.example.com");
+    fetchComposioConnectionsMock.mockResolvedValue({ connections: [] });
     initiateComposioConnectMock.mockResolvedValue({
       redirect_url: "https://composio.example/connect/zoho",
     });
@@ -117,5 +121,65 @@ describe("Composio connect API", () => {
       "zoho",
       "https://real-org.sandbox.merseoriginals.com/api/composio/callback",
     );
+  });
+
+  it("rejects a second active connection for the same app", async () => {
+    fetchComposioConnectionsMock.mockResolvedValue({
+      connections: [
+        {
+          id: "ca_gmail_1",
+          toolkit_slug: "gmail",
+          toolkit_name: "Gmail",
+          status: "ACTIVE",
+          created_at: "2026-04-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const response = await POST(
+      new Request("http://localhost/api/composio/connect", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ toolkit: "gmail" }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "APP_ALREADY_CONNECTED",
+      connection_id: "ca_gmail_1",
+      toolkit: "gmail",
+    });
+    expect(initiateComposioConnectMock).not.toHaveBeenCalled();
+  });
+
+  it("treats Google Calendar connect slug aliases as the same app", async () => {
+    fetchComposioConnectionsMock.mockResolvedValue({
+      connections: [
+        {
+          id: "ca_calendar_1",
+          toolkit_slug: "google-calendar",
+          toolkit_name: "Google Calendar",
+          status: "ACTIVE",
+          created_at: "2026-04-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const response = await POST(
+      new Request("http://localhost/api/composio/connect", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ toolkit: "googlecalendar" }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "APP_ALREADY_CONNECTED",
+      connection_id: "ca_calendar_1",
+      toolkit: "google-calendar",
+    });
+    expect(initiateComposioConnectMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/composio/connect/route.ts
+++ b/apps/web/app/api/composio/connect/route.ts
@@ -1,9 +1,15 @@
 import {
+  fetchComposioConnections,
   initiateComposioConnect,
   resolveComposioApiKey,
   resolveComposioEligibility,
   resolveComposioGatewayUrl,
 } from "@/lib/composio";
+import {
+  extractComposioConnections,
+  normalizeComposioConnections,
+  normalizeComposioToolkitSlug,
+} from "@/lib/composio-client";
 import { resolveComposioConnectToolkitSlug } from "@/lib/composio-normalization";
 import { resolveAppPublicOrigin } from "@/lib/public-origin";
 
@@ -54,8 +60,25 @@ export async function POST(request: Request) {
   const gatewayUrl = resolveComposioGatewayUrl();
   const requestedToolkit = body.toolkit.trim();
   const connectToolkit = resolveComposioConnectToolkitSlug(requestedToolkit);
+  const normalizedToolkit = normalizeComposioToolkitSlug(connectToolkit);
 
   try {
+    const activeConnection = normalizeComposioConnections(
+      extractComposioConnections(await fetchComposioConnections(gatewayUrl, apiKey)),
+    ).find((connection) => connection.normalized_toolkit_slug === normalizedToolkit && connection.is_active);
+
+    if (activeConnection) {
+      return Response.json(
+        {
+          error: "This app is already connected. Disconnect it before connecting another account.",
+          code: "APP_ALREADY_CONNECTED",
+          connection_id: activeConnection.id,
+          toolkit: normalizedToolkit,
+        },
+        { status: 409 },
+      );
+    }
+
     const data = await initiateComposioConnect(
       gatewayUrl,
       apiKey,

--- a/apps/web/app/components/integrations/composio-apps-section.test.tsx
+++ b/apps/web/app/components/integrations/composio-apps-section.test.tsx
@@ -298,7 +298,8 @@ describe("ComposioAppsSection", () => {
     expect(screen.getByText("Connections")).toBeInTheDocument();
     expect(screen.getByText("Personal Gmail")).toBeInTheDocument();
     expect(screen.getByText("Work Gmail")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Connect another account" })).toBeInTheDocument();
+    expect(screen.getByText("One Gmail account can be connected at a time. Disconnect the current connection before connecting a different account.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Connect another account" })).not.toBeInTheDocument();
   });
 
   it("shows MCP repair bar only when status is unhealthy", async () => {

--- a/apps/web/app/components/integrations/composio-connect-modal.test.tsx
+++ b/apps/web/app/components/integrations/composio-connect-modal.test.tsx
@@ -56,7 +56,7 @@ describe("ComposioConnectModal", () => {
     }) as typeof fetch;
   });
 
-  it("renders existing accounts and connect-another-account actions", () => {
+  it("renders existing accounts without allowing another active account connection", () => {
     renderModal({
       connections: [
         {
@@ -105,7 +105,9 @@ describe("ComposioConnectModal", () => {
     expect(screen.getByText("Personal Gmail")).toBeInTheDocument();
     expect(screen.getByText("Work Gmail")).toBeInTheDocument();
     expect(screen.getAllByText("Same account reconnected")).toHaveLength(2);
-    expect(screen.getByRole("button", { name: "Connect another account" })).toBeInTheDocument();
+    expect(screen.getByText("One Gmail account can be connected at a time. Disconnect the current connection before connecting a different account.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Connect another account" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Connect Gmail" })).not.toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: "Disconnect" })).toHaveLength(2);
   });
 

--- a/apps/web/app/components/integrations/composio-connect-modal.tsx
+++ b/apps/web/app/components/integrations/composio-connect-modal.tsx
@@ -114,7 +114,7 @@ export function ComposioConnectModal({
   );
   const connected = activeConnections.length > 0;
   const primaryAction = preferredAction
-    ?? (connected ? "connect" : normalizedConnections.length > 0 ? "reconnect" : "connect");
+    ?? (normalizedConnections.length > 0 ? "reconnect" : "connect");
 
   const stopPopupPolling = useCallback(() => {
     if (popupPollRef.current !== null) {
@@ -174,6 +174,10 @@ export function ComposioConnectModal({
 
   const handleConnect = useCallback(async () => {
     if (!toolkit) return;
+    if (connected) {
+      setError(`Disconnect ${toolkit.name} before connecting a different account.`);
+      return;
+    }
     setConnecting(true);
     setError(null);
     clearPopupState();
@@ -215,7 +219,7 @@ export function ComposioConnectModal({
       setConnecting(false);
       setError(err instanceof Error ? err.message : "Failed to connect.");
     }
-  }, [clearPopupState, onConnectionChange, onOpenChange, stopPopupPolling, toolkit]);
+  }, [clearPopupState, connected, onConnectionChange, onOpenChange, stopPopupPolling, toolkit]);
 
   const handleDisconnect = useCallback(async (connectionId: string) => {
     setDisconnectingId(connectionId);
@@ -330,6 +334,18 @@ export function ComposioConnectModal({
 
           {normalizedConnections.length > 0 ? (
             <div className="space-y-2">
+              {connected && (
+                <div
+                  className="rounded-lg border px-3 py-2 text-[12px]"
+                  style={{
+                    borderColor: "var(--color-border)",
+                    background: "var(--color-surface-hover)",
+                    color: "var(--color-text-muted)",
+                  }}
+                >
+                  One {toolkit.name} account can be connected at a time. Disconnect the current connection before connecting a different account.
+                </div>
+              )}
               <div className="flex items-center justify-between gap-3">
                 <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
                   Connections
@@ -443,21 +459,21 @@ export function ComposioConnectModal({
           >
             Close
           </button>
-          <button
-            type="button"
-            className="rounded-full px-4 py-1.5 text-sm font-medium"
-            style={{ background: "var(--color-accent)", color: "#fff" }}
-            onClick={() => void handleConnect()}
-            disabled={connecting}
-          >
-            {connecting
-              ? "Waiting for authorization..."
-              : primaryAction === "reconnect"
-                ? `Reconnect ${toolkit.name}`
-                : connected
-                ? "Connect another account"
-                : `Connect ${toolkit.name}`}
-          </button>
+          {!connected && (
+            <button
+              type="button"
+              className="rounded-full px-4 py-1.5 text-sm font-medium"
+              style={{ background: "var(--color-accent)", color: "#fff" }}
+              onClick={() => void handleConnect()}
+              disabled={connecting}
+            >
+              {connecting
+                ? "Waiting for authorization..."
+                : primaryAction === "reconnect"
+                  ? `Reconnect ${toolkit.name}`
+                  : `Connect ${toolkit.name}`}
+            </button>
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/web/app/components/workspace/column-header-menu.test.tsx
+++ b/apps/web/app/components/workspace/column-header-menu.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AddColumnPopover } from "./column-header-menu";
+
+describe("AddColumnPopover", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "/api/workspace/enrichment-status") {
+				return new Response(JSON.stringify({ available: true }));
+			}
+			throw new Error(`Unexpected fetch: ${url}`);
+		}) as typeof fetch;
+	});
+
+	it("refreshes enrichment input options when fields change for the same object", async () => {
+		const user = userEvent.setup();
+		const fields = [{ id: "field_name", name: "Name", type: "text" }];
+		const { rerender } = render(
+			<AddColumnPopover
+				objectName="leads"
+				fields={fields}
+				enrichmentAvailable
+				onCreated={() => {}}
+			/>,
+		);
+
+		await user.click(screen.getByTitle("Add column"));
+		await user.click(await screen.findByRole("button", { name: "Full Name" }));
+
+		const inputSelect = screen.getByRole("combobox") as HTMLSelectElement;
+		expect(inputSelect).toHaveValue("");
+		expect(screen.queryByRole("option", { name: "Email" })).not.toBeInTheDocument();
+
+		rerender(
+			<AddColumnPopover
+				objectName="leads"
+				fields={[...fields, { id: "field_email", name: "Email", type: "email" }]}
+				enrichmentAvailable
+				onCreated={() => {}}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole("option", { name: "Email" })).toBeInTheDocument();
+		});
+		expect(inputSelect).toHaveValue("Email");
+		expect(screen.getByText(/Will enrich using.*Email.*column/)).toBeInTheDocument();
+	});
+});

--- a/apps/web/app/components/workspace/column-header-menu.tsx
+++ b/apps/web/app/components/workspace/column-header-menu.tsx
@@ -1,7 +1,15 @@
 "use client";
 
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import React, { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { createPortal } from "react-dom";
+import {
+	autoDetectInputField,
+	buildEnrichmentMeta,
+	getAvailableEnrichmentCategories,
+	getEligibleInputFields,
+	getEnrichmentColumns,
+	type EnrichmentCategory,
+} from "@/lib/enrichment-columns";
 import {
 	DropdownMenu,
 	DropdownMenuTrigger,
@@ -244,7 +252,6 @@ export function InlineRenameInput({
 /* ─── Add Column Popover ─── */
 
 type AddColumnField = { id: string; name: string; type: string };
-type EnrichmentCategory = "people" | "company";
 type EnrichmentColumnOption = {
 	label: string;
 	key: string;
@@ -306,7 +313,6 @@ export function AddColumnPopover({
 	// Enrichment state
 	const [selectedEnrichCol, setSelectedEnrichCol] = useState<EnrichmentColumnOption | null>(null);
 	const [enrichInputField, setEnrichInputField] = useState<string>("");
-	const [enrichGroups, setEnrichGroups] = useState<EnrichmentColumnGroup[]>([]);
 	const [enrichScope, setEnrichScope] = useState<EnrichmentStartPayload["scope"]>("all");
 	const [scopeMenuOpen, setScopeMenuOpen] = useState(false);
 
@@ -337,26 +343,36 @@ export function AddColumnPopover({
 	const inputRef = useRef<HTMLInputElement>(null);
 	const [position, setPosition] = useState({ top: 0, left: 0 });
 
-	// Load enrichment columns lazily
-	useEffect(() => {
-		if (!enrichmentAvailable) return;
-		import("@/lib/enrichment-columns").then(({ getAvailableEnrichmentCategories, getEnrichmentColumns, autoDetectInputField, getEligibleInputFields }) => {
-			const currentFields = fieldsRef.current ?? [];
-			const groups = getAvailableEnrichmentCategories(objectName, currentFields).map((category) => {
-				const inputFields = getEligibleInputFields(category, currentFields);
-				const autoInput = autoDetectInputField(category, currentFields);
-				return {
-					category,
-					label: category === "people" ? "People enrichment" : "Company enrichment",
-					columns: getEnrichmentColumns(category).map((column) => ({ ...column, category })),
-					inputFields,
-					defaultInputField: autoInput?.name ?? "",
-				};
-			});
-			setEnrichGroups(groups);
-			setEnrichInputField(groups.find((group) => group.defaultInputField)?.defaultInputField ?? "");
+	const enrichGroups = useMemo<EnrichmentColumnGroup[]>(() => {
+		const currentFields = fields ?? [];
+		return getAvailableEnrichmentCategories(objectName, currentFields).map((category) => {
+			const inputFields = getEligibleInputFields(category, currentFields);
+			const autoInput = autoDetectInputField(category, currentFields);
+			return {
+				category,
+				label: category === "people" ? "People enrichment" : "Company enrichment",
+				columns: getEnrichmentColumns(category).map((column) => ({ ...column, category })),
+				inputFields,
+				defaultInputField: autoInput?.name ?? "",
+			};
 		});
-	}, [enrichmentAvailable, objectName]);
+	}, [fields, objectName]);
+
+	useEffect(() => {
+		const group = selectedEnrichCol
+			? enrichGroups.find((candidate) => candidate.category === selectedEnrichCol.category)
+			: enrichGroups.find((candidate) => candidate.defaultInputField);
+		if (!group) {
+			if (enrichInputField) {
+				setEnrichInputField("");
+			}
+			return;
+		}
+		const currentInputStillValid = group.inputFields.some((field) => field.name === enrichInputField);
+		if (!currentInputStillValid && group.defaultInputField !== enrichInputField) {
+			setEnrichInputField(group.defaultInputField);
+		}
+	}, [enrichGroups, enrichInputField, selectedEnrichCol]);
 
 	const handleOpen = useCallback(() => {
 		const rect = triggerRef.current?.getBoundingClientRect();
@@ -448,7 +464,6 @@ export function AddColumnPopover({
 		setSaving(true);
 		setError(null);
 		try {
-			const { buildEnrichmentMeta } = await import("@/lib/enrichment-columns");
 			const meta = buildEnrichmentMeta(selectedEnrichCol.category, selectedEnrichCol, enrichInputField);
 			const existingOutputField = fieldsRef.current?.find(
 				(field) => field.name.toLowerCase() === selectedEnrichCol.label.toLowerCase(),


### PR DESCRIPTION
## Summary
- Block starting a second active Composio connection for the same app, including Google Calendar slug aliases.
- Remove the UI path that allowed connecting another account for an already-connected app.
- Recompute enrichment input options from the current fields prop and add a regression test for fields changing while the popover stays open.

## Test plan
- npx vitest run app/api/composio/connect/route.test.ts app/components/integrations/composio-connect-modal.test.tsx app/components/integrations/composio-apps-section.test.tsx app/components/workspace/column-header-menu.test.tsx
- npx tsc --noEmit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Composio connection initiation flow to hard-block starting a new connection when an active one already exists (including slug alias normalization), which could impact existing multi-account user workflows and relies on correct connection normalization.
> 
> **Overview**
> Prevents users from creating a *second active Composio connection* for the same app by having `POST /api/composio/connect` fetch and normalize existing connections, then return a `409` with `code: "APP_ALREADY_CONNECTED"` when an active match exists (including Google Calendar slug aliases).
> 
> Updates the integrations UI to remove the "connect another account" path when a toolkit is already connected, shows a one-account-at-a-time notice, and adds client-side guarding/error messaging in `ComposioConnectModal`.
> 
> Fixes `AddColumnPopover` enrichment options to recompute from the current `fields` prop (so options refresh while the popover stays open) and adds a regression test covering field updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 607b596c2cf39107e2f7be82ea885760f17ff3da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->