### PR TITLE
Add spreadsheet-style table selection for chat context

### DIFF
--- a/apps/web/app/components/chat-panel.tsx
+++ b/apps/web/app/components/chat-panel.tsx
@@ -40,6 +40,7 @@ import {
 import type { ComposioChatAction } from "@/lib/composio-chat-actions";
 import type { ChatModelOption } from "@/lib/chat-models";
 import { prepareFilesForChatUpload } from "@/lib/chat-image-preparation";
+import { formatTableSelectionContext, type TableSelectionContext } from "@/lib/table-selection";
 
 // ── Attachment types & helpers ──
 
@@ -758,6 +759,7 @@ export type FileContext = {
 	filename: string;
 	/** When true the path refers to a directory rather than a file. */
 	isDirectory?: boolean;
+	tableSelection?: TableSelectionContext;
 };
 
 type FileScopedSession = {
@@ -1848,6 +1850,10 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 					const label = fileContext.isDirectory ? "directory" : "file";
 					messageText = `[Context: workspace ${label} '${fileContext.path}']\n\n${messageText}`;
 					lastAnnouncedFilePathRef.current = fileContext.path;
+				}
+
+				if (fileContext?.tableSelection) {
+					messageText = `${formatTableSelectionContext(fileContext.tableSelection)}\n\n${messageText}`;
 				}
 
 				// Store HTML for display and pipe to server via transport

--- a/apps/web/app/components/workspace/data-table.test.tsx
+++ b/apps/web/app/components/workspace/data-table.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DataTable } from "./data-table";
+
+type Row = {
+	id: string;
+	name: string;
+	email: string;
+};
+
+const rows: Row[] = [
+	{ id: "1", name: "Ada", email: "ada@example.com" },
+	{ id: "2", name: "Grace", email: "grace@example.com" },
+];
+
+const columns: ColumnDef<Row>[] = [
+	{ id: "name", accessorKey: "name", header: "Name" },
+	{ id: "email", accessorKey: "email", header: "Email" },
+];
+
+describe("DataTable cell selection", () => {
+	beforeEach(() => {
+		Element.prototype.scrollIntoView = vi.fn();
+	});
+
+	it("selects cells and moves the active cell with arrow keys", () => {
+		const onCellSelectionChange = vi.fn();
+		render(
+			<DataTable
+				columns={columns}
+				data={rows}
+				enableCellSelection
+				onCellSelectionChange={onCellSelectionChange}
+				hideToolbar
+				getRowId={(row) => row.id}
+			/>,
+		);
+
+		const firstCell = screen.getByText("Ada").closest("td");
+		expect(firstCell).not.toBeNull();
+		fireEvent.mouseDown(firstCell!);
+
+		expect(onCellSelectionChange).toHaveBeenLastCalledWith({
+			anchor: { rowIndex: 0, columnId: "name" },
+			focus: { rowIndex: 0, columnId: "name" },
+		});
+		expect(firstCell).toHaveAttribute("aria-selected", "true");
+
+		const tableScroller = firstCell!.closest("div[tabindex='0']");
+		expect(tableScroller).not.toBeNull();
+		fireEvent.keyDown(tableScroller!, { key: "ArrowRight" });
+
+		expect(onCellSelectionChange).toHaveBeenLastCalledWith({
+			anchor: { rowIndex: 0, columnId: "email" },
+			focus: { rowIndex: 0, columnId: "email" },
+		});
+		expect(screen.getByText("ada@example.com").closest("td")).toHaveAttribute("data-dt-cell-active", "true");
+	});
+
+	it("extends a selected range with shift-arrow navigation", () => {
+		render(
+			<DataTable
+				columns={columns}
+				data={rows}
+				enableCellSelection
+				hideToolbar
+				getRowId={(row) => row.id}
+			/>,
+		);
+
+		const firstCell = screen.getByText("Ada").closest("td");
+		fireEvent.mouseDown(firstCell!);
+		const tableScroller = firstCell!.closest("div[tabindex='0']");
+		fireEvent.keyDown(tableScroller!, { key: "ArrowRight" });
+		fireEvent.keyDown(tableScroller!, { key: "ArrowDown", shiftKey: true });
+
+		expect(screen.getByText("ada@example.com").closest("td")).toHaveAttribute("aria-selected", "true");
+		expect(screen.getByText("grace@example.com").closest("td")).toHaveAttribute("aria-selected", "true");
+		expect(screen.getByText("Grace").closest("td")).not.toHaveAttribute("aria-selected");
+	});
+
+	it("uses row numbers as row-selection handles", () => {
+		render(
+			<DataTable
+				columns={columns}
+				data={rows}
+				enableRowSelection
+				hideToolbar
+				getRowId={(row) => row.id}
+			/>,
+		);
+
+		const rowNumberCell = screen.getByText("1").closest("td");
+		fireEvent.mouseDown(rowNumberCell!);
+
+		const firstRowCheckbox = screen.getAllByRole("checkbox")[1] as HTMLInputElement;
+		expect(firstRowCheckbox.checked).toBe(true);
+	});
+});

--- a/apps/web/app/components/workspace/data-table.tsx
+++ b/apps/web/app/components/workspace/data-table.tsx
@@ -44,6 +44,7 @@ import {
 } from "../ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { UrlFavicon } from "./url-favicon";
+import type { TableCellSelectionState, TableSelectionPoint } from "@/lib/table-selection";
 
 /* ─── Types ─── */
 
@@ -69,6 +70,9 @@ export type DataTableProps<TData, TValue> = {
 	enableRowSelection?: boolean;
 	rowSelection?: Record<string, boolean>;
 	onRowSelectionChange?: OnChangeFn<Record<string, boolean>>;
+	enableCellSelection?: boolean;
+	cellSelection?: TableCellSelectionState | null;
+	onCellSelectionChange?: (selection: TableCellSelectionState | null) => void;
 	bulkActions?: React.ReactNode;
 	// column features
 	enableColumnReordering?: boolean;
@@ -128,6 +132,35 @@ function fuzzyFilter(
 ) {
 	const result = rankItem(row.getValue(columnId), filterValue);
 	return result.passed;
+}
+
+const UTILITY_COLUMN_IDS = new Set(["__rownum", "select", "actions", "__add_column"]);
+
+function isEditableEventTarget(target: EventTarget | null): boolean {
+	if (!(target instanceof HTMLElement)) {
+		return false;
+	}
+	return Boolean(target.closest("input, textarea, select, button, a, [contenteditable='true'], [role='button']"));
+}
+
+function resolveCellRange(
+	selection: TableCellSelectionState | null,
+	columnIds: string[],
+	rowCount: number,
+) {
+	if (!selection || rowCount === 0 || columnIds.length === 0) {
+		return null;
+	}
+	const anchorCol = columnIds.indexOf(selection.anchor.columnId);
+	const focusCol = columnIds.indexOf(selection.focus.columnId);
+	if (anchorCol < 0 || focusCol < 0) {
+		return null;
+	}
+	const rowStart = Math.max(0, Math.min(selection.anchor.rowIndex, selection.focus.rowIndex));
+	const rowEnd = Math.min(rowCount - 1, Math.max(selection.anchor.rowIndex, selection.focus.rowIndex));
+	const colStart = Math.min(anchorCol, focusCol);
+	const colEnd = Math.max(anchorCol, focusCol);
+	return { rowStart, rowEnd, colStart, colEnd };
 }
 
 /* ─── Sortable header cell (DnD) ─── */
@@ -200,6 +233,9 @@ export function DataTable<TData, TValue>({
 	enableRowSelection = false,
 	rowSelection: externalRowSelection,
 	onRowSelectionChange,
+	enableCellSelection = false,
+	cellSelection: externalCellSelection,
+	onCellSelectionChange,
 	bulkActions,
 	enableColumnReordering = false,
 	onColumnReorder,
@@ -255,6 +291,7 @@ export function DataTable<TData, TValue>({
 		setColumnSizing(initialColumnSizing ?? {});
 	}, [initialColumnSizing]);
 	const [internalRowSelection, setInternalRowSelection] = useState<Record<string, boolean>>({});
+	const [internalCellSelection, setInternalCellSelection] = useState<TableCellSelectionState | null>(null);
 	const [internalStickyFirstColumn, setInternalStickyFirstColumn] = useState(stickyFirstProp);
 	const stickyFirstColumn =
 		stickyFirstColumnValue !== undefined ? stickyFirstColumnValue : internalStickyFirstColumn;
@@ -274,6 +311,13 @@ export function DataTable<TData, TValue>({
 	const scrollContainerRef = useRef<HTMLDivElement>(null);
 
 	const rowSelectionState = externalRowSelection !== undefined ? externalRowSelection : internalRowSelection;
+	const cellSelectionState = externalCellSelection !== undefined ? externalCellSelection : internalCellSelection;
+	const setCellSelection = useCallback((next: TableCellSelectionState | null) => {
+		if (externalCellSelection === undefined) {
+			setInternalCellSelection(next);
+		}
+		onCellSelectionChange?.(next);
+	}, [externalCellSelection, onCellSelectionChange]);
 
 	// Extract column ID from ColumnDef
 	const getColumnId = useCallback((c: ColumnDef<TData, TValue>): string => {
@@ -544,6 +588,11 @@ export function DataTable<TData, TValue>({
 
 	const selectedCount = Object.keys(rowSelectionState).filter((k) => rowSelectionState[k]).length;
 	const visibleColumns = table.getVisibleFlatColumns().filter((c) => c.id !== "__rownum" && c.id !== "select" && c.id !== "actions" && c.id !== "__add_column");
+	const visibleDataColumnIds = table.getVisibleLeafColumns()
+		.map((column) => column.id)
+		.filter((id) => !UTILITY_COLUMN_IDS.has(id));
+	const visibleRowCount = table.getRowModel().rows.length;
+	const cellSelectionEnabled = enableCellSelection && visibleRowCount > 0 && visibleDataColumnIds.length > 0;
 	// Stable items array for dnd-kit's SortableContext so the dnd
 	// context isn't reset on every render.
 	const sortableHeaderIds = useMemo(
@@ -566,6 +615,85 @@ export function DataTable<TData, TValue>({
 		}
 		return vars;
 	}, [columnSizingState, isResizingColumn, columnVisibility, columnOrder]); // eslint-disable-line react-hooks/exhaustive-deps
+
+	useEffect(() => {
+		if (!cellSelectionState) {
+			return;
+		}
+		const range = resolveCellRange(cellSelectionState, visibleDataColumnIds, visibleRowCount);
+		if (!range) {
+			setCellSelection(null);
+		}
+	}, [cellSelectionState, setCellSelection, visibleDataColumnIds, visibleRowCount]);
+
+	useEffect(() => {
+		if (!cellSelectionState) {
+			return;
+		}
+		scrollContainerRef.current
+			?.querySelector("[data-dt-cell-active='true']")
+			?.scrollIntoView({ block: "nearest", inline: "nearest" });
+	}, [cellSelectionState]);
+
+	const selectedColumnsByRow = useMemo(() => {
+		const range = resolveCellRange(cellSelectionState, visibleDataColumnIds, visibleRowCount);
+		const byRow = new Map<number, string[]>();
+		if (!range) {
+			return byRow;
+		}
+		const selectedColumnIds = visibleDataColumnIds.slice(range.colStart, range.colEnd + 1);
+		for (let rowIdx = range.rowStart; rowIdx <= range.rowEnd; rowIdx++) {
+			byRow.set(rowIdx, selectedColumnIds);
+		}
+		return byRow;
+	}, [cellSelectionState, visibleDataColumnIds, visibleRowCount]);
+
+	const handleCellMouseDown = useCallback((rowIndex: number, columnId: string, event: React.MouseEvent<HTMLTableCellElement>) => {
+		if (!cellSelectionEnabled || event.button !== 0 || isEditableEventTarget(event.target)) {
+			return;
+		}
+		event.preventDefault();
+		event.stopPropagation();
+		scrollContainerRef.current?.focus({ preventScroll: true });
+		const nextPoint = { rowIndex, columnId };
+		setCellSelection(event.shiftKey && cellSelectionState
+			? { anchor: cellSelectionState.anchor, focus: nextPoint }
+			: { anchor: nextPoint, focus: nextPoint });
+	}, [cellSelectionEnabled, cellSelectionState, setCellSelection]);
+
+	const handleCellKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+		if (!cellSelectionEnabled || isEditableEventTarget(event.target)) {
+			return;
+		}
+		if (event.key === "Escape" && cellSelectionState) {
+			event.preventDefault();
+			setCellSelection(null);
+			return;
+		}
+		const deltas: Record<string, { row: number; col: number }> = {
+			ArrowUp: { row: -1, col: 0 },
+			ArrowDown: { row: 1, col: 0 },
+			ArrowLeft: { row: 0, col: -1 },
+			ArrowRight: { row: 0, col: 1 },
+		};
+		const delta = deltas[event.key];
+		if (!delta) {
+			return;
+		}
+		event.preventDefault();
+		const current = cellSelectionState?.focus ?? { rowIndex: 0, columnId: visibleDataColumnIds[0] };
+		const currentColIndex = Math.max(0, visibleDataColumnIds.indexOf(current.columnId));
+		const nextPoint: TableSelectionPoint = {
+			rowIndex: Math.min(Math.max(current.rowIndex + delta.row, 0), visibleRowCount - 1),
+			columnId: visibleDataColumnIds[
+				Math.min(Math.max(currentColIndex + delta.col, 0), visibleDataColumnIds.length - 1)
+			],
+		};
+		setCellSelection({
+			anchor: event.shiftKey && cellSelectionState ? cellSelectionState.anchor : nextPoint,
+			focus: nextPoint,
+		});
+	}, [cellSelectionEnabled, cellSelectionState, setCellSelection, visibleDataColumnIds, visibleRowCount]);
 
 	// ─── Render ───
 
@@ -706,6 +834,8 @@ export function DataTable<TData, TValue>({
 				ref={scrollContainerRef}
 				className="overflow-auto flex-1 min-h-0 max-h-full relative"
 				onScroll={handleScroll}
+				onKeyDown={handleCellKeyDown}
+				tabIndex={cellSelectionEnabled ? 0 : undefined}
 				style={{ overscrollBehavior: "contain" }}
 			>
 				{loading ? (
@@ -856,6 +986,9 @@ export function DataTable<TData, TValue>({
 									isScrolled={isScrolled}
 									onRowClick={onRowClick}
 									getFirstDataColumnFaviconUrl={getFirstDataColumnFaviconUrl}
+									selectedColumnsByRow={selectedColumnsByRow}
+									activeCell={cellSelectionState?.focus ?? null}
+									onCellMouseDown={handleCellMouseDown}
 								/>
 							)}
 						</table>
@@ -949,6 +1082,9 @@ type TableRowProps = {
 	isScrolled: boolean;
 	onRowClick?: (row: any, index: number) => void;
 	firstColumnFaviconUrl: string | null | undefined;
+	selectedCellColumnIds: string;
+	activeCellColumnId: string | null;
+	onCellMouseDown?: (rowIndex: number, columnId: string, event: React.MouseEvent<HTMLTableCellElement>) => void;
 	/** Stable string key encoding visible column IDs in order. When this
 	 * changes (column add/remove/reorder/visibility) the row re-renders. */
 	cellLayoutKey: string;
@@ -964,12 +1100,19 @@ function TableRowInner({
 	isScrolled,
 	onRowClick,
 	firstColumnFaviconUrl,
+	selectedCellColumnIds,
+	activeCellColumnId,
+	onCellMouseDown,
 }: TableRowProps) {
 	const visibleCells = row.getVisibleCells();
 	const firstDataIdx = 1 + (enableRowSelection ? 1 : 0);
 	const altBg = rowIdx % 2 === 0 ? "var(--color-surface)" : "var(--color-bg)";
 	const baseBg = isActive || isSelected ? "var(--color-accent-light)" : altBg;
 	const stickyBg = baseBg;
+	const selectedCellColumns = useMemo(
+		() => new Set(selectedCellColumnIds ? selectedCellColumnIds.split("|") : []),
+		[selectedCellColumnIds],
+	);
 
 	const handleClick = useCallback(() => {
 		onRowClick?.(row.original, rowIdx);
@@ -1010,19 +1153,33 @@ function TableRowInner({
 				const isSelectCol = cell.column.id === "select";
 				const isActionsCol = cell.column.id === "actions";
 				const isAddCol = cell.column.id === "__add_column";
+				const isDataCell = !isRownumCol && !isSelectCol && !isActionsCol && !isAddCol;
 				const isRightSticky = isActionsCol || isAddCol;
 				const isLastCol = colIdx === visibleCells.length - 1;
 				const cellFaviconUrl = isFirstData && !isSelectCol ? firstColumnFaviconUrl : undefined;
+				const isCellSelected = isDataCell && selectedCellColumns.has(cell.column.id);
+				const isCellActive = isDataCell && activeCellColumnId === cell.column.id;
+				const stickyShadow = isSticky && isScrolled
+					? "4px 0 12px -2px rgba(0,0,0,0.12), 2px 0 4px -1px rgba(0,0,0,0.06)"
+					: "";
+				const selectionShadow = isCellActive
+					? "inset 0 0 0 2px var(--color-accent)"
+					: isCellSelected
+						? "inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 55%, transparent)"
+						: "";
 
 				const cellStyle: React.CSSProperties = {
 					borderColor: "var(--color-border)",
+					...(isCellSelected
+						? { background: "color-mix(in srgb, var(--color-accent) 10%, var(--color-surface))" }
+						: {}),
+					...((stickyShadow || selectionShadow) ? { boxShadow: [stickyShadow, selectionShadow].filter(Boolean).join(", ") } : {}),
 					...(isSticky
 						? {
 								position: "sticky" as const,
 								left: enableRowSelection ? 40 : 0,
 								zIndex: 2,
-								background: stickyBg,
-								boxShadow: isScrolled ? "4px 0 12px -2px rgba(0,0,0,0.12), 2px 0 4px -1px rgba(0,0,0,0.06)" : "none",
+								background: isCellSelected ? "color-mix(in srgb, var(--color-accent) 10%, var(--color-surface))" : stickyBg,
 							}
 						: {}),
 					...(isSelectCol
@@ -1047,6 +1204,9 @@ function TableRowInner({
 				return (
 					<td
 						key={cell.id}
+						data-dt-cell-active={isCellActive ? "true" : undefined}
+						data-row-index={isDataCell ? rowIdx : undefined}
+						data-column-id={isDataCell ? cell.column.id : undefined}
 						className={cn(
 							"align-middle whitespace-nowrap text-[13px] border-b transition-colors box-border",
 							isRownumCol
@@ -1056,8 +1216,26 @@ function TableRowInner({
 									: "px-4 py-3",
 							!isLastCol && "border-r",
 							isSticky && isScrolled && "border-r-2!",
+							isDataCell && "cursor-cell select-none",
 						)}
 						style={cellStyle}
+						aria-selected={isCellSelected || undefined}
+						onMouseDown={(event) => {
+							if (isRownumCol && enableRowSelection && !isEditableEventTarget(event.target)) {
+								event.preventDefault();
+								event.stopPropagation();
+								row.toggleSelected(!row.getIsSelected());
+								return;
+							}
+							if (isDataCell) {
+								onCellMouseDown?.(rowIdx, cell.column.id, event);
+							}
+						}}
+						onClick={(event) => {
+							if (isRownumCol || isDataCell) {
+								event.stopPropagation();
+							}
+						}}
 					>
 						<div className="overflow-hidden">
 							{cellFaviconUrl ? (
@@ -1097,6 +1275,9 @@ const TableRow = React.memo(TableRowInner, (prev, next) => {
 		prev.isScrolled === next.isScrolled &&
 		prev.onRowClick === next.onRowClick &&
 		prev.firstColumnFaviconUrl === next.firstColumnFaviconUrl &&
+		prev.selectedCellColumnIds === next.selectedCellColumnIds &&
+		prev.activeCellColumnId === next.activeCellColumnId &&
+		prev.onCellMouseDown === next.onCellMouseDown &&
 		prev.cellLayoutKey === next.cellLayoutKey
 	);
 });
@@ -1111,6 +1292,9 @@ type DataTableBodyProps = {
 	isScrolled: boolean;
 	onRowClick?: (row: any, index: number) => void;
 	getFirstDataColumnFaviconUrl?: (row: Row<any>, table: Table<any>) => string | null | undefined;
+	selectedColumnsByRow: Map<number, string[]>;
+	activeCell: TableSelectionPoint | null;
+	onCellMouseDown?: (rowIndex: number, columnId: string, event: React.MouseEvent<HTMLTableCellElement>) => void;
 };
 
 function DataTableBodyInner({
@@ -1122,6 +1306,9 @@ function DataTableBodyInner({
 	isScrolled,
 	onRowClick,
 	getFirstDataColumnFaviconUrl,
+	selectedColumnsByRow,
+	activeCell,
+	onCellMouseDown,
 }: DataTableBodyProps) {
 	// Encode visible column layout as a stable string. When columns are
 	// added/removed/reordered/hidden, this changes and rows re-render.
@@ -1136,6 +1323,7 @@ function DataTableBodyInner({
 				const isSelected = row.getIsSelected();
 				const isActive = activeRowId != null && getRowId != null && getRowId(row.original) === activeRowId;
 				const firstColumnFaviconUrl = getFirstDataColumnFaviconUrl?.(row, table) ?? undefined;
+				const selectedCellColumnIds = selectedColumnsByRow.get(rowIdx)?.join("|") ?? "";
 				return (
 					<TableRow
 						key={row.id}
@@ -1148,6 +1336,9 @@ function DataTableBodyInner({
 						isScrolled={isScrolled}
 						onRowClick={onRowClick}
 						firstColumnFaviconUrl={firstColumnFaviconUrl}
+						selectedCellColumnIds={selectedCellColumnIds}
+						activeCellColumnId={activeCell?.rowIndex === rowIdx ? activeCell.columnId : null}
+						onCellMouseDown={onCellMouseDown}
 						cellLayoutKey={cellLayoutKey}
 					/>
 				);

--- a/apps/web/app/components/workspace/object-table.test.tsx
+++ b/apps/web/app/components/workspace/object-table.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ObjectTable } from "./object-table";
+import type { TableSelectionContext } from "@/lib/table-selection";
+
+describe("ObjectTable selection context", () => {
+	beforeEach(() => {
+		Element.prototype.scrollIntoView = vi.fn();
+		global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			if (url === "/api/workspace/enrichment-status") {
+				return new Response(JSON.stringify({ available: false }));
+			}
+			throw new Error(`Unexpected fetch: ${url}`);
+		}) as typeof fetch;
+	});
+
+	it("emits selected cell values for chat context", async () => {
+		const onSelectionContextChange = vi.fn();
+		render(
+			<ObjectTable
+				objectName="people"
+				fields={[
+					{ id: "name", name: "Name", type: "text" },
+					{ id: "email", name: "Email", type: "email" },
+				]}
+				entries={[
+					{ entry_id: "p1", Name: "Ada", Email: "ada@example.com" },
+					{ entry_id: "p2", Name: "Grace", Email: "grace@example.com" },
+				]}
+				hideInternalToolbar
+				onSelectionContextChange={onSelectionContextChange}
+			/>,
+		);
+
+		fireEvent.mouseDown(screen.getByText("Ada").closest("td")!);
+
+		await waitFor(() => {
+			const lastCall = onSelectionContextChange.mock.lastCall?.[0] as TableSelectionContext | null;
+			expect(lastCall).toMatchObject({
+				objectName: "people",
+				kind: "cells",
+				rowCount: 1,
+				columnCount: 1,
+				columns: ["Name"],
+				cells: [{ rowIndex: 0, entryId: "p1", fieldName: "Name", value: "Ada" }],
+			});
+		});
+	});
+
+	it("emits selected row values for chat context", async () => {
+		const onSelectionContextChange = vi.fn();
+		render(
+			<ObjectTable
+				objectName="people"
+				fields={[
+					{ id: "name", name: "Name", type: "text" },
+					{ id: "email", name: "Email", type: "email" },
+				]}
+				entries={[
+					{ entry_id: "p1", Name: "Ada", Email: "ada@example.com" },
+					{ entry_id: "p2", Name: "Grace", Email: "grace@example.com" },
+				]}
+				hideInternalToolbar
+				onSelectionContextChange={onSelectionContextChange}
+			/>,
+		);
+
+		fireEvent.mouseDown(screen.getByText("2").closest("td")!);
+
+		await waitFor(() => {
+			const lastCall = onSelectionContextChange.mock.lastCall?.[0] as TableSelectionContext | null;
+			expect(lastCall).toMatchObject({
+				objectName: "people",
+				kind: "rows",
+				rowCount: 1,
+				columns: expect.arrayContaining(["Name", "Email"]),
+				rows: [{
+					rowIndex: 1,
+					entryId: "p2",
+					values: expect.objectContaining({
+						Name: "Grace",
+						Email: "grace@example.com",
+					}),
+				}],
+			});
+		});
+	});
+});

--- a/apps/web/app/components/workspace/object-table.tsx
+++ b/apps/web/app/components/workspace/object-table.tsx
@@ -18,6 +18,7 @@ import { UrlFavicon } from "./url-favicon";
 import { LinkOpenButton } from "./link-open-button";
 import { LinkPreviewWrapper } from "./workspace-link";
 import { RelationLink } from "./relation-link";
+import type { TableCellSelectionState, TableSelectionContext } from "@/lib/table-selection";
 
 /* ─── Types ─── */
 
@@ -99,6 +100,7 @@ type ObjectTableProps = {
 	/** Controlled sticky-first-column toggle. */
 	stickyFirstColumnValue?: boolean;
 	onStickyFirstColumnChange?: (value: boolean) => void;
+	onSelectionContextChange?: (selection: TableSelectionContext | null) => void;
 };
 
 type EntryRow = Record<string, unknown> & { entry_id?: string };
@@ -834,8 +836,10 @@ export function ObjectTable({
 	onAddRequest,
 	stickyFirstColumnValue,
 	onStickyFirstColumnChange,
+	onSelectionContextChange,
 }: ObjectTableProps) {
 	const [rowSelection, setRowSelection] = useState<Record<string, boolean>>({});
+	const [cellSelection, setCellSelection] = useState<TableCellSelectionState | null>(null);
 	const [showAddModal, setShowAddModal] = useState(false);
 	const [localEntries, setLocalEntries] = useState<EntryRow[]>(entries as EntryRow[]);
 	const [confirmState, setConfirmState] = useState<{
@@ -998,6 +1002,134 @@ export function ObjectTable({
 		if (!reverseRelations) {return [];}
 		return reverseRelations.filter((rr) => Object.keys(rr.entries).length > 0);
 	}, [reverseRelations]);
+
+	const selectionColumnLabels = useMemo(() => {
+		const labels: Record<string, string> = {};
+		for (const field of dataFields) {
+			labels[field.id] = field.name;
+		}
+		labels.created_at = "created_at";
+		labels.updated_at = "updated_at";
+		for (const rr of activeReverseRelations) {
+			labels[`rev_${rr.sourceObjectName}_${rr.fieldName}`] = `${displayObjectName(rr.sourceObjectName)} via ${rr.fieldName}`;
+		}
+		for (const field of actionFields) {
+			labels[`action_${field.id}`] = field.name;
+		}
+		return labels;
+	}, [activeReverseRelations, actionFields, dataFields]);
+
+	const selectionColumns = useMemo(
+		() => Object.entries(selectionColumnLabels)
+			.filter(([columnId]) => columnVisibility?.[columnId] !== false)
+			.slice(0, 20),
+		[selectionColumnLabels, columnVisibility],
+	);
+
+	const readSelectionValue = useCallback((entry: EntryRow, columnId: string, label: string) => {
+		if (columnId === "created_at") {
+			return safeString(resolveEntryMetaValue(entry, CREATED_AT_KEYS));
+		}
+		if (columnId === "updated_at") {
+			return safeString(resolveEntryMetaValue(entry, UPDATED_AT_KEYS));
+		}
+		if (columnId.startsWith("rev_")) {
+			const relation = activeReverseRelations.find(
+				(rr) => `rev_${rr.sourceObjectName}_${rr.fieldName}` === columnId,
+			);
+			const entryId = safeString(entry.entry_id);
+			return relation?.entries[entryId]?.map((item) => item.label).join(", ") ?? "";
+		}
+		return safeString(entry[label]);
+	}, [activeReverseRelations]);
+
+	useEffect(() => {
+		if (!onSelectionContextChange) {
+			return;
+		}
+
+		const selectedRowIndexes = Object.keys(rowSelection)
+			.filter((index) => rowSelection[index])
+			.map(Number)
+			.filter((index) => Number.isInteger(index) && localEntries[index]);
+
+		if (selectedRowIndexes.length > 0) {
+			const rows = selectedRowIndexes.map((rowIndex) => {
+				const entry = localEntries[rowIndex];
+				const values: Record<string, string> = {};
+				for (const [columnId, label] of selectionColumns) {
+					values[label] = readSelectionValue(entry, columnId, label);
+				}
+				return {
+					rowIndex,
+					entryId: safeString(entry.entry_id),
+					values,
+				};
+			});
+			onSelectionContextChange({
+				objectName,
+				kind: "rows",
+				rowCount: rows.length,
+				columnCount: selectionColumns.length,
+				columns: selectionColumns.map(([, label]) => label),
+				rows,
+				updatedAt: Date.now(),
+			});
+			return;
+		}
+
+		if (!cellSelection) {
+			onSelectionContextChange(null);
+			return;
+		}
+
+		const columnIds = selectionColumns.map(([columnId]) => columnId);
+		const anchorColumnIndex = columnIds.indexOf(cellSelection.anchor.columnId);
+		const focusColumnIndex = columnIds.indexOf(cellSelection.focus.columnId);
+		if (anchorColumnIndex < 0 || focusColumnIndex < 0) {
+			onSelectionContextChange(null);
+			return;
+		}
+		const rowStart = Math.max(0, Math.min(cellSelection.anchor.rowIndex, cellSelection.focus.rowIndex));
+		const rowEnd = Math.min(localEntries.length - 1, Math.max(cellSelection.anchor.rowIndex, cellSelection.focus.rowIndex));
+		const colStart = Math.min(anchorColumnIndex, focusColumnIndex);
+		const colEnd = Math.max(anchorColumnIndex, focusColumnIndex);
+		const selectedColumns = selectionColumns.slice(colStart, colEnd + 1);
+		const cells = [];
+		for (let rowIndex = rowStart; rowIndex <= rowEnd; rowIndex++) {
+			const entry = localEntries[rowIndex];
+			if (!entry) {
+				continue;
+			}
+			for (const [columnId, label] of selectedColumns) {
+				cells.push({
+					rowIndex,
+					entryId: safeString(entry.entry_id),
+					fieldName: label,
+					value: readSelectionValue(entry, columnId, label),
+				});
+			}
+		}
+		onSelectionContextChange({
+			objectName,
+			kind: "cells",
+			rowCount: rowEnd - rowStart + 1,
+			columnCount: selectedColumns.length,
+			columns: selectedColumns.map(([, label]) => label),
+			cells,
+			updatedAt: Date.now(),
+		});
+	}, [
+		cellSelection,
+		localEntries,
+		objectName,
+		onSelectionContextChange,
+		readSelectionValue,
+		rowSelection,
+		selectionColumns,
+	]);
+
+	useEffect(() => () => onSelectionContextChange?.(null), [onSelectionContextChange]);
 
 	// Precompute the first URL favicon per entry once (instead of recomputing
 	// per row, per render, which used to walk every cell of every row and
@@ -1483,9 +1615,12 @@ export function ObjectTable({
 			enableSorting
 			enableGlobalFilter
 			enableRowSelection
+			enableCellSelection
 			enableColumnReordering
 			rowSelection={rowSelection}
 			onRowSelectionChange={setRowSelection}
+			cellSelection={cellSelection}
+			onCellSelectionChange={setCellSelection}
 			onColumnReorder={handleColumnReorder}
 			searchPlaceholder={`Search ${displayObjectName(objectName)}...`}
 			onRefresh={onRefresh}

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -73,6 +73,7 @@ import { ChatComposioModalHost } from "../components/integrations/chat-composio-
 import { CloudSettingsPanel } from "../components/settings/cloud-settings-panel";
 import { CronJobDetail } from "../components/cron/cron-job-detail";
 import { CronSessionView } from "../components/cron/cron-session-view";
+import type { TableSelectionContext } from "@/lib/table-selection";
 import type { CronJob, CronJobsResponse } from "../types/cron";
 import { useIsMobile } from "../hooks/use-mobile";
 import { ObjectFilterBar } from "../components/workspace/object-filter-bar";
@@ -562,6 +563,7 @@ function WorkspacePageInner() {
   // Terminal drawer state
   const [terminalOpen, setTerminalOpen] = useState(false);
   const [pendingComposioAction, setPendingComposioAction] = useState<ComposioChatAction | null>(null);
+  const [tableSelectionContext, setTableSelectionContext] = useState<TableSelectionContext | null>(null);
 
   // Tabs state — single source of truth for content + chat tabs.
   // Replaces the older tabState/activePath/content/activeContentTabId quartet
@@ -969,8 +971,8 @@ function WorkspacePageInner() {
       isVirtualPath(activePath) ||
       activeContentTab?.kind === "crm-inbox" ||
       activeContentTab?.kind === "crm-calendar";
-    return { path: activePath, filename, isDirectory };
-  }, [activePath, activeContentTab?.kind]);
+    return { path: activePath, filename, isDirectory, tableSelection: tableSelectionContext ?? undefined };
+  }, [activePath, activeContentTab?.kind, tableSelectionContext]);
 
   // Live reload from the agent: ContentRenderer/useTabContent owns the live
   // file payload now, so this stub simply forces a refresh of the active tab
@@ -2321,6 +2323,7 @@ function WorkspacePageInner() {
       onCronRunChange={setCronRun}
       onSendCommand={handleCronSendCommand}
       onMakeTabPermanent={promoteTabByPath}
+      onTableSelectionContextChange={setTableSelectionContext}
     />
   ), [
     workspaceExists, workspaceRoot, tree, activePath, browseDir, treeLoading,
@@ -2328,7 +2331,7 @@ function WorkspacePageInner() {
     refreshCurrentObject, refreshTree, handleEditorNavigate, handleOpenEntry,
     searchIndex, handleSelectCronJob, handleBackToCronDashboard,
     cronView, cronCalMode, cronDate, cronRunFilter, cronRun,
-    handleCronSendCommand, promoteTabByPath,
+    handleCronSendCommand, promoteTabByPath, setTableSelectionContext,
   ]);
 
   const renderRightPanelPlaceholder = useCallback(() => (
@@ -2695,6 +2698,7 @@ function ContentRenderer({
   onCronRunChange,
   onSendCommand,
   onMakeTabPermanent,
+  onTableSelectionContextChange,
 }: {
   content: ContentState;
   workspaceExists: boolean;
@@ -2730,6 +2734,7 @@ function ContentRenderer({
   onCronRunChange: (run: number | null) => void;
   onSendCommand: (message: string) => void;
   onMakeTabPermanent: (path: string) => void;
+  onTableSelectionContextChange: (selection: TableSelectionContext | null) => void;
 }) {
   switch (content.kind) {
     case "loading":
@@ -2750,6 +2755,7 @@ function ContentRenderer({
           onRefreshTree={onRefreshTree}
           onOpenEntry={onOpenEntry}
           activeEntryId={activeEntryId}
+          onSelectionContextChange={onTableSelectionContextChange}
         />
       );
 
@@ -2994,6 +3000,7 @@ function ObjectView({
   onRefreshTree,
   onOpenEntry,
   activeEntryId,
+  onSelectionContextChange,
 }: {
   data: ObjectData;
   members?: Array<{ id: string; name: string; email: string; role: string }>;
@@ -3006,6 +3013,7 @@ function ObjectView({
     relatedObjectId?: string,
   ) => void;
   activeEntryId?: string;
+  onSelectionContextChange?: (selection: TableSelectionContext | null) => void;
 }) {
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -3827,6 +3835,7 @@ function ObjectView({
             stickyFirstColumnValue={stickyFirstColumn}
             onStickyFirstColumnChange={setStickyFirstColumn}
             onAddRequest={handleOpenAddModal}
+            onSelectionContextChange={onSelectionContextChange}
           />
         )}
         {currentViewType === "calendar" && (

--- a/apps/web/lib/table-selection.test.ts
+++ b/apps/web/lib/table-selection.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { formatTableSelectionContext, tableSelectionFingerprint, type TableSelectionContext } from "./table-selection";
+
+describe("table selection context", () => {
+	it("formats selected cells for chat context", () => {
+		const selection: TableSelectionContext = {
+			objectName: "people",
+			kind: "cells",
+			rowCount: 1,
+			columnCount: 2,
+			columns: ["Name", "Email"],
+			cells: [
+				{ rowIndex: 0, entryId: "p1", fieldName: "Name", value: "Ada" },
+				{ rowIndex: 0, entryId: "p1", fieldName: "Email", value: "ada@example.com" },
+			],
+			updatedAt: 1,
+		};
+
+		expect(formatTableSelectionContext(selection)).toContain("[Selected table cells: people]");
+		expect(formatTableSelectionContext(selection)).toContain("row 1 (p1), Email: ada@example.com");
+	});
+
+	it("fingerprints selection by contents, not timestamp", () => {
+		const base: TableSelectionContext = {
+			objectName: "company",
+			kind: "rows",
+			rowCount: 1,
+			columnCount: 1,
+			columns: ["Name"],
+			rows: [{ rowIndex: 0, entryId: "c1", values: { Name: "Acme" } }],
+			updatedAt: 1,
+		};
+
+		expect(tableSelectionFingerprint(base)).toBe(
+			tableSelectionFingerprint({ ...base, updatedAt: 2 }),
+		);
+	});
+});

--- a/apps/web/lib/table-selection.ts
+++ b/apps/web/lib/table-selection.ts
@@ -1,0 +1,85 @@
+export type TableSelectionPoint = {
+	rowIndex: number;
+	columnId: string;
+};
+
+export type TableCellSelectionState = {
+	anchor: TableSelectionPoint;
+	focus: TableSelectionPoint;
+};
+
+export type TableSelectionCellSnapshot = {
+	rowIndex: number;
+	entryId: string;
+	fieldName: string;
+	value: string;
+};
+
+export type TableSelectionRowSnapshot = {
+	rowIndex: number;
+	entryId: string;
+	values: Record<string, string>;
+};
+
+export type TableSelectionContext = {
+	objectName: string;
+	kind: "cells" | "rows";
+	rowCount: number;
+	columnCount: number;
+	columns: string[];
+	cells?: TableSelectionCellSnapshot[];
+	rows?: TableSelectionRowSnapshot[];
+	updatedAt: number;
+};
+
+export function tableSelectionFingerprint(selection: TableSelectionContext | null | undefined): string {
+	if (!selection) {
+		return "";
+	}
+	const cellKey = selection.cells
+		?.map((cell) => `${cell.entryId}:${cell.fieldName}:${cell.value}`)
+		.join("|") ?? "";
+	const rowKey = selection.rows
+		?.map((row) => `${row.entryId}:${Object.entries(row.values).map(([key, value]) => `${key}:${value}`).join(",")}`)
+		.join("|") ?? "";
+	return [
+		selection.objectName,
+		selection.kind,
+		selection.rowCount,
+		selection.columnCount,
+		selection.columns.join(","),
+		cellKey,
+		rowKey,
+	].join("::");
+}
+
+export function formatTableSelectionContext(selection: TableSelectionContext): string {
+	if (selection.kind === "rows") {
+		const rows = selection.rows ?? [];
+		const preview = rows.slice(0, 10).map((row) => {
+			const values = selection.columns
+				.map((column) => `${column}: ${row.values[column] ?? ""}`)
+				.join("; ");
+			return `- row ${row.rowIndex + 1} (${row.entryId}): ${values}`;
+		});
+		const suffix = rows.length > preview.length ? `\n- ...${rows.length - preview.length} more selected rows` : "";
+		return [
+			`[Selected table rows: ${selection.objectName}]`,
+			`${selection.rowCount} row${selection.rowCount === 1 ? "" : "s"} selected.`,
+			`Columns: ${selection.columns.join(", ")}`,
+			...preview,
+		].join("\n") + suffix;
+	}
+
+	const cells = selection.cells ?? [];
+	const preview = cells.slice(0, 30).map((cell) =>
+		`- row ${cell.rowIndex + 1} (${cell.entryId}), ${cell.fieldName}: ${cell.value}`,
+	);
+	const suffix = cells.length > preview.length ? `\n- ...${cells.length - preview.length} more selected cells` : "";
+	return [
+		`[Selected table cells: ${selection.objectName}]`,
+		`${selection.rowCount} row${selection.rowCount === 1 ? "" : "s"} x ${selection.columnCount} column${selection.columnCount === 1 ? "" : "s"} selected.`,
+		`Columns: ${selection.columns.join(", ")}`,
+		...preview,
+	].join("\n") + suffix;
+}


### PR DESCRIPTION
## Summary
- Add spreadsheet-style cell selection and arrow-key navigation to workspace tables, including shift-arrow range extension and row-number row selection.
- Convert selected cells/rows into structured table context and prepend it to chat messages so the agent can see what the user selected.
- Cover the table selection mechanics and chat-context payload formatting with focused regressions.

## Test plan
- pnpm --dir apps/web test app/components/workspace/data-table.test.tsx app/components/workspace/object-table.test.tsx lib/table-selection.test.ts
- pnpm --dir apps/web exec tsc --noEmit
- Browser QA on http://localhost:3100/?path=people: selected a cell, moved with ArrowRight, extended with Shift+ArrowDown, selected a row via row number, and intercepted /api/chat to confirm selected row context is included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new keyboard/mouse-driven cell selection behavior to the core `DataTable` and threads a new selection payload into chat message text, which could impact table interaction edge cases and prompt construction but does not touch auth or persistence.
> 
> **Overview**
> **Adds spreadsheet-style selection to workspace tables.** `DataTable` now supports cell-range selection with click/shift-click and arrow/shift-arrow navigation, highlights an *active cell*, clears selection with Escape, and allows toggling row selection via row-number cells.
> 
> **Threads table selection into chat prompts.** `ObjectTable` derives a `TableSelectionContext` snapshot for selected rows or cells (limited to visible columns) and bubbles it up through `workspace-content` into `ChatPanel`, which prepends a formatted selection summary to the user message.
> 
> **Adds focused tests and utilities.** Introduces `lib/table-selection` (types, formatting, stable fingerprinting) plus Vitest coverage for selection mechanics (`data-table.test.tsx`), selection snapshot emission (`object-table.test.tsx`), and formatting/fingerprinting (`table-selection.test.ts`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5167c7344e17f21e9414290b9ee5a7dadbec68a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->