### PR TITLE
Fix responsive workspace table layout

### DIFF
--- a/apps/web/app/components/crm/person-profile.tsx
+++ b/apps/web/app/components/crm/person-profile.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "../ui/button";
 import { PersonAvatar } from "./person-avatar";
 import { CompanyFavicon } from "./company-favicon";
@@ -166,6 +166,39 @@ export function PersonProfile({
     [personId],
   );
 
+  // Notes is a single richtext field on the People object — same PATCH
+  // surface as `handleSaveName`. Mirroring the optimistic pattern keeps the
+  // textarea from re-rendering through a skeleton when the user blurs.
+  const handleSaveNotes = useCallback(
+    async (next: string) => {
+      const res = await fetch(
+        `/api/workspace/objects/people/entries/${encodeURIComponent(personId)}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ fields: { Notes: next } }),
+        },
+      );
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      setData((prev) =>
+        prev
+          ? {
+              ...prev,
+              person: {
+                ...prev.person,
+                notes: next,
+                updated_at: new Date().toISOString(),
+              },
+            }
+          : prev,
+      );
+    },
+    [personId],
+  );
+
   if (loading && !data) {
     return (
       <div className="flex h-full flex-col" style={{ background: "var(--color-background)" }}>
@@ -224,7 +257,7 @@ export function PersonProfile({
               onOpenCompany={onOpenCompany}
             />
           )}
-          {tab === "notes" && <NotesTab data={data} />}
+          {tab === "notes" && <NotesTab data={data} onSave={handleSaveNotes} />}
         </div>
       </div>
     </div>
@@ -658,19 +691,159 @@ function ActivityTab({
   );
 }
 
-function NotesTab({ data }: { data: PersonResponse }) {
-  if (!data.person.notes?.trim()) {
-    return (
-      <CrmEmptyState
-        title="No notes yet"
-        description="Notes added in the People object detail panel will show up here."
-      />
-    );
-  }
+// ---------------------------------------------------------------------------
+// Notes tab — inline autosaving editor
+// ---------------------------------------------------------------------------
+//
+// `Notes` is a single richtext field on the People object. Rather than send
+// the user to the workspace detail panel to type one, we render an
+// always-visible auto-growing textarea right here. The affordance IS the
+// editor — there's no click-to-edit step, no modal.
+//
+// Save model:
+//   - Autosave on blur, but skip the PATCH if the value is unchanged.
+//   - Cmd/Ctrl+Enter saves without losing focus (so the user can keep typing).
+//   - Escape reverts the draft to the last persisted value.
+//   - "Saved · just now" / "Saving…" / red retry button under the editor.
+//
+// `data.person.notes` is the source of truth; we sync `draft` to it whenever
+// the parent reloads the person (e.g., after a name save) so we don't clobber
+// fresh server state with a stale local draft.
+function NotesTab({
+  data,
+  onSave,
+}: {
+  data: PersonResponse;
+  onSave: (next: string) => Promise<void>;
+}) {
+  const persisted = data.person.notes ?? "";
+  const [draft, setDraft] = useState(persisted);
+  const [saving, setSaving] = useState(false);
+  const [savedAt, setSavedAt] = useState<string | null>(data.person.updated_at);
+  const [error, setError] = useState<string | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  // Used to short-circuit `commit()` if the value matches what's already
+  // saved — prevents a redundant PATCH on every blur.
+  const lastSavedRef = useRef(persisted);
+  // Track in-flight saves so a blur-fired save and a Cmd+Enter save can't
+  // race the optimistic state into the wrong order.
+  const savingRef = useRef(false);
+
+  useEffect(() => {
+    if (persisted !== lastSavedRef.current) {
+      lastSavedRef.current = persisted;
+      setDraft(persisted);
+    }
+  }, [persisted]);
+
+  // Auto-grow: reset to `auto` first so the textarea can shrink, then snap
+  // to scrollHeight. Re-runs every time the draft changes.
+  const autoGrow = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) {return;}
+    el.style.height = "auto";
+    el.style.height = `${Math.max(el.scrollHeight, 160)}px`;
+  }, []);
+  useEffect(() => {
+    autoGrow();
+  }, [draft, autoGrow]);
+
+  const commit = useCallback(
+    async (next: string) => {
+      if (savingRef.current) {return;}
+      if (next === lastSavedRef.current) {return;}
+      savingRef.current = true;
+      setSaving(true);
+      setError(null);
+      try {
+        await onSave(next);
+        lastSavedRef.current = next;
+        setSavedAt(new Date().toISOString());
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Couldn't save note.");
+      } finally {
+        savingRef.current = false;
+        setSaving(false);
+      }
+    },
+    [onSave],
+  );
+
+  // Re-render the "Saved · 12s ago" line over time without bumping any
+  // server state — a 30s tick is plenty granular for the relative buckets
+  // formatRelativeDate produces.
+  const [, forceTick] = useState(0);
+  useEffect(() => {
+    if (!savedAt || saving) {return;}
+    const id = window.setInterval(() => forceTick((n) => n + 1), 30_000);
+    return () => window.clearInterval(id);
+  }, [savedAt, saving]);
+
+  const firstName = data.person.name?.trim().split(/\s+/)[0] ?? null;
+  const placeholder = firstName
+    ? `Write a note about ${firstName}…`
+    : "Write a note…";
+
+  const dirty = draft !== lastSavedRef.current;
+
   return (
-    <article className="prose prose-sm max-w-none" style={{ color: "var(--color-text)" }}>
-      <pre style={{ whiteSpace: "pre-wrap", fontFamily: "inherit" }}>{data.person.notes}</pre>
-    </article>
+    <section className="space-y-2">
+      <textarea
+        ref={textareaRef}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => {
+          void commit(draft);
+        }}
+        onKeyDown={(e) => {
+          if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+            e.preventDefault();
+            void commit(draft);
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            setDraft(lastSavedRef.current);
+            setError(null);
+          }
+        }}
+        placeholder={placeholder}
+        aria-label="Notes"
+        className="w-full resize-none rounded-2xl border px-4 py-3 text-[14px] leading-relaxed transition-shadow focus:outline-none focus:ring-2 focus:ring-(--color-accent)/30"
+        style={{
+          minHeight: 160,
+          color: "var(--color-text)",
+          background: "var(--color-surface)",
+          borderColor: "var(--color-border)",
+          fontFamily: "inherit",
+        }}
+      />
+      <div
+        className="flex items-center justify-end gap-2 px-1 text-[11px]"
+        style={{ color: "var(--color-text-muted)" }}
+      >
+        {error ? (
+          <button
+            type="button"
+            onClick={() => {
+              void commit(draft);
+            }}
+            className="hover:underline"
+            style={{ color: "var(--color-error)" }}
+          >
+            Couldn&apos;t save — retry
+          </button>
+        ) : saving ? (
+          <span>Saving…</span>
+        ) : dirty ? (
+          <span style={{ opacity: 0.7 }}>Unsaved changes</span>
+        ) : savedAt ? (
+          <span>
+            Saved
+            {" · "}
+            {formatRelativeDate(savedAt) || "just now"}
+          </span>
+        ) : null}
+      </div>
+    </section>
   );
 }
 

--- a/apps/web/app/components/crm/person-profile.tsx
+++ b/apps/web/app/components/crm/person-profile.tsx
@@ -706,9 +706,9 @@ function ActivityTab({
 //   - Escape reverts the draft to the last persisted value.
 //   - "Saved · just now" / "Saving…" / red retry button under the editor.
 //
-// `data.person.notes` is the source of truth; we sync `draft` to it whenever
-// the parent reloads the person (e.g., after a name save) so we don't clobber
-// fresh server state with a stale local draft.
+// `data.person.notes` and `data.person.updated_at` are the source of truth; we
+// sync local editor state whenever the parent reloads the person so we don't
+// clobber fresh server state or show stale save timestamps.
 function NotesTab({
   data,
   onSave,
@@ -717,9 +717,10 @@ function NotesTab({
   onSave: (next: string) => Promise<void>;
 }) {
   const persisted = data.person.notes ?? "";
+  const persistedSavedAt = data.person.updated_at;
   const [draft, setDraft] = useState(persisted);
   const [saving, setSaving] = useState(false);
-  const [savedAt, setSavedAt] = useState<string | null>(data.person.updated_at);
+  const [savedAt, setSavedAt] = useState<string | null>(persistedSavedAt);
   const [error, setError] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   // Used to short-circuit `commit()` if the value matches what's already
@@ -734,7 +735,8 @@ function NotesTab({
       lastSavedRef.current = persisted;
       setDraft(persisted);
     }
-  }, [persisted]);
+    setSavedAt(persistedSavedAt);
+  }, [persisted, persistedSavedAt]);
 
   // Auto-grow: reset to `auto` first so the textarea can shrink, then snap
   // to scrollHeight. Re-runs every time the draft changes.

--- a/apps/web/app/components/workspace/column-header-menu.test.tsx
+++ b/apps/web/app/components/workspace/column-header-menu.test.tsx
@@ -49,7 +49,7 @@ describe("AddColumnPopover", () => {
 			expect(screen.getByRole("option", { name: "Email" })).toBeInTheDocument();
 		});
 		expect(inputSelect).toHaveValue("Email");
-		expect(screen.getByText(/Will enrich using.*Email.*column/)).toBeInTheDocument();
+		expect(screen.queryByText(/Will enrich using.*Email.*column/)).not.toBeInTheDocument();
 	});
 
 	it("does not render the old column-name search field in the add-column popover", async () => {

--- a/apps/web/app/components/workspace/column-header-menu.tsx
+++ b/apps/web/app/components/workspace/column-header-menu.tsx
@@ -834,12 +834,7 @@ export function AddColumnPopover({
 										))}
 									</select>
 								</div>
-								{enrichInputField && (
-									<div className="flex items-center gap-1.5 text-xs px-1" style={{ color: "var(--color-text-muted)" }}>
-										<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z" /></svg>
-										Will enrich using &ldquo;{enrichInputField}&rdquo; column
-									</div>
-								)}
+
 								{selectedOutputExists && (
 									<div className="flex items-center gap-1.5 text-xs px-1" style={{ color: "var(--color-accent)" }}>
 										<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6 9 17l-5-5" /></svg>
@@ -1010,10 +1005,6 @@ export function AddColumnPopover({
 									/>
 								</div>
 							)}
-
-							<div className="px-3 pb-2 text-[11px]" style={{ color: "var(--color-text-muted)" }}>
-								Creates &ldquo;{nextDefaultFieldName(fieldTypeLabel(type), fieldsRef.current)}&rdquo;. Rename it from the column menu after creating.
-							</div>
 
 							{error && (
 								<div className="px-3 pb-2">

--- a/apps/web/app/components/workspace/data-table.tsx
+++ b/apps/web/app/components/workspace/data-table.tsx
@@ -717,7 +717,7 @@ export function DataTable<TData, TValue>({
 				{/* Search */}
 				{enableGlobalFilter && (
 					<div
-						className="flex items-center gap-2 h-8 px-3 backdrop-blur-sm rounded-full focus-within:ring-2 focus-within:ring-(--color-accent)/30 transition-shadow max-w-[260px] min-w-[140px] shadow-[0_0_21px_0_rgba(0,0,0,0.05)]"
+						className="flex min-w-[140px] max-w-[260px] flex-[1_1_180px] items-center gap-2 h-8 px-3 backdrop-blur-sm rounded-full focus-within:ring-2 focus-within:ring-(--color-accent)/30 transition-shadow shadow-[0_0_21px_0_rgba(0,0,0,0.05)]"
 						style={{ border: "1px solid var(--color-border)", background: "var(--color-surface)" }}
 					>
 						<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0" style={{ color: "var(--color-text-muted)", opacity: 0.5 }}>
@@ -757,75 +757,75 @@ export function DataTable<TData, TValue>({
 					</div>
 				)}
 
-				<div className="flex-1" />
+				<div className="ml-auto flex min-w-0 max-w-full flex-[1_1_220px] flex-wrap items-center justify-end gap-2">
+					{toolbarExtra}
 
-				{toolbarExtra}
-
-				{/* Columns menu */}
-				<DropdownMenu>
-					<DropdownMenuTrigger
-						className="h-8 px-3 flex items-center gap-1.5 rounded-full text-xs cursor-pointer transition-colors backdrop-blur-sm shadow-[0_0_21px_0_rgba(0,0,0,0.05)] outline-none focus:outline-none"
-						style={{ color: "var(--color-text-muted)", border: "1px solid var(--color-border)", background: "var(--color-surface)" }}
-					>
-						<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-							<rect width="18" height="18" x="3" y="3" rx="2" /><path d="M9 3v18" /><path d="M15 3v18" />
-						</svg>
-						Columns
-					</DropdownMenuTrigger>
-					<DropdownMenuContent align="end" sideOffset={6}>
-						<DropdownMenuCheckboxItem
-							checked={stickyFirstColumn}
-							onSelect={() => setStickyFirstColumn((v) => !v)}
+					{/* Columns menu */}
+					<DropdownMenu>
+						<DropdownMenuTrigger
+							className="h-8 px-3 flex items-center gap-1.5 rounded-full text-xs cursor-pointer transition-colors backdrop-blur-sm shadow-[0_0_21px_0_rgba(0,0,0,0.05)] outline-none focus:outline-none"
+							style={{ color: "var(--color-text-muted)", border: "1px solid var(--color-border)", background: "var(--color-surface)" }}
 						>
-							Freeze first column
-						</DropdownMenuCheckboxItem>
-						<DropdownMenuSeparator />
-						{visibleColumns.length === 0 ? (
-							<div className="px-2 py-1.5 text-xs opacity-50">No toggleable columns</div>
-						) : (
-							table.getAllLeafColumns()
-								.filter((c) => c.id !== "__rownum" && c.id !== "select" && c.id !== "actions" && c.id !== "__add_column" && c.getCanHide())
-								.map((column) => (
-									<DropdownMenuCheckboxItem
-										key={column.id}
-										checked={column.getIsVisible()}
-										onSelect={() => column.toggleVisibility(!column.getIsVisible())}
-									>
-										{typeof column.columnDef.header === "string"
-											? column.columnDef.header
-											: String((column.columnDef.meta as Record<string, string> | undefined)?.label ?? column.id)}
-									</DropdownMenuCheckboxItem>
-								))
-						)}
-					</DropdownMenuContent>
-				</DropdownMenu>
+							<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+								<rect width="18" height="18" x="3" y="3" rx="2" /><path d="M9 3v18" /><path d="M15 3v18" />
+							</svg>
+							Columns
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end" sideOffset={6}>
+							<DropdownMenuCheckboxItem
+								checked={stickyFirstColumn}
+								onSelect={() => setStickyFirstColumn((v) => !v)}
+							>
+								Freeze first column
+							</DropdownMenuCheckboxItem>
+							<DropdownMenuSeparator />
+							{visibleColumns.length === 0 ? (
+								<div className="px-2 py-1.5 text-xs opacity-50">No toggleable columns</div>
+							) : (
+								table.getAllLeafColumns()
+									.filter((c) => c.id !== "__rownum" && c.id !== "select" && c.id !== "actions" && c.id !== "__add_column" && c.getCanHide())
+									.map((column) => (
+										<DropdownMenuCheckboxItem
+											key={column.id}
+											checked={column.getIsVisible()}
+											onSelect={() => column.toggleVisibility(!column.getIsVisible())}
+										>
+											{typeof column.columnDef.header === "string"
+												? column.columnDef.header
+												: String((column.columnDef.meta as Record<string, string> | undefined)?.label ?? column.id)}
+										</DropdownMenuCheckboxItem>
+									))
+							)}
+						</DropdownMenuContent>
+					</DropdownMenu>
 
-				{/* Refresh button */}
-				{onRefresh && (
-					<button
-						type="button"
-						onClick={onRefresh}
-						className="h-8 w-8 rounded-full flex items-center justify-center cursor-pointer transition-colors backdrop-blur-sm shadow-[0_0_21px_0_rgba(0,0,0,0.05)]"
-						style={{ border: "1px solid var(--color-border)", background: "var(--color-surface)", color: "var(--color-text-muted)" }}
-					>
-						<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" /><path d="M3 3v5h5" /><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16" /><path d="M16 21h5v-5" /></svg>
-					</button>
-				)}
+					{/* Refresh button */}
+					{onRefresh && (
+						<button
+							type="button"
+							onClick={onRefresh}
+							className="h-8 w-8 rounded-full flex items-center justify-center cursor-pointer transition-colors backdrop-blur-sm shadow-[0_0_21px_0_rgba(0,0,0,0.05)]"
+							style={{ border: "1px solid var(--color-border)", background: "var(--color-surface)", color: "var(--color-text-muted)" }}
+						>
+							<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" /><path d="M3 3v5h5" /><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16" /><path d="M16 21h5v-5" /></svg>
+						</button>
+					)}
 
-				{/* Add button */}
-				{onAdd && (
-					<button
-						type="button"
-						onClick={onAdd}
-						className="h-8 px-3 flex items-center gap-1.5 rounded-full text-xs font-medium cursor-pointer transition-colors shadow-[0_0_21px_0_rgba(0,0,0,0.05)]"
-						style={{
-							background: "var(--color-accent)",
-							color: "#fff",
-						}}
-					>
-						{addButtonLabel}
-					</button>
-				)}
+					{/* Add button */}
+					{onAdd && (
+						<button
+							type="button"
+							onClick={onAdd}
+							className="h-8 px-3 flex items-center gap-1.5 rounded-full text-xs font-medium cursor-pointer transition-colors shadow-[0_0_21px_0_rgba(0,0,0,0.05)]"
+							style={{
+								background: "var(--color-accent)",
+								color: "#fff",
+							}}
+						>
+							{addButtonLabel}
+						</button>
+					)}
+				</div>
 			</div>
 			)}
 

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -900,10 +900,7 @@ function WorkspacePageInner() {
   // Whether the left sidebar is in compact (icon-only) mode.
   const isLeftSidebarCompact = leftSidebarWidth < LEFT_SIDEBAR_FULL_MIN;
   const reservedLeftSidebarWidth = !isMobile && !leftSidebarCollapsed ? leftSidebarWidth : 0;
-  const maxUsableRightPanelWidth = useMemo(() => {
-    if (rightPanelCollapsed) {
-      return 0;
-    }
+  const availableRightPanelMaxWidth = useMemo(() => {
     const totalWidth = layoutWidth || (typeof window !== "undefined" ? window.innerWidth : 0);
     if (!totalWidth) {
       return rightPanelWidth;
@@ -913,10 +910,10 @@ function WorkspacePageInner() {
       RIGHT_PANEL_MIN,
       RIGHT_PANEL_MAX,
     );
-  }, [isMobile, layoutWidth, reservedLeftSidebarWidth, rightPanelCollapsed, rightPanelWidth]);
+  }, [layoutWidth, reservedLeftSidebarWidth, rightPanelWidth]);
   const effectiveRightPanelWidth = rightPanelCollapsed
     ? 0
-    : Math.min(rightPanelWidth, maxUsableRightPanelWidth);
+    : Math.min(rightPanelWidth, availableRightPanelMaxWidth);
 
   // Snap-aware resize handler: dragging below the compact threshold snaps to icon mode;
   // dragging into the gap between threshold and full min snaps to full min.
@@ -2618,7 +2615,7 @@ function WorkspacePageInner() {
               mode="right"
               containerRef={layoutRef}
               min={RIGHT_PANEL_MIN}
-              max={maxUsableRightPanelWidth || RIGHT_PANEL_MAX}
+              max={availableRightPanelMaxWidth}
               onResize={setRightPanelWidth}
             />
             <RightPanel>

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -162,6 +162,7 @@ const LEFT_SIDEBAR_FULL_MIN = 200;
 const LEFT_SIDEBAR_FULL_DEFAULT = 260;
 const LEFT_SIDEBAR_MIN = LEFT_SIDEBAR_COMPACT_WIDTH;
 const LEFT_SIDEBAR_MAX = 480;
+const CENTER_PANEL_MIN = 300;
 const RIGHT_PANEL_MIN = 360;
 const RIGHT_PANEL_MAX = 2000;
 const STORAGE_LEFT = "dench-workspace-left-sidebar-width";
@@ -488,6 +489,7 @@ function WorkspacePageInner() {
   const chatPanelRefs = useRef<Record<string, ChatPanelHandle | null>>({});
   // Root layout ref for resize handle position (handle follows cursor)
   const layoutRef = useRef<HTMLDivElement>(null);
+  const [layoutWidth, setLayoutWidth] = useState(0);
 
   // Live-reactive tree via SSE watcher (with browse-mode support)
   const {
@@ -564,6 +566,26 @@ function WorkspacePageInner() {
   const [terminalOpen, setTerminalOpen] = useState(false);
   const [pendingComposioAction, setPendingComposioAction] = useState<ComposioChatAction | null>(null);
   const [tableSelectionContext, setTableSelectionContext] = useState<TableSelectionContext | null>(null);
+
+  useEffect(() => {
+    const updateLayoutWidth = () => {
+      setLayoutWidth(layoutRef.current?.clientWidth ?? window.innerWidth);
+    };
+    updateLayoutWidth();
+
+    const observer =
+      typeof ResizeObserver !== "undefined" && layoutRef.current
+        ? new ResizeObserver(updateLayoutWidth)
+        : null;
+    if (layoutRef.current) {
+      observer?.observe(layoutRef.current);
+    }
+    window.addEventListener("resize", updateLayoutWidth);
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener("resize", updateLayoutWidth);
+    };
+  }, []);
 
   // Tabs state — single source of truth for content + chat tabs.
   // Replaces the older tabState/activePath/content/activeContentTabId quartet
@@ -877,6 +899,24 @@ function WorkspacePageInner() {
 
   // Whether the left sidebar is in compact (icon-only) mode.
   const isLeftSidebarCompact = leftSidebarWidth < LEFT_SIDEBAR_FULL_MIN;
+  const reservedLeftSidebarWidth = !isMobile && !leftSidebarCollapsed ? leftSidebarWidth : 0;
+  const maxUsableRightPanelWidth = useMemo(() => {
+    if (rightPanelCollapsed) {
+      return 0;
+    }
+    const totalWidth = layoutWidth || (typeof window !== "undefined" ? window.innerWidth : 0);
+    if (!totalWidth) {
+      return rightPanelWidth;
+    }
+    return clamp(
+      totalWidth - reservedLeftSidebarWidth - CENTER_PANEL_MIN,
+      RIGHT_PANEL_MIN,
+      RIGHT_PANEL_MAX,
+    );
+  }, [isMobile, layoutWidth, reservedLeftSidebarWidth, rightPanelCollapsed, rightPanelWidth]);
+  const effectiveRightPanelWidth = rightPanelCollapsed
+    ? 0
+    : Math.min(rightPanelWidth, maxUsableRightPanelWidth);
 
   // Snap-aware resize handler: dragging below the compact threshold snaps to icon mode;
   // dragging into the gap between threshold and full min snaps to full min.
@@ -1214,8 +1254,8 @@ function WorkspacePageInner() {
       setRightPanelCollapsed(false);
       return;
     }
-    const CHAT_MIN = 420;
-    const ideal = window.innerWidth - leftSidebarWidth - CHAT_MIN;
+    const totalWidth = layoutRef.current?.clientWidth ?? window.innerWidth;
+    const ideal = totalWidth - leftSidebarWidth - CENTER_PANEL_MIN;
     const wideTarget = clamp(ideal, RIGHT_PANEL_MIN, RIGHT_PANEL_MAX);
     setRightPanelCollapsed(false);
     setRightPanelWidth((current) => Math.max(current, wideTarget));
@@ -2409,7 +2449,7 @@ function WorkspacePageInner() {
 
 
       {/* ── Center: chat panel ── */}
-      <main className="flex-1 flex flex-col min-w-[420px] overflow-hidden relative" style={{ background: "var(--color-main-bg)" }}>
+      <main className="flex-1 flex flex-col min-w-[300px] overflow-hidden relative" style={{ background: "var(--color-main-bg)" }}>
         {/* Mobile top bar */}
         {isMobile && (
           <div
@@ -2566,19 +2606,19 @@ function WorkspacePageInner() {
         <aside
           className={`sidebar-animate flex-shrink-0 min-h-0 flex flex-col relative ${rightPanelCollapsed ? "overflow-hidden" : "border-l overflow-hidden"}`}
           style={{
-            width: rightPanelCollapsed ? 0 : rightPanelWidth,
-            minWidth: rightPanelCollapsed ? 0 : rightPanelWidth,
+            width: effectiveRightPanelWidth,
+            minWidth: effectiveRightPanelWidth,
             borderColor: "var(--color-border)",
             background: "var(--color-bg)",
             transition: "width 200ms ease, min-width 200ms ease",
           }}
         >
-          <div className="flex h-full min-h-0 flex-col relative overflow-hidden" style={{ width: rightPanelWidth, minWidth: rightPanelWidth }}>
+          <div className="flex h-full min-h-0 flex-col relative overflow-hidden" style={{ width: effectiveRightPanelWidth, minWidth: effectiveRightPanelWidth }}>
             <ResizeHandle
               mode="right"
               containerRef={layoutRef}
               min={RIGHT_PANEL_MIN}
-              max={RIGHT_PANEL_MAX}
+              max={maxUsableRightPanelWidth || RIGHT_PANEL_MAX}
               onResize={setRightPanelWidth}
             />
             <RightPanel>
@@ -3676,14 +3716,13 @@ function ObjectView({
         {/* Right: search, filter, views, settings, refresh, +Add.
             `ml-auto` pushes this cluster to the right edge whether the row
             wraps or not. */}
-        <div className="ml-auto flex items-center gap-1.5 flex-shrink-0">
-          {/* Search input — hidden on narrow widths so the rest of the toolbar fits */}
+        <div className="ml-auto flex min-w-0 max-w-full flex-[1_1_280px] flex-wrap items-center justify-end gap-1.5">
+          {/* Search input — shrinks/wraps before core actions disappear. */}
           <div
-            className="hidden md:flex items-center gap-1.5 h-7 px-2 rounded-md focus-within:ring-2 focus-within:ring-(--color-accent)/30 transition-shadow"
+            className="flex min-w-[128px] max-w-[180px] flex-[1_1_150px] items-center gap-1.5 h-7 px-2 rounded-md focus-within:ring-2 focus-within:ring-(--color-accent)/30 transition-shadow"
             style={{
               border: "1px solid var(--color-border)",
               background: "var(--color-surface)",
-              width: 180,
             }}
           >
             <svg

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -911,9 +911,21 @@ function WorkspacePageInner() {
       RIGHT_PANEL_MAX,
     );
   }, [layoutWidth, reservedLeftSidebarWidth, rightPanelWidth]);
-  const effectiveRightPanelWidth = rightPanelCollapsed
-    ? 0
-    : Math.min(rightPanelWidth, availableRightPanelMaxWidth);
+  // Right panel width contract — three values, three concerns:
+  //   - rightPanelWidth          → user's saved preference (persisted to localStorage,
+  //                                only mutated by the resize handle). Never used as a
+  //                                rendered width directly.
+  //   - renderedRightPanelWidth  → preference clamped to currently-available space.
+  //                                Used as the inner content width so right-panel pages
+  //                                instantly reflow when the left sidebar opens/closes,
+  //                                instead of overflowing and getting clipped by the
+  //                                outer aside's overflow-hidden.
+  //   - effectiveRightPanelWidth → renderedRightPanelWidth, but 0 while collapsed.
+  //                                Used as the OUTER aside width so collapse animates
+  //                                smoothly (outer wipes over inner; inner stays at
+  //                                rendered width during the 200ms transition).
+  const renderedRightPanelWidth = Math.min(rightPanelWidth, availableRightPanelMaxWidth);
+  const effectiveRightPanelWidth = rightPanelCollapsed ? 0 : renderedRightPanelWidth;
 
   // Snap-aware resize handler: dragging below the compact threshold snaps to icon mode;
   // dragging into the gap between threshold and full min snaps to full min.
@@ -2610,7 +2622,7 @@ function WorkspacePageInner() {
             transition: "width 200ms ease, min-width 200ms ease",
           }}
         >
-          <div className="flex h-full min-h-0 flex-col relative overflow-hidden" style={{ width: rightPanelWidth, minWidth: rightPanelWidth }}>
+          <div className="flex h-full min-h-0 flex-col relative overflow-hidden" style={{ width: renderedRightPanelWidth, minWidth: renderedRightPanelWidth }}>
             <ResizeHandle
               mode="right"
               containerRef={layoutRef}

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -1255,11 +1255,11 @@ function WorkspacePageInner() {
       return;
     }
     const totalWidth = layoutRef.current?.clientWidth ?? window.innerWidth;
-    const ideal = totalWidth - leftSidebarWidth - CENTER_PANEL_MIN;
+    const ideal = totalWidth - reservedLeftSidebarWidth - CENTER_PANEL_MIN;
     const wideTarget = clamp(ideal, RIGHT_PANEL_MIN, RIGHT_PANEL_MAX);
     setRightPanelCollapsed(false);
     setRightPanelWidth((current) => Math.max(current, wideTarget));
-  }, [leftSidebarWidth]);
+  }, [reservedLeftSidebarWidth]);
 
   const handleNavigate = useCallback(
     (
@@ -2613,7 +2613,7 @@ function WorkspacePageInner() {
             transition: "width 200ms ease, min-width 200ms ease",
           }}
         >
-          <div className="flex h-full min-h-0 flex-col relative overflow-hidden" style={{ width: effectiveRightPanelWidth, minWidth: effectiveRightPanelWidth }}>
+          <div className="flex h-full min-h-0 flex-col relative overflow-hidden" style={{ width: rightPanelWidth, minWidth: rightPanelWidth }}>
             <ResizeHandle
               mode="right"
               containerRef={layoutRef}


### PR DESCRIPTION
## Summary
- Keep the right workspace panel within the viewport when the left sidebar is expanded or the window is narrow.
- Let the center chat panel shrink further so content panels do not get pushed off-screen.
- Wrap table/object toolbar actions so search, filters, settings, refresh, and Add remain reachable at narrow widths.

## Test plan
- pnpm --dir apps/web exec tsc --noEmit
- git diff --check
- Browser checked at 1016x768 with the left sidebar expanded and the Companies table open: right panel stays inside the viewport and Add/add-column controls remain visible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core workspace layout sizing and resize behavior, which can cause responsive regressions across screen sizes. Adds new optimistic PATCH-based autosave for CRM notes, which may surface edge cases around save failures/races.
> 
> **Overview**
> **Workspace responsiveness:** The right panel now measures available layout width (via `ResizeObserver`) and clamps its rendered width so it stays within the viewport when the left sidebar expands or the window narrows; the center panel minimum width is reduced to `300px`, and the resize handle max is dynamically limited.
> 
> **Table/tooling UX:** Table toolbars are reflowed to wrap/shrink (search + actions cluster) so controls like Columns/Refresh/Add remain reachable on narrow widths; `AddColumnPopover` removes the “Will enrich using … column” hint (test updated accordingly).
> 
> **CRM notes editing:** The People profile `Notes` tab becomes an inline, auto-growing textarea with optimistic autosave (blur / Cmd+Enter), Escape-to-revert, and a saved/saving/error indicator, persisting via `PATCH` to the People entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55c9e376d933d1bfdf47ad938c8ebf7e53974611. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->