### PR TITLE
Fix company teams and select column controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ dist/protocol.schema.json
 # Generated at build time (bakes POSTHOG_KEY into the plugin)
 extensions/posthog-analytics/lib/build-env.js
 .cursor/debug-*.log
+.gstack/

--- a/apps/web/app/api/crm/companies/[id]/route.test.ts
+++ b/apps/web/app/api/crm/companies/[id]/route.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ONBOARDING_OBJECT_IDS } from "@/lib/workspace-schema-migrations";
+import { GET } from "./route";
+
+const { loadCrmFieldMapsMock, safeQueryMock } = vi.hoisted(() => ({
+  loadCrmFieldMapsMock: vi.fn(),
+  safeQueryMock: vi.fn(),
+}));
+
+vi.mock("@/lib/crm-queries", () => ({
+  buildEntryProjection: vi.fn((params: {
+    objectId: string;
+    aliasedFields: Array<{ name: string; alias: string }>;
+    whereSql?: string;
+  }) => {
+    const aliases = params.aliasedFields
+      .map(({ name, alias }) => `${name}:${alias}`)
+      .join(",");
+    return `projection object=${params.objectId} fields=${aliases} where=${params.whereSql ?? ""}`;
+  }),
+  buildLatestMessagePerThreadCte: vi.fn(() => null),
+  hydratePeopleByIds: vi.fn(async () => new Map()),
+  jsonArrayContains: (columnExpr: string, id: string) => {
+    const safeId = id.replace(/'/g, "''").replace(/"/g, '""');
+    return `${columnExpr} LIKE '%"${safeId}"%'`;
+  },
+  loadCrmFieldMaps: loadCrmFieldMapsMock,
+  safeQuery: safeQueryMock,
+  sqlString: (value: string) => `'${value.replace(/'/g, "''")}'`,
+}));
+
+const baseFieldMaps = {
+  people: {
+    "Full Name": "people_name",
+    "Email Address": "people_email",
+    Company: "people_company",
+    "Job Title": "people_job_title",
+    "Strength Score": "people_strength",
+    "Last Interaction At": "people_last_interaction",
+    "Avatar URL": "people_avatar",
+  },
+  company: {
+    "Company Name": "company_name",
+    Domain: "company_domain",
+    Website: "company_website",
+    Industry: "company_industry",
+    Type: "company_type",
+    Source: "company_source",
+    "Strength Score": "company_strength",
+    "Last Interaction At": "company_last_interaction",
+    Notes: "company_notes",
+  },
+  email_thread: {},
+  email_message: {},
+  calendar_event: {},
+  interaction: {},
+};
+
+describe("CRM company profile API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadCrmFieldMapsMock.mockResolvedValue(baseFieldMaps);
+  });
+
+  it("populates Team from the People.Company relation even when email domain does not match", async () => {
+    let peopleSql = "";
+    safeQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes(`object=${ONBOARDING_OBJECT_IDS.company}`)) {
+        return [{
+          entry_id: "comp_plaid_012",
+          name: "Plaid",
+          domain: "plaid.com",
+          website: "https://plaid.com",
+          strength_score: "0",
+        }];
+      }
+      if (sql.includes(`object=${ONBOARDING_OBJECT_IDS.people}`)) {
+        peopleSql = sql;
+        if (!sql.includes("sub.company_id = 'comp_plaid_012'")) {
+          return [];
+        }
+        return [{
+          entry_id: "ppl_zachperret_20",
+          name: "Zach Perret",
+          email: "zach@founder.example",
+          company_id: "comp_plaid_012",
+          job_title: "CEO",
+          strength_score: "12",
+          last_interaction_at: null,
+          avatar_url: null,
+        }];
+      }
+      return [];
+    });
+
+    const res = await GET(
+      new Request("http://localhost/api/crm/companies/comp_plaid_012"),
+      { params: Promise.resolve({ id: "comp_plaid_012" }) },
+    );
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.people).toHaveLength(1);
+    expect(json.people[0]).toMatchObject({
+      id: "ppl_zachperret_20",
+      name: "Zach Perret",
+      email: "zach@founder.example",
+      job_title: "CEO",
+    });
+    expect(json.summary.people_count).toBe(1);
+    expect(json.summary.strongest_contact).toBe("Zach Perret");
+    expect(peopleSql).toContain("Company:company_id");
+    expect(peopleSql).toContain("sub.company_id = 'comp_plaid_012'");
+    expect(peopleSql).toContain(`sub.company_id LIKE '%"comp_plaid_012"%'`);
+  });
+
+  it("normalizes URL-like company domains for the email-domain fallback", async () => {
+    loadCrmFieldMapsMock.mockResolvedValue({
+      ...baseFieldMaps,
+      people: {
+        ...baseFieldMaps.people,
+        Company: undefined,
+      },
+    });
+    safeQueryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes(`object=${ONBOARDING_OBJECT_IDS.company}`)) {
+        return [{
+          entry_id: "comp_plaid_012",
+          name: "Plaid",
+          domain: "https://plaid.com/about",
+          website: null,
+          strength_score: "0",
+        }];
+      }
+      if (sql.includes(`object=${ONBOARDING_OBJECT_IDS.people}`)) {
+        if (!sql.includes("LOWER(SUBSTR(sub.email, INSTR(sub.email, '@') + 1)) = 'plaid.com'")) {
+          return [];
+        }
+        return [{
+          entry_id: "ppl_domain_match",
+          name: "Domain Match",
+          email: "person@plaid.com",
+          job_title: "Operator",
+          strength_score: null,
+          last_interaction_at: null,
+          avatar_url: null,
+        }];
+      }
+      return [];
+    });
+
+    const res = await GET(
+      new Request("http://localhost/api/crm/companies/comp_plaid_012"),
+      { params: Promise.resolve({ id: "comp_plaid_012" }) },
+    );
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.people).toHaveLength(1);
+    expect(json.people[0]).toMatchObject({
+      id: "ppl_domain_match",
+      name: "Domain Match",
+      email: "person@plaid.com",
+    });
+  });
+});

--- a/apps/web/app/api/crm/companies/[id]/route.ts
+++ b/apps/web/app/api/crm/companies/[id]/route.ts
@@ -5,11 +5,12 @@ import {
   buildEntryProjection,
   buildLatestMessagePerThreadCte,
   hydratePeopleByIds,
+  jsonArrayContains,
   loadCrmFieldMaps,
   safeQuery,
   sqlString,
 } from "@/lib/crm-queries";
-import { deriveWebsite } from "@/lib/website-from-domain";
+import { deriveDisplayDomain, deriveWebsite } from "@/lib/website-from-domain";
 import { getConnectionStrengthBucket } from "@/lib/connection-strength-label";
 
 export const dynamic = "force-dynamic";
@@ -68,7 +69,7 @@ export async function GET(
     updated_at: raw.updated_at,
   };
 
-  // ─── 2. People at this company (match by domain on People.Email Address) ─
+  // ─── 2. People at this company ─────────────────────────────────────────
   type PersonRow = Record<string, string | null>;
   let people: Array<{
     id: string;
@@ -81,14 +82,32 @@ export async function GET(
     last_interaction_at: string | null;
     avatar_url: string | null;
   }> = [];
-  if (company.domain) {
-    const safeDomain = company.domain.replace(/'/g, "''").toLowerCase();
+  const companyDomain = deriveDisplayDomain(company.domain ?? company.website);
+  const peopleCompanyFieldId = fieldMaps.people["Company"];
+  const peoplePredicates: string[] = [];
+  if (peopleCompanyFieldId) {
+    peoplePredicates.push(
+      `sub.company_id = ${sqlString(company.id)}`,
+      jsonArrayContains("sub.company_id", company.id),
+    );
+  }
+  if (companyDomain) {
+    const domainSql = sqlString(companyDomain.toLowerCase());
+    const emailDomainSql = "LOWER(SUBSTR(sub.email, INSTR(sub.email, '@') + 1))";
+    peoplePredicates.push(
+      `${emailDomainSql} = ${domainSql}`,
+      `${emailDomainSql} LIKE '%.' || ${domainSql}`,
+    );
+  }
+
+  if (peoplePredicates.length > 0) {
     const peopleProjection = buildEntryProjection({
       objectId: ONBOARDING_OBJECT_IDS.people,
       fieldMap: fieldMaps.people,
       aliasedFields: [
         { name: "Full Name", alias: "name" },
         { name: "Email Address", alias: "email" },
+        { name: "Company", alias: "company_id" },
         { name: "Job Title", alias: "job_title" },
         { name: "Strength Score", alias: "strength_score" },
         { name: "Last Interaction At", alias: "last_interaction_at" },
@@ -105,8 +124,7 @@ export async function GET(
       SELECT * FROM (
         SELECT DISTINCT ON (COALESCE(LOWER(TRIM(sub.email)), sub.entry_id)) sub.*
         FROM (${peopleProjection}) sub
-        WHERE LOWER(SUBSTR(sub.email, INSTR(sub.email, '@') + 1)) = '${safeDomain}'
-           OR LOWER(SUBSTR(sub.email, INSTR(sub.email, '@') + 1)) LIKE '%.${safeDomain}'
+        WHERE ${peoplePredicates.map((predicate) => `(${predicate})`).join("\n           OR ")}
         ORDER BY COALESCE(LOWER(TRIM(sub.email)), sub.entry_id),
                  TRY_CAST(sub.strength_score AS DOUBLE) DESC NULLS LAST,
                  sub.last_interaction_at DESC NULLS LAST

--- a/apps/web/app/api/workspace/objects/[name]/fields/[fieldId]/route.test.ts
+++ b/apps/web/app/api/workspace/objects/[name]/fields/[fieldId]/route.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PATCH } from "./route";
+
+const {
+	duckdbExecOnFileMock,
+	duckdbQueryOnFileMock,
+	findDuckDBForObjectMock,
+	findObjectDirMock,
+	readObjectYamlMock,
+	writeObjectYamlMock,
+} = vi.hoisted(() => ({
+	duckdbExecOnFileMock: vi.fn(),
+	duckdbQueryOnFileMock: vi.fn(),
+	findDuckDBForObjectMock: vi.fn(),
+	findObjectDirMock: vi.fn(),
+	readObjectYamlMock: vi.fn(),
+	writeObjectYamlMock: vi.fn(),
+}));
+
+vi.mock("@/lib/workspace", () => ({
+	duckdbExecOnFile: duckdbExecOnFileMock,
+	duckdbQueryOnFile: duckdbQueryOnFileMock,
+	findDuckDBForObject: findDuckDBForObjectMock,
+	findObjectDir: findObjectDirMock,
+	pivotViewIdentifier: (objectName: string) => `"v_${objectName}"`,
+	readObjectYaml: readObjectYamlMock,
+	writeObjectYaml: writeObjectYamlMock,
+}));
+
+describe("workspace field metadata API", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		findDuckDBForObjectMock.mockReturnValue("/ws/workspace.duckdb");
+		findObjectDirMock.mockReturnValue("/ws/leads");
+		readObjectYamlMock.mockReturnValue({});
+		duckdbExecOnFileMock.mockReturnValue(true);
+		duckdbQueryOnFileMock.mockImplementation((_dbFile: string, sql: string) => {
+			if (sql.includes("SELECT id FROM objects")) {
+				return [{ id: "obj_leads" }];
+			}
+			if (sql.includes("SELECT type, enum_values FROM fields")) {
+				return [{
+					type: "enum",
+					enum_values: JSON.stringify(["Lead", "Customer", "Churned"]),
+				}];
+			}
+			if (sql.includes("SELECT name FROM fields")) {
+				return [{ name: "Status" }];
+			}
+			if (sql.includes("SELECT name, type, required, enum_values")) {
+				return [{
+					name: "Status",
+					type: "enum",
+					required: false,
+					enum_values: JSON.stringify(["Lead", "Customer"]),
+					default_value: null,
+					sort_order: 0,
+				}];
+			}
+			if (sql.includes("SELECT COUNT(*) as cnt FROM entries")) {
+				return [{ cnt: 2 }];
+			}
+			return [];
+		});
+	});
+
+	it("updates select options and clears removed values from entries", async () => {
+		const res = await PATCH(
+			new Request("http://localhost/api/workspace/objects/leads/fields/status", {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ enum_values: ["Lead", "Customer"] }),
+			}),
+			{ params: Promise.resolve({ name: "leads", fieldId: "status" }) },
+		);
+
+		expect(res.status).toBe(200);
+		expect(duckdbExecOnFileMock).toHaveBeenCalledWith(
+			"/ws/workspace.duckdb",
+			"UPDATE fields SET enum_values = '[\"Lead\",\"Customer\"]'::JSON WHERE id = 'status'",
+		);
+		expect(duckdbExecOnFileMock).toHaveBeenCalledWith(
+			"/ws/workspace.duckdb",
+			"UPDATE entry_fields SET value = NULL WHERE field_id = 'status' AND value IN ('Churned')",
+		);
+		expect(writeObjectYamlMock).toHaveBeenCalledWith(
+			"/ws/leads",
+			expect.objectContaining({
+				entry_count: 2,
+				fields: [
+					{
+						name: "Status",
+						type: "enum",
+						enum_values: ["Lead", "Customer"],
+					},
+				],
+			}),
+		);
+	});
+
+	it("renames existing entry values when exactly one select option changes", async () => {
+		const res = await PATCH(
+			new Request("http://localhost/api/workspace/objects/leads/fields/status", {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ enum_values: ["Prospect", "Customer", "Churned"] }),
+			}),
+			{ params: Promise.resolve({ name: "leads", fieldId: "status" }) },
+		);
+
+		expect(res.status).toBe(200);
+		expect(duckdbExecOnFileMock).toHaveBeenCalledWith(
+			"/ws/workspace.duckdb",
+			"UPDATE entry_fields SET value = 'Prospect' WHERE field_id = 'status' AND value = 'Lead'",
+		);
+		expect(duckdbExecOnFileMock).not.toHaveBeenCalledWith(
+			"/ws/workspace.duckdb",
+			expect.stringContaining("value = NULL"),
+		);
+	});
+
+	it("rejects duplicate select options", async () => {
+		const res = await PATCH(
+			new Request("http://localhost/api/workspace/objects/leads/fields/status", {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ enum_values: ["Lead", "lead"] }),
+			}),
+			{ params: Promise.resolve({ name: "leads", fieldId: "status" }) },
+		);
+
+		expect(res.status).toBe(400);
+		await expect(res.json()).resolves.toMatchObject({
+			error: "enum_values must be an array of unique strings",
+		});
+	});
+});

--- a/apps/web/app/api/workspace/objects/[name]/fields/[fieldId]/route.ts
+++ b/apps/web/app/api/workspace/objects/[name]/fields/[fieldId]/route.ts
@@ -18,7 +18,7 @@ function sqlEscape(s: string): string {
 /**
  * PATCH /api/workspace/objects/[name]/fields/[fieldId]
  * Update field metadata.
- * Body: { name?: string, default_value?: string | null }
+ * Body: { name?: string, default_value?: string | null, enum_values?: string[] }
  */
 export async function PATCH(
 	req: Request,
@@ -47,19 +47,28 @@ export async function PATCH(
 	const newName = typeof body.name === "string" ? body.name.trim() : null;
 	const hasDefaultValue = Object.prototype.hasOwnProperty.call(body, "default_value");
 	const defaultValue: unknown = body.default_value;
+	const hasEnumValues = Object.prototype.hasOwnProperty.call(body, "enum_values");
+	const enumValues = hasEnumValues ? normalizeEnumValues(body.enum_values) : null;
 
 	if (
 		(!newName || newName.length === 0)
 		&& !hasDefaultValue
+		&& !hasEnumValues
 	) {
 		return Response.json(
-			{ error: "Name or default_value is required" },
+			{ error: "Name, default_value, or enum_values is required" },
 			{ status: 400 },
 		);
 	}
 	if (hasDefaultValue && defaultValue !== null && typeof defaultValue !== "string") {
 		return Response.json(
 			{ error: "default_value must be a string or null" },
+			{ status: 400 },
+		);
+	}
+	if (hasEnumValues && !enumValues) {
+		return Response.json(
+			{ error: "enum_values must be an array of unique strings" },
 			{ status: 400 },
 		);
 	}
@@ -77,13 +86,20 @@ export async function PATCH(
 	const objectId = objects[0].id;
 
 	// Validate field exists and belongs to this object
-	const fieldExists = duckdbQueryOnFile<{ cnt: number }>(dbFile,
-		`SELECT COUNT(*) as cnt FROM fields WHERE id = '${sqlEscape(fieldId)}' AND object_id = '${sqlEscape(objectId)}'`,
+	const fields = duckdbQueryOnFile<{ type: string; enum_values: string | null }>(dbFile,
+		`SELECT type, enum_values FROM fields WHERE id = '${sqlEscape(fieldId)}' AND object_id = '${sqlEscape(objectId)}'`,
 	);
-	if (!fieldExists[0] || fieldExists[0].cnt === 0) {
+	if (fields.length === 0) {
 		return Response.json(
 			{ error: "Field not found" },
 			{ status: 404 },
+		);
+	}
+	const field = fields[0];
+	if (hasEnumValues && field.type !== "enum") {
+		return Response.json(
+			{ error: "enum_values can only be updated for select fields" },
+			{ status: 400 },
 		);
 	}
 
@@ -107,6 +123,9 @@ export async function PATCH(
 	if (hasDefaultValue) {
 		updates.push(defaultValue === null ? "default_value = NULL" : `default_value = '${sqlEscape(defaultValue as string)}'`);
 	}
+	if (hasEnumValues && enumValues) {
+		updates.push(`enum_values = '${sqlEscape(JSON.stringify(enumValues))}'::JSON`);
+	}
 
 	const ok = duckdbExecOnFile(dbFile,
 		`UPDATE fields SET ${updates.join(", ")} WHERE id = '${sqlEscape(fieldId)}'`,
@@ -117,6 +136,24 @@ export async function PATCH(
 			{ error: "Failed to rename field" },
 			{ status: 500 },
 		);
+	}
+
+	if (hasEnumValues && enumValues) {
+		const changes = getEnumValueChanges(field.enum_values, enumValues);
+		if (
+			changes.removed.length === 1
+			&& changes.added.length === 1
+			&& changes.currentLength === enumValues.length
+		) {
+			duckdbExecOnFile(dbFile,
+				`UPDATE entry_fields SET value = '${sqlEscape(changes.added[0])}' WHERE field_id = '${sqlEscape(fieldId)}' AND value = '${sqlEscape(changes.removed[0])}'`,
+			);
+		} else if (changes.removed.length > 0) {
+			const removedList = changes.removed.map((value) => `'${sqlEscape(value)}'`).join(", ");
+			duckdbExecOnFile(dbFile,
+				`UPDATE entry_fields SET value = NULL WHERE field_id = '${sqlEscape(fieldId)}' AND value IN (${removedList})`,
+			);
+		}
 	}
 
 	regeneratePivotView(dbFile, name, objectId);
@@ -194,6 +231,56 @@ export async function DELETE(
 }
 
 /* ─── Shared helpers ─── */
+
+function normalizeEnumValues(value: unknown): string[] | null {
+	if (!Array.isArray(value)) {
+		return null;
+	}
+	const seen = new Set<string>();
+	const normalized: string[] = [];
+	for (const item of value) {
+		if (typeof item !== "string") {
+			return null;
+		}
+		const trimmed = item.trim();
+		if (!trimmed) {
+			continue;
+		}
+		const key = trimmed.toLocaleLowerCase();
+		if (seen.has(key)) {
+			return null;
+		}
+		seen.add(key);
+		normalized.push(trimmed);
+	}
+	return normalized;
+}
+
+function getEnumValueChanges(
+	currentJson: string | null,
+	nextValues: string[],
+): { added: string[]; removed: string[]; currentLength: number } {
+	if (!currentJson) {
+		return { added: nextValues, removed: [], currentLength: 0 };
+	}
+	let currentValues: unknown;
+	try {
+		currentValues = JSON.parse(currentJson);
+	} catch {
+		return { added: nextValues, removed: [], currentLength: 0 };
+	}
+	if (!Array.isArray(currentValues)) {
+		return { added: nextValues, removed: [], currentLength: 0 };
+	}
+	const currentStrings = currentValues.filter((value): value is string => typeof value === "string");
+	const nextSet = new Set(nextValues);
+	const currentSet = new Set(currentStrings);
+	return {
+		added: nextValues.filter((value) => !currentSet.has(value)),
+		removed: currentStrings.filter((value) => !nextSet.has(value)),
+		currentLength: currentStrings.length,
+	};
+}
 
 function regeneratePivotView(dbFile: string, objectName: string, objectId: string) {
 	const fields = duckdbQueryOnFile<{ name: string }>(

--- a/apps/web/app/components/workspace/column-header-menu.test.tsx
+++ b/apps/web/app/components/workspace/column-header-menu.test.tsx
@@ -1,15 +1,15 @@
 // @vitest-environment jsdom
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { AddColumnPopover } from "./column-header-menu";
+import { AddColumnPopover, SelectOptionsEditor } from "./column-header-menu";
 
 describe("AddColumnPopover", () => {
 	beforeEach(() => {
 		vi.restoreAllMocks();
 		global.fetch = vi.fn(async (input: RequestInfo | URL) => {
-			const url = typeof input === "string" ? input : input.toString();
+			const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
 			if (url === "/api/workspace/enrichment-status") {
 				return new Response(JSON.stringify({ available: true }));
 			}
@@ -32,7 +32,7 @@ describe("AddColumnPopover", () => {
 		await user.click(screen.getByTitle("Add column"));
 		await user.click(await screen.findByRole("button", { name: "Full Name" }));
 
-		const inputSelect = screen.getByRole("combobox") as HTMLSelectElement;
+		const inputSelect = screen.getByRole("combobox");
 		expect(inputSelect).toHaveValue("");
 		expect(screen.queryByRole("option", { name: "Email" })).not.toBeInTheDocument();
 
@@ -50,5 +50,53 @@ describe("AddColumnPopover", () => {
 		});
 		expect(inputSelect).toHaveValue("Email");
 		expect(screen.getByText(/Will enrich using.*Email.*column/)).toBeInTheDocument();
+	});
+
+	it("does not render the old column-name search field in the add-column popover", async () => {
+		const user = userEvent.setup();
+		render(
+			<AddColumnPopover
+				objectName="leads"
+				fields={[]}
+				enrichmentAvailable={false}
+				onCreated={() => {}}
+			/>,
+		);
+
+		await user.click(screen.getByTitle("Add column"));
+
+		expect(screen.queryByPlaceholderText("Column name...")).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Text" })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Create" })).toBeEnabled();
+	});
+});
+
+describe("SelectOptionsEditor", () => {
+	it("lets select fields add, edit, and remove options from the header menu", async () => {
+		const user = userEvent.setup();
+		const onOptionsUpdate = vi.fn(async () => {});
+
+		render(
+			<SelectOptionsEditor
+				values={["Lead", "Customer"]}
+				onSave={onOptionsUpdate}
+			/>,
+		);
+
+		expect(await screen.findByText("Options")).toBeInTheDocument();
+
+		await user.type(screen.getByPlaceholderText("Add option..."), "Qualified");
+		await user.click(screen.getByRole("button", { name: "Add option" }));
+		expect(onOptionsUpdate).toHaveBeenLastCalledWith(["Lead", "Customer", "Qualified"]);
+
+		const leadInput = screen.getByLabelText("Edit option Lead");
+		fireEvent.change(leadInput, { target: { value: "Prospect" } });
+		fireEvent.click(screen.getByRole("button", { name: "Save option Prospect" }));
+		await waitFor(() => {
+			expect(onOptionsUpdate).toHaveBeenLastCalledWith(["Prospect", "Customer", "Qualified"]);
+		});
+
+		await user.click(screen.getByRole("button", { name: "Remove option Customer" }));
+		expect(onOptionsUpdate).toHaveBeenLastCalledWith(["Prospect", "Qualified"]);
 	});
 });

--- a/apps/web/app/components/workspace/column-header-menu.tsx
+++ b/apps/web/app/components/workspace/column-header-menu.tsx
@@ -83,12 +83,13 @@ export function FieldTypeIcon({ type, size = 14, className }: { type: string; si
 /* ─── Column Header Menu ─── */
 
 export type ColumnHeaderMenuProps = {
-	field: { id: string; name: string; type: string; default_value?: string };
+	field: { id: string; name: string; type: string; default_value?: string; enum_values?: string[] };
 	sortDirection: "asc" | "desc" | false;
 	onSort: (desc: boolean) => void;
 	onHide: () => void;
 	onRename: () => void;
 	onDelete: () => void;
+	onOptionsUpdate?: (values: string[]) => Promise<void>;
 	canMoveLeft: boolean;
 	canMoveRight: boolean;
 	onMoveLeft: () => void;
@@ -101,7 +102,7 @@ export type ColumnHeaderMenuProps = {
 
 export function ColumnHeaderMenu({
 	field, sortDirection, onSort, onHide, onRename, onDelete,
-	canMoveLeft, canMoveRight, onMoveLeft, onMoveRight, onReEnrich,
+	canMoveLeft, canMoveRight, onMoveLeft, onMoveRight, onReEnrich, onOptionsUpdate,
 	open: controlledOpen, onOpenChange,
 }: ColumnHeaderMenuProps) {
 	const isEnrichment = (() => {
@@ -128,7 +129,7 @@ export function ColumnHeaderMenu({
 					<path d="m6 9 6 6 6-6" />
 				</svg>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent align="start" sideOffset={6} className="min-w-[180px]">
+			<DropdownMenuContent align="start" sideOffset={6} className={field.type === "enum" ? "min-w-[260px]" : "min-w-[180px]"}>
 				<div className="flex items-center gap-2 px-2.5 py-1.5 text-xs normal-case tracking-normal" style={{ color: "var(--color-text-muted)" }}>
 					<FieldTypeIcon type={field.type} size={14} className="shrink-0" />
 					<span className="font-medium">{fieldTypeLabel(field.type)}</span>
@@ -141,6 +142,15 @@ export function ColumnHeaderMenu({
 					<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" /></svg>
 					Rename
 				</DropdownMenuItem>
+				{field.type === "enum" && onOptionsUpdate && (
+					<>
+						<DropdownMenuSeparator />
+						<SelectOptionsEditor
+							values={field.enum_values ?? []}
+							onSave={onOptionsUpdate}
+						/>
+					</>
+				)}
 				{isEnrichment && onReEnrich && (
 					<>
 						<DropdownMenuSeparator />
@@ -195,6 +205,194 @@ export function ColumnHeaderMenu({
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);
+}
+
+export function SelectOptionsEditor({
+	values,
+	onSave,
+}: {
+	values: string[];
+	onSave: (values: string[]) => Promise<void>;
+}) {
+	const [options, setOptions] = useState<string[]>(values);
+	const [draft, setDraft] = useState("");
+	const [saving, setSaving] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		setOptions(values);
+		setError(null);
+	}, [values]);
+
+	const saveOptions = useCallback(async (nextValues: string[]) => {
+		const normalized = normalizeOptionList(nextValues);
+		if (!normalized.ok) {
+			setError(normalized.error);
+			return false;
+		}
+		setSaving(true);
+		setError(null);
+		try {
+			await onSave(normalized.values);
+			setOptions(normalized.values);
+			return true;
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Failed to save options");
+			return false;
+		} finally {
+			setSaving(false);
+		}
+	}, [onSave]);
+
+	const addDraft = useCallback(async () => {
+		const next = draft.trim();
+		if (!next) {
+			return;
+		}
+		const didSave = await saveOptions([...options, next]);
+		if (didSave) {
+			setDraft("");
+		}
+	}, [draft, options, saveOptions]);
+
+	const renameOption = useCallback(async (index: number, nextValue: string) => {
+		const next = [...options];
+		next[index] = nextValue;
+		await saveOptions(next);
+	}, [options, saveOptions]);
+
+	const removeOption = useCallback((index: number) => {
+		void saveOptions(options.filter((_, candidateIndex) => candidateIndex !== index));
+	}, [options, saveOptions]);
+
+	return (
+		<div
+			className="px-2.5 py-2"
+			onClick={(e) => e.stopPropagation()}
+			onPointerDown={(e) => e.stopPropagation()}
+			onKeyDown={(e) => e.stopPropagation()}
+		>
+			<div className="mb-1.5 flex items-center justify-between gap-2">
+				<span className="text-[10px] font-medium uppercase tracking-wider" style={{ color: "var(--color-text-muted)" }}>
+					Options
+				</span>
+				{saving && (
+					<span className="text-[10px]" style={{ color: "var(--color-text-muted)" }}>
+						Saving...
+					</span>
+				)}
+			</div>
+			<div className="space-y-1">
+				{options.length === 0 && (
+					<div className="px-2 py-1.5 text-xs rounded-lg" style={{ color: "var(--color-text-muted)", background: "var(--color-surface)" }}>
+						No options yet
+					</div>
+				)}
+				{options.map((option, index) => (
+					<div key={`${option}:${index}`} className="flex items-center gap-1">
+						<input
+							value={option}
+							disabled={saving}
+							onChange={(e) => {
+								const next = [...options];
+								next[index] = e.target.value;
+								setOptions(next);
+							}}
+							onBlur={(e) => void renameOption(index, e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") {
+									e.preventDefault();
+									void renameOption(index, e.currentTarget.value);
+								}
+							}}
+							className="min-w-0 flex-1 rounded-full px-2 py-1 text-xs outline-none"
+							style={{
+								background: "var(--color-surface)",
+								color: "var(--color-text)",
+								border: "1px solid var(--color-border)",
+							}}
+							aria-label={`Edit option ${option}`}
+						/>
+						<button
+							type="button"
+							disabled={saving}
+							onClick={() => void renameOption(index, option)}
+							className="flex h-7 w-7 items-center justify-center rounded-full transition-colors disabled:opacity-40 hover:opacity-70"
+							style={{ color: "var(--color-text-muted)" }}
+							aria-label={`Save option ${option}`}
+						>
+							<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6 9 17l-5-5" /></svg>
+						</button>
+						<button
+							type="button"
+							disabled={saving}
+							onClick={() => removeOption(index)}
+							className="flex h-7 w-7 items-center justify-center rounded-full transition-colors disabled:opacity-40 hover:opacity-70"
+							style={{ color: "var(--color-text-muted)" }}
+							aria-label={`Remove option ${option}`}
+						>
+							<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M18 6 6 18" /><path d="m6 6 12 12" /></svg>
+						</button>
+					</div>
+				))}
+			</div>
+			<div className="mt-1.5 flex items-center gap-1">
+				<input
+					value={draft}
+					disabled={saving}
+					onChange={(e) => setDraft(e.target.value)}
+					onKeyDown={(e) => {
+						if (e.key === "Enter") {
+							e.preventDefault();
+							void addDraft();
+						}
+					}}
+					placeholder="Add option..."
+					className="min-w-0 flex-1 rounded-full px-2 py-1 text-xs outline-none"
+					style={{
+						background: "var(--color-surface)",
+						color: "var(--color-text)",
+						border: "1px solid var(--color-border)",
+					}}
+				/>
+				<button
+					type="button"
+					disabled={saving || !draft.trim()}
+					onClick={() => void addDraft()}
+					className="flex h-7 w-7 items-center justify-center rounded-full text-xs font-medium transition-colors disabled:opacity-40"
+					style={{ background: "var(--color-accent)", color: "white" }}
+					aria-label="Add option"
+				>
+					<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 5v14" /><path d="M5 12h14" /></svg>
+				</button>
+			</div>
+			{error && (
+				<p className="mt-1.5 px-1 text-[11px]" style={{ color: "var(--color-error)" }}>
+					{error}
+				</p>
+			)}
+		</div>
+	);
+}
+
+function normalizeOptionList(values: string[]):
+	| { ok: true; values: string[] }
+	| { ok: false; error: string } {
+	const seen = new Set<string>();
+	const normalized: string[] = [];
+	for (const value of values) {
+		const trimmed = value.trim();
+		if (!trimmed) {
+			continue;
+		}
+		const key = trimmed.toLocaleLowerCase();
+		if (seen.has(key)) {
+			return { ok: false, error: "Options must be unique" };
+		}
+		seen.add(key);
+		normalized.push(trimmed);
+	}
+	return { ok: true, values: normalized };
 }
 
 /* ─── Inline Rename Input ─── */
@@ -290,6 +488,18 @@ function enrichScopeButtonLabel(scope: EnrichmentStartPayload["scope"]): string 
 	return ENRICH_SCOPE_OPTIONS.find((option) => option.value === scope)?.buttonLabel ?? "all";
 }
 
+function nextDefaultFieldName(baseName: string, fields: AddColumnField[] | undefined): string {
+	const existingNames = new Set((fields ?? []).map((field) => field.name.toLocaleLowerCase()));
+	if (!existingNames.has(baseName.toLocaleLowerCase())) {
+		return baseName;
+	}
+	let index = 2;
+	while (existingNames.has(`${baseName} ${index}`.toLocaleLowerCase())) {
+		index++;
+	}
+	return `${baseName} ${index}`;
+}
+
 export function AddColumnPopover({
 	objectName,
 	onCreated,
@@ -304,7 +514,6 @@ export function AddColumnPopover({
 	onEnrichmentStart?: (payload: EnrichmentStartPayload) => void;
 }) {
 	const [open, setOpen] = useState(false);
-	const [name, setName] = useState("");
 	const [type, setType] = useState("text");
 	const [enumInput, setEnumInput] = useState("");
 	const [saving, setSaving] = useState(false);
@@ -340,7 +549,6 @@ export function AddColumnPopover({
 
 	const triggerRef = useRef<HTMLButtonElement>(null);
 	const panelRef = useRef<HTMLDivElement>(null);
-	const inputRef = useRef<HTMLInputElement>(null);
 	const [position, setPosition] = useState({ top: 0, left: 0 });
 
 	const enrichGroups = useMemo<EnrichmentColumnGroup[]>(() => {
@@ -385,7 +593,6 @@ export function AddColumnPopover({
 			setPosition({ top: rect.bottom + 6, left });
 		}
 		setOpen(true);
-		setName("");
 		setType("text");
 		setEnumInput("");
 		setError(null);
@@ -400,13 +607,6 @@ export function AddColumnPopover({
 		setSelectedEnrichCol(null);
 		setScopeMenuOpen(false);
 	}, []);
-
-	useEffect(() => {
-		if (open && !selectedEnrichCol) {
-			const timer = setTimeout(() => inputRef.current?.focus(), 50);
-			return () => clearTimeout(timer);
-		}
-	}, [open, selectedEnrichCol]);
 
 	useEffect(() => {
 		if (!open) return;
@@ -430,8 +630,8 @@ export function AddColumnPopover({
 	}, [open, handleClose]);
 
 	const handleCreate = useCallback(async () => {
-		if (!name.trim()) return;
-		const body: Record<string, unknown> = { name: name.trim(), type };
+		const fieldName = nextDefaultFieldName(fieldTypeLabel(type), fieldsRef.current);
+		const body: Record<string, unknown> = { name: fieldName, type };
 		if (type === "enum") {
 			const vals = enumInput.split(",").map((s) => s.trim()).filter(Boolean);
 			if (vals.length === 0) { setError("Add at least one option"); return; }
@@ -457,7 +657,7 @@ export function AddColumnPopover({
 		} finally {
 			setSaving(false);
 		}
-	}, [name, type, enumInput, objectName, handleClose, onCreated]);
+	}, [type, enumInput, objectName, handleClose, onCreated]);
 
 	const handleEnrichCreate = useCallback(async () => {
 		if (!selectedEnrichCol || !enrichInputField) return;
@@ -698,27 +898,6 @@ export function AddColumnPopover({
 					) : (
 						/* Standard column creation view */
 						<>
-							<div className="p-3 pb-2" style={{ borderBottom: "1px solid var(--color-border)" }}>
-								<input
-									ref={inputRef}
-									type="text"
-									value={name}
-									onChange={(e) => setName(e.target.value)}
-									onKeyDown={(e) => {
-										e.stopPropagation();
-										if (e.key === "Enter" && name.trim()) { void handleCreate(); }
-										if (e.key === "Escape") { handleClose(); }
-									}}
-									placeholder="Column name..."
-									className="w-full px-2.5 py-1.5 text-sm rounded-lg outline-none"
-									style={{
-										background: "var(--color-surface)",
-										color: "var(--color-text)",
-										border: "1px solid var(--color-border)",
-									}}
-								/>
-							</div>
-
 							<div className="flex-1 overflow-y-auto">
 								<div className="p-2">
 									<div className="text-[10px] font-medium uppercase tracking-wider px-1 mb-1.5" style={{ color: "var(--color-text-muted)" }}>
@@ -795,7 +974,7 @@ export function AddColumnPopover({
 										onChange={(e) => setEnumInput(e.target.value)}
 										onKeyDown={(e) => {
 											e.stopPropagation();
-											if (e.key === "Enter" && name.trim()) { void handleCreate(); }
+											if (e.key === "Enter") { void handleCreate(); }
 										}}
 										placeholder="Options (comma-separated)"
 										className="w-full px-2.5 py-1.5 text-sm rounded-lg outline-none"
@@ -807,6 +986,10 @@ export function AddColumnPopover({
 									/>
 								</div>
 							)}
+
+							<div className="px-3 pb-2 text-[11px]" style={{ color: "var(--color-text-muted)" }}>
+								Creates &ldquo;{nextDefaultFieldName(fieldTypeLabel(type), fieldsRef.current)}&rdquo;. Rename it from the column menu after creating.
+							</div>
 
 							{error && (
 								<div className="px-3 pb-2">
@@ -826,7 +1009,7 @@ export function AddColumnPopover({
 								<button
 									type="button"
 									onClick={() => void handleCreate()}
-									disabled={saving || !name.trim()}
+									disabled={saving || (type === "enum" && enumInput.split(",").map((s) => s.trim()).filter(Boolean).length === 0)}
 									className="px-3 py-1.5 text-xs font-medium rounded-lg transition-colors disabled:opacity-40"
 									style={{ background: "var(--color-accent)", color: "white" }}
 								>

--- a/apps/web/app/components/workspace/object-table.tsx
+++ b/apps/web/app/components/workspace/object-table.tsx
@@ -1056,6 +1056,22 @@ export function ObjectTable({
 		setRenamingFieldId(null);
 	}, [objectName, onRefresh]);
 
+	const handleUpdateColumnOptions = useCallback(async (fieldId: string, values: string[]) => {
+		const res = await fetch(
+			`/api/workspace/objects/${encodeURIComponent(objectName)}/fields/${encodeURIComponent(fieldId)}`,
+			{
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ enum_values: values }),
+			},
+		);
+		if (!res.ok) {
+			const body = (await res.json().catch(() => ({}))) as { error?: string };
+			throw new Error(body.error ?? `HTTP ${res.status}`);
+		}
+		onRefresh?.();
+	}, [objectName, onRefresh]);
+
 	const handleDeleteColumn = useCallback((fieldId: string, fieldName: string) => {
 		setConfirmState({
 			open: true,
@@ -1148,6 +1164,7 @@ export function ObjectTable({
 								onHide={() => column.toggleVisibility(false)}
 								onRename={() => setRenamingFieldId(field.id)}
 								onDelete={() => handleDeleteColumn(field.id, field.name)}
+								onOptionsUpdate={(values) => handleUpdateColumnOptions(field.id, values)}
 								canMoveLeft={fieldIdx > 0}
 								canMoveRight={fieldIdx < dataFields.length - 1}
 								onMoveLeft={() => handleMoveColumn(field.id, "left")}
@@ -1318,7 +1335,7 @@ export function ObjectTable({
 		// `onEntryClick` and `updateLocalEntryField` are read inside the `cell`
 		// closures and were missing from the original deps (stale-closure bug);
 		// they're included now.
-	}, [dataFields, actionFields, activeReverseRelations, objectName, members, relationLabels, relationFaviconUrls, onNavigateToObject, onNavigateToEntry, onEntryClick, onRefresh, updateLocalEntryField, showToast, renamingFieldId, handleRenameColumn, handleDeleteColumn, handleMoveColumn, enrichmentProgress, handleReEnrich, enrichedCellIds, openMenuFieldId]);
+	}, [dataFields, actionFields, activeReverseRelations, objectName, members, relationLabels, relationFaviconUrls, onNavigateToObject, onNavigateToEntry, onEntryClick, onRefresh, updateLocalEntryField, showToast, renamingFieldId, handleRenameColumn, handleUpdateColumnOptions, handleDeleteColumn, handleMoveColumn, enrichmentProgress, handleReEnrich, enrichedCellIds, openMenuFieldId]);
 
 	// Add entry handler — delegates to parent when provided, otherwise opens local modal.
 	const handleAdd = useCallback(() => {


### PR DESCRIPTION
## Summary
- Populate company Team tabs from explicit People.Company relationships, with email-domain fallback still intact.
- Remove the unused Add Column name/search field and use safe default column names.
- Add Select option management from the column header menu, including add, rename, remove, and value migration for renamed options.

## Test plan
- pnpm --dir apps/web test 'app/api/crm/companies/[id]/route.test.ts' 'app/components/workspace/column-header-menu.test.tsx' 'app/api/workspace/objects/[name]/fields/[fieldId]/route.test.ts'
- pnpm --dir apps/web exec tsc --noEmit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SQL predicate construction for CRM company people queries and adds data-migration behavior when updating select options, which could affect displayed/mutated workspace data if edge cases are missed.
> 
> **Overview**
> **CRM company Team results are now sourced from explicit `People.Company` relationships**, with email-domain matching kept as a fallback (including normalization via `deriveDisplayDomain` and support for relation values stored as arrays).
> 
> **Workspace select fields can now be edited in-place**: the field metadata PATCH API accepts `enum_values`, validates uniqueness, updates stored enum JSON, and migrates existing `entry_fields` values (rename single option change; otherwise null out removed values). The table UI adds a column-menu `SelectOptionsEditor` that calls this API.
> 
> **Column creation UX is simplified** by removing the add-column name input and auto-generating a unique default field name based on type (with updated tests). `.gitignore` also now excludes `.gstack/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8516d0f50decde96bf1bbe42edc93727d32dc27a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->