### PR TITLE
Fix Bugbot follow-ups from merged PRs

### DIFF
--- a/apps/web/app/components/crm/editable-title-heading.test.tsx
+++ b/apps/web/app/components/crm/editable-title-heading.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { EditableTitleHeading } from "./editable-title-heading";
+
+describe("EditableTitleHeading", () => {
+	it("guards against Enter and blur issuing duplicate saves", async () => {
+		const user = userEvent.setup();
+		let resolveSave: (() => void) | undefined;
+		const saveName = vi.fn(() => new Promise<void>((resolve) => {
+			resolveSave = resolve;
+		}));
+
+		render(<EditableTitleHeading name="" saveName={saveName} />);
+
+		await user.click(screen.getByRole("button", { name: "Add a name" }));
+		const input = screen.getByRole("textbox", { name: "Name" });
+		await user.type(input, "Ada Lovelace");
+
+		fireEvent.keyDown(input, { key: "Enter" });
+		fireEvent.blur(input);
+
+		expect(saveName).toHaveBeenCalledTimes(1);
+		expect(saveName).toHaveBeenCalledWith("Ada Lovelace");
+		resolveSave?.();
+	});
+});

--- a/apps/web/app/components/crm/editable-title-heading.tsx
+++ b/apps/web/app/components/crm/editable-title-heading.tsx
@@ -39,6 +39,7 @@ export function EditableTitleHeading({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const committingRef = useRef(false);
 
   useEffect(() => {
     if (editing && inputRef.current) {
@@ -60,11 +61,15 @@ export function EditableTitleHeading({
   }, []);
 
   const commit = useCallback(async () => {
+    if (committingRef.current) {
+      return;
+    }
     const next = draft.trim();
     if (!next) {
       cancelEdit();
       return;
     }
+    committingRef.current = true;
     setSaving(true);
     setError(null);
     try {
@@ -74,6 +79,7 @@ export function EditableTitleHeading({
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save name.");
     } finally {
+      committingRef.current = false;
       setSaving(false);
     }
   }, [draft, cancelEdit, saveName]);

--- a/apps/web/app/components/workspace/column-header-menu.test.tsx
+++ b/apps/web/app/components/workspace/column-header-menu.test.tsx
@@ -69,6 +69,49 @@ describe("AddColumnPopover", () => {
 		expect(screen.getByRole("button", { name: "Text" })).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Create" })).toBeEnabled();
 	});
+
+	it("refreshes fields after reusing an existing enrichment output column", async () => {
+		const user = userEvent.setup();
+		const onCreated = vi.fn();
+		const onEnrichmentStart = vi.fn();
+		const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			if (url === "/api/workspace/enrichment-status") {
+				return new Response(JSON.stringify({ available: true }));
+			}
+			if (url === "/api/workspace/objects/leads/fields/field_full_name" && init?.method === "PATCH") {
+				return new Response(JSON.stringify({ ok: true }));
+			}
+			throw new Error(`Unexpected fetch: ${url}`);
+		});
+		global.fetch = fetchMock as typeof fetch;
+
+		render(
+			<AddColumnPopover
+				objectName="leads"
+				fields={[
+					{ id: "field_email", name: "Email", type: "email" },
+					{ id: "field_full_name", name: "Full Name", type: "text" },
+				]}
+				enrichmentAvailable
+				onCreated={onCreated}
+				onEnrichmentStart={onEnrichmentStart}
+			/>,
+		);
+
+		await user.click(screen.getByTitle("Add column"));
+		await user.click(await screen.findByRole("button", { name: "Full Name" }));
+		await user.click(screen.getByRole("button", { name: "Enrich all" }));
+
+		await waitFor(() => {
+			expect(onCreated).toHaveBeenCalledTimes(1);
+		});
+		expect(onEnrichmentStart).toHaveBeenCalledWith(expect.objectContaining({
+			fieldId: "field_full_name",
+			fieldName: "Full Name",
+			inputFieldName: "Email",
+		}));
+	});
 });
 
 describe("SelectOptionsEditor", () => {
@@ -98,5 +141,31 @@ describe("SelectOptionsEditor", () => {
 
 		await user.click(screen.getByRole("button", { name: "Remove option Customer" }));
 		expect(onOptionsUpdate).toHaveBeenLastCalledWith(["Prospect", "Qualified"]);
+	});
+
+	it("does not double-save when an option input blurs before clicking save", async () => {
+		let resolveSave: (() => void) | undefined;
+		const onOptionsUpdate = vi.fn(() => new Promise<void>((resolve) => {
+			resolveSave = resolve;
+		}));
+
+		render(
+			<SelectOptionsEditor
+				values={["Lead", "Customer"]}
+				onSave={onOptionsUpdate}
+			/>,
+		);
+
+		const leadInput = screen.getByLabelText("Edit option Lead");
+		fireEvent.change(leadInput, { target: { value: "Prospect" } });
+		fireEvent.blur(leadInput);
+		fireEvent.click(screen.getByRole("button", { name: "Save option Prospect" }));
+
+		expect(onOptionsUpdate).toHaveBeenCalledTimes(1);
+		expect(onOptionsUpdate).toHaveBeenCalledWith(["Prospect", "Customer"]);
+		resolveSave?.();
+		await waitFor(() => {
+			expect(screen.queryByText("Saving...")).not.toBeInTheDocument();
+		});
 	});
 });

--- a/apps/web/app/components/workspace/column-header-menu.tsx
+++ b/apps/web/app/components/workspace/column-header-menu.tsx
@@ -218,28 +218,46 @@ export function SelectOptionsEditor({
 	const [draft, setDraft] = useState("");
 	const [saving, setSaving] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const savingRef = useRef(false);
+	const savedOptionsRef = useRef(values);
 
 	useEffect(() => {
 		setOptions(values);
+		savedOptionsRef.current = values;
 		setError(null);
 	}, [values]);
 
 	const saveOptions = useCallback(async (nextValues: string[]) => {
+		if (savingRef.current) {
+			return false;
+		}
 		const normalized = normalizeOptionList(nextValues);
 		if (!normalized.ok) {
 			setError(normalized.error);
 			return false;
 		}
+		const currentSaved = savedOptionsRef.current;
+		if (
+			normalized.values.length === currentSaved.length &&
+			normalized.values.every((value, index) => value === currentSaved[index])
+		) {
+			setOptions(normalized.values);
+			setError(null);
+			return true;
+		}
+		savingRef.current = true;
 		setSaving(true);
 		setError(null);
 		try {
 			await onSave(normalized.values);
 			setOptions(normalized.values);
+			savedOptionsRef.current = normalized.values;
 			return true;
 		} catch (err) {
 			setError(err instanceof Error ? err.message : "Failed to save options");
 			return false;
 		} finally {
+			savingRef.current = false;
 			setSaving(false);
 		}
 	}, [onSave]);
@@ -256,6 +274,10 @@ export function SelectOptionsEditor({
 	}, [draft, options, saveOptions]);
 
 	const renameOption = useCallback(async (index: number, nextValue: string) => {
+		const originalValue = savedOptionsRef.current[index] ?? "";
+		if (nextValue.trim() === originalValue) {
+			return;
+		}
 		const next = [...options];
 		next[index] = nextValue;
 		await saveOptions(next);
@@ -316,6 +338,7 @@ export function SelectOptionsEditor({
 						<button
 							type="button"
 							disabled={saving}
+							onMouseDown={(e) => e.preventDefault()}
 							onClick={() => void renameOption(index, option)}
 							className="flex h-7 w-7 items-center justify-center rounded-full transition-colors disabled:opacity-40 hover:opacity-70"
 							style={{ color: "var(--color-text-muted)" }}
@@ -681,6 +704,7 @@ export function AddColumnPopover({
 					return;
 				}
 				handleClose();
+				onCreated();
 				onEnrichmentStartRef.current?.({
 					fieldId: existingOutputField.id,
 					fieldName: existingOutputField.name,

--- a/apps/web/app/components/workspace/object-table.tsx
+++ b/apps/web/app/components/workspace/object-table.tsx
@@ -768,7 +768,7 @@ function FirstColumnCellInner({ value, entryId, onEntryClick }: FirstColumnCellP
 					onClick={handleOpenClick}
 					title="Open"
 					aria-label="Open entry"
-					className="absolute right-0 top-1/2 -translate-y-1/2 inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[10px] font-medium cursor-pointer opacity-0 group-hover/row:opacity-100 focus-visible:opacity-100 transition-opacity duration-100 outline-none focus-visible:ring-1"
+					className="pointer-events-none absolute right-0 top-1/2 -translate-y-1/2 inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[10px] font-medium cursor-pointer opacity-0 group-hover/row:pointer-events-auto group-hover/row:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 transition-opacity duration-100 outline-none focus-visible:ring-1"
 					style={{
 						background: "var(--color-bg)",
 						color: "var(--color-text-muted)",

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -3112,7 +3112,7 @@ function ObjectView({
     const defaultVt = resolveViewType(undefined, undefined, data.object.default_view);
     saveTableViewState(data.object.name, {
       viewType: currentViewType !== defaultVt ? currentViewType : undefined,
-      view: activeViewName,
+      view: activeViewName && activeViewName !== data.activeView ? activeViewName : undefined,
       filters: filters.rules.length > 0 ? filters : undefined,
       search: serverSearch || undefined,
       sort: sortRules && sortRules.length > 0 ? sortRules : undefined,

--- a/apps/web/lib/enrichment-columns.test.ts
+++ b/apps/web/lib/enrichment-columns.test.ts
@@ -42,7 +42,7 @@ describe("getEligibleInputFields", () => {
 			{ id: "email", name: "Email", type: "email" },
 		])).toEqual(["people"]);
 
-		expect(getAvailableEnrichmentCategories("accounts_list", [
+		expect(getAvailableEnrichmentCategories("portfolio", [
 			{ id: "domain", name: "Domain", type: "text" },
 		])).toEqual(["company"]);
 	});

--- a/apps/web/lib/table-view-state.test.ts
+++ b/apps/web/lib/table-view-state.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { loadTableViewState, saveTableViewState } from "./table-view-state";
+
+describe("table view state persistence", () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+	});
+
+	it("removes storage when all saved view customizations return to defaults", () => {
+		saveTableViewState("people", {
+			view: "Recent leads",
+			search: "ada",
+		});
+		expect(loadTableViewState("people")).toMatchObject({
+			view: "Recent leads",
+			search: "ada",
+		});
+
+		saveTableViewState("people", {});
+
+		expect(loadTableViewState("people")).toEqual({});
+	});
+});


### PR DESCRIPTION
## Summary
- Fix high/medium Bugbot findings from recently merged PRs: stale table view persistence, duplicate CRM title saves, hidden first-column open-button clicks, and enrichment/select-option refresh behavior.
- Add focused regression coverage for the save guards, enrichment reuse refresh, generic enrichment detection, and table-view storage cleanup.

## Test plan
- pnpm --dir apps/web test app/components/workspace/column-header-menu.test.tsx app/components/crm/editable-title-heading.test.tsx lib/enrichment-columns.test.ts lib/table-view-state.test.ts
- pnpm --dir apps/web exec tsc --noEmit
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI behavior changes with added regression tests; main risk is subtle interaction/state regressions in save flows and view persistence.
> 
> **Overview**
> Fixes duplicate-save edge cases in inline editors by adding re-entrancy/identity guards: `EditableTitleHeading` now prevents Enter+blur from issuing two saves, and `SelectOptionsEditor` avoids concurrent saves and no-op re-saves (with `onMouseDown` preventing blur-triggered double-submit when clicking the save button).
> 
> Improves workspace UX/state correctness: reusing an existing enrichment output column now triggers `onCreated()` (so the fields list refreshes), the first-column “Open” affordance in `ObjectTable` no longer intercepts clicks while hidden (via `pointer-events`), and `workspace-content` stops persisting `view` to localStorage when it matches the server active view (allowing storage cleanup back to defaults).
> 
> Adds focused Vitest coverage for these regressions, including table-view-state removal when returning to defaults and updated enrichment category detection expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efe2d7e1ee3ef9cbb342603f3ae2c89337396b15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->