### PR TITLE
Panel width and animation

### DIFF
--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -1255,11 +1255,11 @@ function WorkspacePageInner() {
       return;
     }
     const totalWidth = layoutRef.current?.clientWidth ?? window.innerWidth;
-    const ideal = totalWidth - leftSidebarWidth - CENTER_PANEL_MIN;
+    const ideal = totalWidth - reservedLeftSidebarWidth - CENTER_PANEL_MIN;
     const wideTarget = clamp(ideal, RIGHT_PANEL_MIN, RIGHT_PANEL_MAX);
     setRightPanelCollapsed(false);
     setRightPanelWidth((current) => Math.max(current, wideTarget));
-  }, [leftSidebarWidth]);
+  }, [reservedLeftSidebarWidth]);
 
   const handleNavigate = useCallback(
     (
@@ -2613,7 +2613,7 @@ function WorkspacePageInner() {
             transition: "width 200ms ease, min-width 200ms ease",
           }}
         >
-          <div className="flex h-full min-h-0 flex-col relative overflow-hidden" style={{ width: effectiveRightPanelWidth, minWidth: effectiveRightPanelWidth }}>
+          <div className="flex h-full min-h-0 flex-col relative overflow-hidden" style={{ width: rightPanelWidth, minWidth: rightPanelWidth }}>
             <ResizeHandle
               mode="right"
               containerRef={layoutRef}


### PR DESCRIPTION
Fix right panel width calculation when left sidebar is collapsed and restore smooth right panel collapse animation.

The `ensureRightPanelOpenWide` function now correctly uses `reservedLeftSidebarWidth` to account for the left sidebar's collapsed state, preventing the right panel from opening too narrow. Additionally, the inner right panel `div` now uses `rightPanelWidth` and has a CSS transition, ensuring content smoothly clips during collapse instead of disappearing instantly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/layout tweak limited to workspace panel sizing and inline styles; main risk is minor visual regression in panel resize/collapse behavior.
> 
> **Overview**
> Fixes right-panel auto-widening to account for a collapsed left sidebar by basing `ensureRightPanelOpenWide` on `reservedLeftSidebarWidth`.
> 
> Adjusts the right panel’s inner container sizing to use `rightPanelWidth` (instead of the collapsed `effectiveRightPanelWidth`) so content clips smoothly during the outer width transition rather than disappearing abruptly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18ce36860dffa7749dae56c346ebad725a7d9958. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->