### PR TITLE
Keep editor save button visible

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -951,6 +951,7 @@ label {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 0.75rem;
   padding: 0.5rem 1rem;
   min-height: 2.75rem;
   border-bottom: 1px solid var(--color-border);
@@ -959,6 +960,8 @@ label {
   position: sticky;
   top: 0;
   z-index: 20;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .editor-top-bar-left {
@@ -973,7 +976,12 @@ label {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  margin-left: auto;
   flex-shrink: 0;
+  position: sticky;
+  right: 1rem;
+  z-index: 1;
+  background: var(--color-surface);
 }
 
 /* Hide the keyboard hint when the editor's container is too narrow so the
@@ -987,6 +995,9 @@ label {
 
 .editor-save-indicator {
   font-size: 0.75rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .editor-save-unsaved {
@@ -1009,9 +1020,12 @@ label {
   background: var(--color-surface-hover);
   border-radius: 0.375rem;
   border: 1px solid var(--color-border);
+  flex-shrink: 0;
 }
 
 .editor-save-button {
+  order: -1;
+  flex-shrink: 0;
   padding: 0.35rem 1rem;
   font-size: 0.8rem;
   font-weight: 500;
@@ -1061,6 +1075,8 @@ label {
   background: var(--color-surface);
   flex-shrink: 0;
   gap: 0.75rem;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .rich-doc-topbar-left {
@@ -1074,7 +1090,12 @@ label {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  margin-left: auto;
   flex-shrink: 0;
+  position: sticky;
+  right: 1rem;
+  z-index: 1;
+  background: var(--color-surface);
 }
 
 .rich-doc-filename {


### PR DESCRIPTION
## Summary
- Keep markdown and rich-document editor save controls pinned within the visible top bar.
- Allow save status text and shortcut hints to collapse before the actual Save button disappears.

## Test plan
- pnpm --dir apps/web test app/components/workspace/markdown-editor.test.tsx app/components/workspace/rich-document-editor.test.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout tweaks to editor top bars; low risk aside from potential minor visual regressions on edge viewport/container sizes.
> 
> **Overview**
> Keeps the markdown and rich-document editor Save controls visible by tightening the top-bar layout and preventing right-side actions from being pushed off-screen.
> 
> Updates `globals.css` to constrain top-bar overflow (`max-width`/`overflow`), make the right control cluster sticky on the right, and ensure ancillary text (save status + shortcut hint) can truncate or hide before the `Save` button (via ellipsis + `flex-shrink: 0`/reordering).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d21e91155de578b92a98682f63101b477cec07d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->