### PR TITLE
fix(chat): clean titles, lazy session creation, and visible workspace chats

### DIFF
--- a/apps/web/app/api/chat/chat.test.ts
+++ b/apps/web/app/api/chat/chat.test.ts
@@ -467,7 +467,12 @@ describe("Chat API routes", () => {
       );
     });
 
-    it("rebuilds agent message from raw user text + structured workspace context", async () => {
+    it("layers Context + Selected-table prefixes on top of inline attachments", async () => {
+      // [Attached files: …] is intentionally NOT moved into workspaceContext
+      // — it stays in the user message text because chat-message.tsx parses
+      // it to render the AttachedFilesCard. The agent prompt should have
+      // table selection FIRST, then Context, then Attached files, then user
+      // text — matching the legacy ordering the agent already understands.
       const { resolveAgentWorkspacePrefix } = await import("@/lib/workspace");
       vi.mocked(resolveAgentWorkspacePrefix).mockReturnValue(null);
       const { startRun, persistUserMessage, hasActiveRun, subscribeToRun } =
@@ -486,20 +491,23 @@ describe("Chat API routes", () => {
             {
               id: "m1",
               role: "user",
-              parts: [{ type: "text", text: "summarize this" }],
+              parts: [
+                {
+                  type: "text",
+                  text: "[Attached files: notes.md]\n\nsummarize this",
+                },
+              ],
             },
           ],
           sessionId: "s1",
           workspaceContext: {
             filePath: "~crm/people",
             isDirectory: true,
-            attachedFilePaths: ["notes.md"],
           },
         }),
       });
       await POST(req);
 
-      // Agent gets the prefixed prompt (so its tool/context use is unchanged).
       expect(startRun).toHaveBeenCalledWith(
         expect.objectContaining({
           message: expect.stringContaining(
@@ -517,11 +525,13 @@ describe("Chat API routes", () => {
           message: expect.stringContaining("summarize this"),
         }),
       );
-      // But the persisted user text stays clean — this is what the chat
-      // title backfill reads, so it must not include the bracketed prefixes.
+      // persistUserMessage stores the message text the user actually sees
+      // (with the Attached files prefix); the title cleaner strips it on read.
       expect(persistUserMessage).toHaveBeenCalledWith(
         "s1",
-        expect.objectContaining({ content: "summarize this" }),
+        expect.objectContaining({
+          content: "[Attached files: notes.md]\n\nsummarize this",
+        }),
       );
     });
 

--- a/apps/web/app/api/chat/chat.test.ts
+++ b/apps/web/app/api/chat/chat.test.ts
@@ -425,6 +425,10 @@ describe("Chat API routes", () => {
     });
 
     it("resolves workspace file paths in message", async () => {
+      // Post v3-chat refactor, the client sends raw user text plus a
+      // structured `workspaceContext` body field. The route reconstructs
+      // the `[Context: workspace file '...']` prefix and applies the
+      // workspace prefix from resolveAgentWorkspacePrefix.
       const { resolveAgentWorkspacePrefix } = await import("@/lib/workspace");
       vi.mocked(resolveAgentWorkspacePrefix).mockReturnValue("workspace");
       const { startRun, hasActiveRun, subscribeToRun } = await import("@/lib/active-runs");
@@ -441,17 +445,83 @@ describe("Chat API routes", () => {
             {
               id: "m1",
               role: "user",
-              parts: [{ type: "text", text: "[Context: workspace file 'doc.md']" }],
+              parts: [{ type: "text", text: "what does this say?" }],
             },
           ],
           sessionId: "s1",
+          workspaceContext: { filePath: "doc.md", isDirectory: false },
         }),
       });
       await POST(req);
       expect(startRun).toHaveBeenCalledWith(
         expect.objectContaining({
-          message: expect.stringContaining("workspace/doc.md"),
+          message: expect.stringContaining(
+            "[Context: workspace file 'workspace/doc.md']",
+          ),
         }),
+      );
+      expect(startRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("what does this say?"),
+        }),
+      );
+    });
+
+    it("rebuilds agent message from raw user text + structured workspace context", async () => {
+      const { resolveAgentWorkspacePrefix } = await import("@/lib/workspace");
+      vi.mocked(resolveAgentWorkspacePrefix).mockReturnValue(null);
+      const { startRun, persistUserMessage, hasActiveRun, subscribeToRun } =
+        await import("@/lib/active-runs");
+      vi.mocked(hasActiveRun).mockReturnValue(false);
+      vi.mocked(subscribeToRun).mockReturnValue(() => {});
+      vi.mocked(startRun).mockClear();
+      vi.mocked(persistUserMessage).mockClear();
+
+      const { POST } = await import("./route.js");
+      const req = new Request("http://localhost/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [
+            {
+              id: "m1",
+              role: "user",
+              parts: [{ type: "text", text: "summarize this" }],
+            },
+          ],
+          sessionId: "s1",
+          workspaceContext: {
+            filePath: "~crm/people",
+            isDirectory: true,
+            attachedFilePaths: ["notes.md"],
+          },
+        }),
+      });
+      await POST(req);
+
+      // Agent gets the prefixed prompt (so its tool/context use is unchanged).
+      expect(startRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            "[Context: workspace directory '~crm/people']",
+          ),
+        }),
+      );
+      expect(startRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("[Attached files: notes.md]"),
+        }),
+      );
+      expect(startRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("summarize this"),
+        }),
+      );
+      // But the persisted user text stays clean — this is what the chat
+      // title backfill reads, so it must not include the bracketed prefixes.
+      expect(persistUserMessage).toHaveBeenCalledWith(
+        "s1",
+        expect.objectContaining({ content: "summarize this" }),
       );
     });
 

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -33,6 +33,10 @@ import {
 	buildChatImageHydrationErrorMessage,
 	hydrateMessageImageAttachments,
 } from "@/lib/chat-image-attachments";
+import {
+	buildAgentMessage,
+	type WorkspaceContext,
+} from "@/lib/agent-message";
 
 export const runtime = "nodejs";
 
@@ -90,6 +94,7 @@ export async function POST(req: Request) {
 		modelOverride,
 		acknowledgeUnsafeOpenAiSwitch,
 		hasAssistantHistory: hasAssistantHistoryHint,
+		workspaceContext,
 	}: {
 		messages: UIMessage[];
 		sessionId?: string;
@@ -99,6 +104,7 @@ export async function POST(req: Request) {
 		modelOverride?: string;
 		acknowledgeUnsafeOpenAiSwitch?: boolean;
 		hasAssistantHistory?: boolean;
+		workspaceContext?: WorkspaceContext;
 	} = await req.json();
 
 	const lastUserMessage = messages.filter((m) => m.role === "user").pop();
@@ -174,14 +180,17 @@ export async function POST(req: Request) {
 		}
 	}
 
-	let agentMessage = userText;
+	// Build the prompt the agent sees. With workspaceContext sent as a
+	// structured body field (post v3-chat refactor), prefixes are
+	// reconstructed here rather than parsed back out of userText. Legacy
+	// callers without workspaceContext still work because buildAgentMessage
+	// returns userText unchanged when no context is supplied.
 	const wsPrefix = resolveAgentWorkspacePrefix();
-	if (wsPrefix) {
-		agentMessage = userText.replace(
-			/\[Context: workspace file '([^']+)'\]/,
-			`[Context: workspace file '${wsPrefix}/$1']`,
-		);
-	}
+	const agentMessage = buildAgentMessage({
+		userText,
+		workspaceContext,
+		workspacePrefix: wsPrefix,
+	});
 	const imageHydration = hydrateMessageImageAttachments(agentMessage);
 	const imageHydrationError = buildChatImageHydrationErrorMessage(
 		imageHydration.skipped,

--- a/apps/web/app/api/web-sessions/[id]/messages/route.ts
+++ b/apps/web/app/api/web-sessions/[id]/messages/route.ts
@@ -6,6 +6,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { resolveWebChatDir } from "@/lib/workspace";
+import { cleanTitleText } from "../../shared";
 
 export const dynamic = "force-dynamic";
 
@@ -137,10 +138,7 @@ function deriveTitleFromMessages(lines: string[]): string | null {
           .map((p: UITextPart) => p.text)
           .join(" ");
       }
-      const cleaned = text
-        .replace(/\[Attached files:[^\]]*\]/g, "")
-        .replace(/\s+/g, " ")
-        .trim();
+      const cleaned = cleanTitleText(text);
       if (!cleaned) {continue;}
       return cleaned.length > 60 ? cleaned.slice(0, 60).trimEnd() + "…" : cleaned;
     } catch {

--- a/apps/web/app/api/web-sessions/shared.ts
+++ b/apps/web/app/api/web-sessions/shared.ts
@@ -85,15 +85,25 @@ export function readIndex(): WebSessionMeta[] {
       dirty = true;
     }
 
-    // 2) Retitle any indexed session that still says "New Chat" but has
-    //    actual user content on disk. This catches chats that were
-    //    created before the server-side auto-title logic landed.
+    // 2) Retitle indexed sessions whose stored title needs cleanup:
+    //    - still says "New Chat" but has user content on disk (chats
+    //      created before the server-side auto-title logic landed), or
+    //    - currently displays a bracketed prefix like
+    //      `[Context: workspace file '...']` / `[Selected table ...]` /
+    //      `[Attached files: ...]` that leaked in before the v3-chat wire
+    //      format moved that metadata to a structured field.
     for (const session of index) {
-      if (session.title && session.title !== "New Chat") {continue;}
+      const needsBackfill = !session.title || session.title === "New Chat";
+      const hasBracketPrefix =
+        !!session.title &&
+        /\[(?:Context: workspace|Selected table|Attached files:)/.test(
+          session.title,
+        );
+      if (!needsBackfill && !hasBracketPrefix) {continue;}
       const fp = join(dir, `${session.id}.jsonl`);
       if (!existsSync(fp)) {continue;}
       const { title } = summarizeSessionFile(fp);
-      if (title && title !== "New Chat") {
+      if (title && title !== "New Chat" && title !== session.title) {
         session.title = title;
         dirty = true;
       }
@@ -106,6 +116,23 @@ export function readIndex(): WebSessionMeta[] {
   } catch { /* best-effort */ }
 
   return index;
+}
+
+/**
+ * Strip workspace-context/attachment/table-selection prefixes from text
+ * intended for use as a chat title. Older sessions baked these prefixes
+ * directly into the persisted user message (the new wire format sends
+ * them as a structured `workspaceContext` field instead), so this cleanup
+ * is what retroactively fixes ugly titles like
+ * `[Context: workspace file 'company']` showing up in the sidebar.
+ */
+export function cleanTitleText(text: string): string {
+  return text
+    .replace(/\[Context:\s*workspace\s+(?:file|directory)\s+'[^']*'\]/g, "")
+    .replace(/\[Selected table (?:rows|cells)[^\]]*\][\s\S]*?(?=\n\n|$)/g, "")
+    .replace(/\[Attached files:[^\]]*\]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 /**
@@ -139,10 +166,7 @@ function summarizeSessionFile(fp: string): { title: string; messageCount: number
             .map((p: UITextPart) => p.text)
             .join(" ");
         }
-        const cleaned = text
-          .replace(/\[Attached files:[^\]]*\]/g, "")
-          .replace(/\s+/g, " ")
-          .trim();
+        const cleaned = cleanTitleText(text);
         if (!cleaned) {continue;}
         title = cleaned.length > 60 ? cleaned.slice(0, 60).trimEnd() + "…" : cleaned;
         break;

--- a/apps/web/app/api/web-sessions/web-sessions.test.ts
+++ b/apps/web/app/api/web-sessions/web-sessions.test.ts
@@ -119,6 +119,24 @@ describe("Web Sessions API", () => {
       expect(mockWrite).toHaveBeenCalled();
     });
 
+    it("creates a workspace-level session (no filePath) when filePath is omitted", async () => {
+      // The chat panel's createSession (post v3 fix) intentionally never
+      // sends `filePath` — workspace context is now per-message, not
+      // per-session. The sidebar filter still hides any session that
+      // does have a filePath, so this assertion guards against a
+      // regression where filePath sneaks back into createSession bodies.
+      const { POST } = await import("./route.js");
+      const req = new Request("http://localhost/api/web-sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "Workspace Chat" }),
+      });
+      const res = await POST(req);
+      const json = await res.json();
+      expect(json.session.title).toBe("Workspace Chat");
+      expect(json.session.filePath).toBeUndefined();
+    });
+
     it("creates session with custom title", async () => {
       const { POST } = await import("./route.js");
       const req = new Request("http://localhost/api/web-sessions", {

--- a/apps/web/app/api/web-sessions/web-sessions.test.ts
+++ b/apps/web/app/api/web-sessions/web-sessions.test.ts
@@ -301,4 +301,55 @@ describe("Web Sessions API", () => {
       expect(mockWrite).toHaveBeenCalled();
     });
   });
+
+  describe("cleanTitleText", () => {
+    it("strips [Attached files: ...] prefixes", async () => {
+      const { cleanTitleText } = await import("./shared.js");
+      expect(
+        cleanTitleText("[Attached files: a.md, b.md]\n\nsummarize"),
+      ).toBe("summarize");
+    });
+
+    it("strips [Context: workspace file '...'] prefixes", async () => {
+      const { cleanTitleText } = await import("./shared.js");
+      expect(
+        cleanTitleText("[Context: workspace file 'company']\n\nhow you doing?"),
+      ).toBe("how you doing?");
+    });
+
+    it("strips [Context: workspace directory '...'] prefixes", async () => {
+      const { cleanTitleText } = await import("./shared.js");
+      expect(
+        cleanTitleText(
+          "[Context: workspace directory '~crm/people']\n\nlist everyone",
+        ),
+      ).toBe("list everyone");
+    });
+
+    it("strips [Selected table rows: ...] blocks even when multiline", async () => {
+      const { cleanTitleText } = await import("./shared.js");
+      const input =
+        "[Selected table rows: people]\n3 rows selected.\nColumns: name, email\n- row 1 (p1): name: Ada\n\nwhat are these?";
+      expect(cleanTitleText(input)).toBe("what are these?");
+    });
+
+    it("strips multiple stacked prefixes from a single message", async () => {
+      const { cleanTitleText } = await import("./shared.js");
+      const input =
+        "[Selected table cells: people]\n1 row selected.\n\n[Context: workspace directory '~crm/people']\n\n[Attached files: notes.md]\n\nhelp me write a follow up";
+      expect(cleanTitleText(input)).toBe("help me write a follow up");
+    });
+
+    it("returns empty string when message is only prefixes", async () => {
+      const { cleanTitleText } = await import("./shared.js");
+      expect(
+        cleanTitleText("[Context: workspace file 'doc.md']"),
+      ).toBe("");
+    });
+
+    it("leaves untouched text alone", async () => {
+      const { cleanTitleText } = await import("./shared.js");
+      expect(cleanTitleText("plain old message")).toBe("plain old message");
+    });
+  });
 });

--- a/apps/web/app/components/chat-panel.tsx
+++ b/apps/web/app/components/chat-panel.tsx
@@ -1801,26 +1801,36 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 					onSessionsChange?.();
 				}
 
-				// Merge mention paths and attachment paths into the structured
-				// workspaceContext sent alongside the message. Previously these
-				// were baked into the user message as `[Attached files: …]` /
-				// `[Context: workspace …]` / `[Selected table …]` prefixes;
-				// that polluted the persisted user text and produced ugly chat
-				// titles. We now send raw userText to /api/chat and rebuild
-				// the agent prompt server-side via buildAgentMessage.
+				// Two prefix kinds, two destinations:
+				//
+				// 1. `[Attached files: …]` stays inline in the user message
+				//    text. chat-message.tsx parses it back out to render
+				//    the AttachedFilesCard above the bubble, so this prefix
+				//    is load-bearing for the UI. The session-title cleaner
+				//    strips it, so titles still read like normal prose.
+				// 2. `[Context: workspace …]` and `[Selected table …]` are
+				//    agent-only signals (no UI affordance). They move to a
+				//    structured `workspaceContext` body field so they never
+				//    end up in the persisted user text — that polluted
+				//    chat titles in the sidebar and was the bug report.
 				const allFilePaths = [
 					...mentionedFiles.map((f) => f.path),
 					...currentAttachments.map((f) => f.path),
 				];
+
+				let messageText = userText;
+				if (allFilePaths.length > 0) {
+					const prefix = `[Attached files: ${allFilePaths.join(", ")}]`;
+					messageText = messageText
+						? `${prefix}\n\n${messageText}`
+						: prefix;
+				}
 
 				const announceFilePath =
 					!!fileContext &&
 					lastAnnouncedFilePathRef.current !== fileContext.path;
 
 				const workspaceContext: WorkspaceContext = {};
-				if (allFilePaths.length > 0) {
-					workspaceContext.attachedFilePaths = allFilePaths;
-				}
 				if (announceFilePath && fileContext) {
 					workspaceContext.filePath = fileContext.path;
 					workspaceContext.isDirectory = fileContext.isDirectory;
@@ -1833,10 +1843,11 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 					lastAnnouncedFilePathRef.current = fileContext.path;
 				}
 
-				// Store HTML keyed by raw userText so the user-message renderer
-				// (chat-message.tsx) can recover the rich-text version when
-				// echoing back the message that was just sent.
-				userHtmlMapRef.current.set(userText, html);
+				// Store HTML keyed by the message text the renderer will see
+				// (with [Attached files: …] inline) so chat-message.tsx can
+				// recover the rich-text version when echoing back the
+				// message that was just sent.
+				userHtmlMapRef.current.set(messageText, html);
 				pendingHtmlRef.current = html;
 
 				userScrolledAwayRef.current = false;
@@ -1844,27 +1855,23 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 				if (gatewaySessionKey) {
 					// The gateway flow is a separate transport (POST /api/gateway/chat
 					// sends `{message: string}` to an upstream gateway that owns
-					// session storage). It still expects an inline-prefixed prompt,
-					// so we assemble messageText the legacy way for that path only.
-					let messageText = userText;
-					if (allFilePaths.length > 0) {
-						const prefix = `[Attached files: ${allFilePaths.join(", ")}]`;
-						messageText = messageText
-							? `${prefix}\n\n${messageText}`
-							: prefix;
-					}
+					// session storage). It still expects an inline-prefixed prompt
+					// for ALL signals — including Context/Selected-table — since
+					// it has no `workspaceContext` field, so assemble the full
+					// legacy messageText for that path only.
+					let gatewayMessageText = messageText;
 					if (announceFilePath && fileContext) {
 						const label = fileContext.isDirectory ? "directory" : "file";
-						messageText = `[Context: workspace ${label} '${fileContext.path}']\n\n${messageText}`;
+						gatewayMessageText = `[Context: workspace ${label} '${fileContext.path}']\n\n${gatewayMessageText}`;
 					}
 					if (fileContext?.tableSelection) {
-						messageText = `${formatTableSelectionContext(fileContext.tableSelection)}\n\n${messageText}`;
+						gatewayMessageText = `${formatTableSelectionContext(fileContext.tableSelection)}\n\n${gatewayMessageText}`;
 					}
 
 					const userMsg = {
 						id: `user-${Date.now()}`,
 						role: "user" as const,
-						parts: [{ type: "text" as const, text: messageText }] as UIMessage["parts"],
+						parts: [{ type: "text" as const, text: gatewayMessageText }] as UIMessage["parts"],
 					};
 					setMessages((prev) => [...prev, userMsg]);
 
@@ -1872,7 +1879,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 						const res = await fetch("/api/gateway/chat", {
 							method: "POST",
 							headers: { "Content-Type": "application/json" },
-							body: JSON.stringify({ sessionKey: gatewaySessionKey, message: messageText }),
+							body: JSON.stringify({ sessionKey: gatewaySessionKey, message: gatewayMessageText }),
 						});
 						if (res.ok && res.body) {
 							setStreamError(null);
@@ -1885,12 +1892,13 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 						setStreamError("Failed to send message.");
 					}
 				} else {
-					// /api/chat path: send raw userText + structured
-					// workspaceContext via the transport body callback.
+					// /api/chat path: send messageText (raw text + inline
+					// attachments prefix only) + structured workspaceContext
+					// via the transport body callback.
 					if (Object.keys(workspaceContext).length > 0) {
 						pendingWorkspaceContextRef.current = workspaceContext;
 					}
-					void sendMessage({ text: userText });
+					void sendMessage({ text: messageText });
 				}
 
 				setTimeout(() => {

--- a/apps/web/app/components/chat-panel.tsx
+++ b/apps/web/app/components/chat-panel.tsx
@@ -1098,8 +1098,10 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 			}
 		}, [messages.length, optimisticUserText]);
 
-		// Track an in-flight pre-created session so we don't fire it twice.
-		const preCreatedSessionRef = useRef<Promise<string> | null>(null);
+		// Sessions are now created lazily on the first submit (see
+		// handleEditorSubmit). The previous "warmup on hero mount" path
+		// produced empty session rows in the sidebar whenever the user
+		// opened a +/new chat and then navigated away without typing.
 
 		const isStreaming =
 			status === "streaming" ||
@@ -1825,10 +1827,13 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 						setOptimisticUserText(userText);
 					}
 
-					// Reuse a session that may already be in flight from the
-					// pre-create-on-mount warmup. Fall back to a fresh call.
-					sessionId = await (preCreatedSessionRef.current ?? createSession(title));
-					preCreatedSessionRef.current = null;
+					// Create the session lazily on first submit. This is the
+					// only place where a workspace-level session is created
+					// from the chat panel — the previous mount-time warmup
+					// was removed because it produced empty session rows in
+					// the sidebar whenever a user opened a chat and walked
+					// away without typing.
+					sessionId = await createSession(title);
 					setCurrentSessionId(sessionId);
 					sessionIdRef.current = sessionId;
 					onActiveSessionChange?.(sessionId);
@@ -2096,13 +2101,6 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 			userHtmlMapRef.current.clear();
 			lastAnnouncedFilePathRef.current = null;
 			newSessionPendingRef.current = false;
-			// Drop any in-flight warmup session — otherwise the next submit
-			// would reuse the pre-warmed id (handleEditorSubmit reads this
-			// ref before falling back to a fresh createSession), silently
-			// threading the "new" chat into the old session instead of
-			// starting clean. The pre-create effect will re-arm on the next
-			// tick for the new chat.
-			preCreatedSessionRef.current = null;
 			setQueuedMessages([]);
 			requestAnimationFrame(() => {
 				editorRef.current?.focus();
@@ -2305,25 +2303,6 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 			!isSubagentMode &&
 			!loadingSession &&
 			optimisticUserText === null;
-
-		// Warm up the session in the background while the user is still on
-		// the hero screen, so the first submit doesn't pay for createSession
-		// (which can be slow on cold-start dev compiles). Pre-creates only
-		// when the panel is visible and there's no session yet.
-		useEffect(() => {
-			if (
-				!visible ||
-				currentSessionId ||
-				isSubagentMode ||
-				isGatewayMode ||
-				loadingSession ||
-				preCreatedSessionRef.current ||
-				messages.length > 0
-			) {
-				return;
-			}
-			preCreatedSessionRef.current = createSession("New Chat");
-		}, [visible, currentSessionId, isSubagentMode, isGatewayMode, loadingSession, messages.length, createSession]);
 
 		// ── Input bar content (shared between hero and bottom positions) ──
 

--- a/apps/web/app/components/chat-panel.tsx
+++ b/apps/web/app/components/chat-panel.tsx
@@ -1843,11 +1843,6 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 					lastAnnouncedFilePathRef.current = fileContext.path;
 				}
 
-				// Store HTML keyed by the message text the renderer will see
-				// (with [Attached files: …] inline) so chat-message.tsx can
-				// recover the rich-text version when echoing back the
-				// message that was just sent.
-				userHtmlMapRef.current.set(messageText, html);
 				pendingHtmlRef.current = html;
 
 				userScrolledAwayRef.current = false;
@@ -1867,6 +1862,12 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 					if (fileContext?.tableSelection) {
 						gatewayMessageText = `${formatTableSelectionContext(fileContext.tableSelection)}\n\n${gatewayMessageText}`;
 					}
+
+					// Key the HTML map by the SAME text the UI message will carry,
+					// so chat-message.tsx's `userHtmlMap.get(textContent)` lookup
+					// matches and the rich rendering (mention pills etc.) is
+					// preserved on first render of the user's bubble.
+					userHtmlMapRef.current.set(gatewayMessageText, html);
 
 					const userMsg = {
 						id: `user-${Date.now()}`,
@@ -1895,6 +1896,11 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 					// /api/chat path: send messageText (raw text + inline
 					// attachments prefix only) + structured workspaceContext
 					// via the transport body callback.
+					//
+					// useChat's sendMessage will create a UI message whose
+					// text part equals `messageText`, so key the HTML map by
+					// `messageText` to match chat-message.tsx's lookup.
+					userHtmlMapRef.current.set(messageText, html);
 					if (Object.keys(workspaceContext).length > 0) {
 						pendingWorkspaceContextRef.current = workspaceContext;
 					}

--- a/apps/web/app/components/chat-panel.tsx
+++ b/apps/web/app/components/chat-panel.tsx
@@ -41,6 +41,7 @@ import type { ComposioChatAction } from "@/lib/composio-chat-actions";
 import type { ChatModelOption } from "@/lib/chat-models";
 import { prepareFilesForChatUpload } from "@/lib/chat-image-preparation";
 import { formatTableSelectionContext, type TableSelectionContext } from "@/lib/table-selection";
+import type { WorkspaceContext } from "@/lib/agent-message";
 
 // ── Attachment types & helpers ──
 
@@ -982,6 +983,13 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 		const userHtmlMapRef = useRef(new Map<string, string>());
 		const pendingHtmlRef = useRef<string | null>(null);
 
+		// Workspace context to send with the next /api/chat POST. Set by
+		// handleEditorSubmit just before it calls sendMessage; read once and
+		// cleared by the transport body callback below. Sending it as a
+		// structured field (instead of baking prefixes into the user message)
+		// keeps persisted user text — and the chat title — clean.
+		const pendingWorkspaceContextRef = useRef<WorkspaceContext | null>(null);
+
 		// ── Message queue (messages to send after current run completes) ──
 		const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([]);
 		// Ref mirror of queuedMessages, so callbacks that close over state
@@ -1052,6 +1060,10 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 						if (pendingHtmlRef.current) {
 							extra.userHtml = pendingHtmlRef.current;
 							pendingHtmlRef.current = null;
+						}
+						if (pendingWorkspaceContextRef.current) {
+							extra.workspaceContext = pendingWorkspaceContextRef.current;
+							pendingWorkspaceContextRef.current = null;
 						}
 					return extra;
 				},
@@ -1831,38 +1843,66 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 					}
 				}
 
-				// Build message with optional attachment prefix
-				let messageText = userText;
-
-				// Merge mention paths and attachment paths
+				// Merge mention paths and attachment paths into the structured
+				// workspaceContext sent alongside the message. Previously these
+				// were baked into the user message as `[Attached files: …]` /
+				// `[Context: workspace …]` / `[Selected table …]` prefixes;
+				// that polluted the persisted user text and produced ugly chat
+				// titles. We now send raw userText to /api/chat and rebuild
+				// the agent prompt server-side via buildAgentMessage.
 				const allFilePaths = [
 					...mentionedFiles.map((f) => f.path),
 					...currentAttachments.map((f) => f.path),
 				];
+
+				const announceFilePath =
+					!!fileContext &&
+					lastAnnouncedFilePathRef.current !== fileContext.path;
+
+				const workspaceContext: WorkspaceContext = {};
 				if (allFilePaths.length > 0) {
-					const prefix = `[Attached files: ${allFilePaths.join(", ")}]`;
-					messageText = messageText
-						? `${prefix}\n\n${messageText}`
-						: prefix;
+					workspaceContext.attachedFilePaths = allFilePaths;
+				}
+				if (announceFilePath && fileContext) {
+					workspaceContext.filePath = fileContext.path;
+					workspaceContext.isDirectory = fileContext.isDirectory;
+				}
+				if (fileContext?.tableSelection) {
+					workspaceContext.tableSelection = fileContext.tableSelection;
 				}
 
-				if (fileContext && lastAnnouncedFilePathRef.current !== fileContext.path) {
-					const label = fileContext.isDirectory ? "directory" : "file";
-					messageText = `[Context: workspace ${label} '${fileContext.path}']\n\n${messageText}`;
+				if (announceFilePath && fileContext) {
 					lastAnnouncedFilePathRef.current = fileContext.path;
 				}
 
-				if (fileContext?.tableSelection) {
-					messageText = `${formatTableSelectionContext(fileContext.tableSelection)}\n\n${messageText}`;
-				}
-
-				// Store HTML for display and pipe to server via transport
-				userHtmlMapRef.current.set(messageText, html);
+				// Store HTML keyed by raw userText so the user-message renderer
+				// (chat-message.tsx) can recover the rich-text version when
+				// echoing back the message that was just sent.
+				userHtmlMapRef.current.set(userText, html);
 				pendingHtmlRef.current = html;
 
 				userScrolledAwayRef.current = false;
 
 				if (gatewaySessionKey) {
+					// The gateway flow is a separate transport (POST /api/gateway/chat
+					// sends `{message: string}` to an upstream gateway that owns
+					// session storage). It still expects an inline-prefixed prompt,
+					// so we assemble messageText the legacy way for that path only.
+					let messageText = userText;
+					if (allFilePaths.length > 0) {
+						const prefix = `[Attached files: ${allFilePaths.join(", ")}]`;
+						messageText = messageText
+							? `${prefix}\n\n${messageText}`
+							: prefix;
+					}
+					if (announceFilePath && fileContext) {
+						const label = fileContext.isDirectory ? "directory" : "file";
+						messageText = `[Context: workspace ${label} '${fileContext.path}']\n\n${messageText}`;
+					}
+					if (fileContext?.tableSelection) {
+						messageText = `${formatTableSelectionContext(fileContext.tableSelection)}\n\n${messageText}`;
+					}
+
 					const userMsg = {
 						id: `user-${Date.now()}`,
 						role: "user" as const,
@@ -1887,7 +1927,12 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 						setStreamError("Failed to send message.");
 					}
 				} else {
-					void sendMessage({ text: messageText });
+					// /api/chat path: send raw userText + structured
+					// workspaceContext via the transport body callback.
+					if (Object.keys(workspaceContext).length > 0) {
+						pendingWorkspaceContextRef.current = workspaceContext;
+					}
+					void sendMessage({ text: userText });
 				}
 
 				setTimeout(() => {

--- a/apps/web/app/components/chat-panel.tsx
+++ b/apps/web/app/components/chat-panel.tsx
@@ -763,14 +763,6 @@ export type FileContext = {
 	tableSelection?: TableSelectionContext;
 };
 
-type FileScopedSession = {
-	id: string;
-	title: string;
-	createdAt: number;
-	updatedAt: number;
-	messageCount: number;
-};
-
 /** A message waiting to be sent after the current agent run finishes. */
 type QueuedMessage = {
 	id: string;
@@ -973,11 +965,6 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 		// the user opens a different file on the right panel and sends a new message,
 		// the agent is re-informed about the current context.
 		const lastAnnouncedFilePathRef = useRef<string | null>(null);
-
-		// File-scoped session list (compact mode only)
-		const [fileSessions, setFileSessions] = useState<
-			FileScopedSession[]
-		>([]);
 
 		// ── Rich HTML for user messages (keyed by message ID or text fallback) ──
 		const userHtmlMapRef = useRef(new Map<string, string>());
@@ -1240,19 +1227,24 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 
 		const createSession = useCallback(
 			async (title: string): Promise<string> => {
-				const body: Record<string, string> = { title };
-				if (filePath) {
-					body.filePath = filePath;
-				}
+				// All chat sessions are workspace-level since the v3 three-column
+				// refactor. The previous behavior — binding `filePath` on the
+				// session whenever any content tab was active — caused the
+				// workspace sidebar to hide perfectly normal chats started from
+				// CRM views or virtual tabs (the sidebar still filters out
+				// sessions with `filePath` set, which is the correct behavior
+				// for legacy file-scoped sessions). Workspace context for the
+				// agent is now carried per-message via `workspaceContext` on
+				// POST /api/chat, so the session itself stays unscoped.
 				const res = await fetch("/api/web-sessions", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify(body),
+					body: JSON.stringify({ title }),
 				});
 				const data = await res.json();
 				return data.session.id;
 			},
-			[filePath],
+			[],
 		);
 
 		// ── Stream reconnection ──
@@ -1393,34 +1385,11 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 			[setMessages],
 		);
 
-		// ── File-scoped session initialization ──
-		const fetchFileSessionsRef = useRef<
-			(() => Promise<FileScopedSession[]>) | null
-		>(null);
-
-		fetchFileSessionsRef.current = async () => {
-			if (!filePath) {
-				return [];
-			}
-			try {
-				const res = await fetch(
-					`/api/web-sessions?filePath=${encodeURIComponent(filePath)}`,
-				);
-				const data = await res.json();
-				return (data.sessions || []) as FileScopedSession[];
-			} catch {
-				return [];
-			}
-		};
-
-		// v3 three-column refactor: file-scoped sessions were removed.
-		// The center chat keeps its current session regardless of which file is opened on
-		// the right panel. `fileContext` (via `filePath`) only augments the message payload
-		// ("[Context: workspace file 'X']") and the input placeholder — it no longer resets
-		// the panel or swaps to a file-scoped session.
-		useEffect(() => {
-			return;
-		}, [filePath]);
+		// v3 three-column refactor: file-scoped sessions were removed. The
+		// center chat keeps its current session regardless of which file is
+		// open on the right panel. `fileContext` (via `filePath`) only
+		// augments the per-message workspaceContext payload — it never
+		// resets the panel or swaps to a file-scoped session.
 
 		// v3: auto-restore session on mount or URL change.
 		// Note: this previously short-circuited when `filePath` was set (file-scoped chat mode);
@@ -1631,14 +1600,6 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 					savedMessageIdsRef.current.add(m.id);
 				}
 
-			if (filePath) {
-				void fetchFileSessionsRef.current?.().then(
-					(sessions) => {
-						setFileSessions(sessions);
-					},
-				);
-			}
-
 			if (filePath && onFileChanged) {
 					fetch(
 						`/api/workspace/file?path=${encodeURIComponent(filePath)}`,
@@ -1838,14 +1799,6 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 					sessionIdRef.current = sessionId;
 					onActiveSessionChange?.(sessionId);
 					onSessionsChange?.();
-
-					if (filePath) {
-						void fetchFileSessionsRef.current?.().then(
-							(sessions) => {
-								setFileSessions(sessions);
-							},
-						);
-					}
 				}
 
 				// Merge mention paths and attachment paths into the structured
@@ -1951,7 +1904,6 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 				createSession,
 				onActiveSessionChange,
 				onSessionsChange,
-				filePath,
 				fileContext,
 				sendMessage,
 				gatewaySessionKey,

--- a/apps/web/app/components/crm/person-profile.tsx
+++ b/apps/web/app/components/crm/person-profile.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "../ui/button";
 import { PersonAvatar } from "./person-avatar";
 import { CompanyFavicon } from "./company-favicon";
@@ -166,6 +166,39 @@ export function PersonProfile({
     [personId],
   );
 
+  // Notes is a single richtext field on the People object — same PATCH
+  // surface as `handleSaveName`. Mirroring the optimistic pattern keeps the
+  // textarea from re-rendering through a skeleton when the user blurs.
+  const handleSaveNotes = useCallback(
+    async (next: string) => {
+      const res = await fetch(
+        `/api/workspace/objects/people/entries/${encodeURIComponent(personId)}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ fields: { Notes: next } }),
+        },
+      );
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      setData((prev) =>
+        prev
+          ? {
+              ...prev,
+              person: {
+                ...prev.person,
+                notes: next,
+                updated_at: new Date().toISOString(),
+              },
+            }
+          : prev,
+      );
+    },
+    [personId],
+  );
+
   if (loading && !data) {
     return (
       <div className="flex h-full flex-col" style={{ background: "var(--color-background)" }}>
@@ -224,7 +257,7 @@ export function PersonProfile({
               onOpenCompany={onOpenCompany}
             />
           )}
-          {tab === "notes" && <NotesTab data={data} />}
+          {tab === "notes" && <NotesTab data={data} onSave={handleSaveNotes} />}
         </div>
       </div>
     </div>
@@ -658,19 +691,159 @@ function ActivityTab({
   );
 }
 
-function NotesTab({ data }: { data: PersonResponse }) {
-  if (!data.person.notes?.trim()) {
-    return (
-      <CrmEmptyState
-        title="No notes yet"
-        description="Notes added in the People object detail panel will show up here."
-      />
-    );
-  }
+// ---------------------------------------------------------------------------
+// Notes tab — inline autosaving editor
+// ---------------------------------------------------------------------------
+//
+// `Notes` is a single richtext field on the People object. Rather than send
+// the user to the workspace detail panel to type one, we render an
+// always-visible auto-growing textarea right here. The affordance IS the
+// editor — there's no click-to-edit step, no modal.
+//
+// Save model:
+//   - Autosave on blur, but skip the PATCH if the value is unchanged.
+//   - Cmd/Ctrl+Enter saves without losing focus (so the user can keep typing).
+//   - Escape reverts the draft to the last persisted value.
+//   - "Saved · just now" / "Saving…" / red retry button under the editor.
+//
+// `data.person.notes` is the source of truth; we sync `draft` to it whenever
+// the parent reloads the person (e.g., after a name save) so we don't clobber
+// fresh server state with a stale local draft.
+function NotesTab({
+  data,
+  onSave,
+}: {
+  data: PersonResponse;
+  onSave: (next: string) => Promise<void>;
+}) {
+  const persisted = data.person.notes ?? "";
+  const [draft, setDraft] = useState(persisted);
+  const [saving, setSaving] = useState(false);
+  const [savedAt, setSavedAt] = useState<string | null>(data.person.updated_at);
+  const [error, setError] = useState<string | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  // Used to short-circuit `commit()` if the value matches what's already
+  // saved — prevents a redundant PATCH on every blur.
+  const lastSavedRef = useRef(persisted);
+  // Track in-flight saves so a blur-fired save and a Cmd+Enter save can't
+  // race the optimistic state into the wrong order.
+  const savingRef = useRef(false);
+
+  useEffect(() => {
+    if (persisted !== lastSavedRef.current) {
+      lastSavedRef.current = persisted;
+      setDraft(persisted);
+    }
+  }, [persisted]);
+
+  // Auto-grow: reset to `auto` first so the textarea can shrink, then snap
+  // to scrollHeight. Re-runs every time the draft changes.
+  const autoGrow = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) {return;}
+    el.style.height = "auto";
+    el.style.height = `${Math.max(el.scrollHeight, 160)}px`;
+  }, []);
+  useEffect(() => {
+    autoGrow();
+  }, [draft, autoGrow]);
+
+  const commit = useCallback(
+    async (next: string) => {
+      if (savingRef.current) {return;}
+      if (next === lastSavedRef.current) {return;}
+      savingRef.current = true;
+      setSaving(true);
+      setError(null);
+      try {
+        await onSave(next);
+        lastSavedRef.current = next;
+        setSavedAt(new Date().toISOString());
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Couldn't save note.");
+      } finally {
+        savingRef.current = false;
+        setSaving(false);
+      }
+    },
+    [onSave],
+  );
+
+  // Re-render the "Saved · 12s ago" line over time without bumping any
+  // server state — a 30s tick is plenty granular for the relative buckets
+  // formatRelativeDate produces.
+  const [, forceTick] = useState(0);
+  useEffect(() => {
+    if (!savedAt || saving) {return;}
+    const id = window.setInterval(() => forceTick((n) => n + 1), 30_000);
+    return () => window.clearInterval(id);
+  }, [savedAt, saving]);
+
+  const firstName = data.person.name?.trim().split(/\s+/)[0] ?? null;
+  const placeholder = firstName
+    ? `Write a note about ${firstName}…`
+    : "Write a note…";
+
+  const dirty = draft !== lastSavedRef.current;
+
   return (
-    <article className="prose prose-sm max-w-none" style={{ color: "var(--color-text)" }}>
-      <pre style={{ whiteSpace: "pre-wrap", fontFamily: "inherit" }}>{data.person.notes}</pre>
-    </article>
+    <section className="space-y-2">
+      <textarea
+        ref={textareaRef}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => {
+          void commit(draft);
+        }}
+        onKeyDown={(e) => {
+          if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+            e.preventDefault();
+            void commit(draft);
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            setDraft(lastSavedRef.current);
+            setError(null);
+          }
+        }}
+        placeholder={placeholder}
+        aria-label="Notes"
+        className="w-full resize-none rounded-2xl border px-4 py-3 text-[14px] leading-relaxed transition-shadow focus:outline-none focus:ring-2 focus:ring-(--color-accent)/30"
+        style={{
+          minHeight: 160,
+          color: "var(--color-text)",
+          background: "var(--color-surface)",
+          borderColor: "var(--color-border)",
+          fontFamily: "inherit",
+        }}
+      />
+      <div
+        className="flex items-center justify-end gap-2 px-1 text-[11px]"
+        style={{ color: "var(--color-text-muted)" }}
+      >
+        {error ? (
+          <button
+            type="button"
+            onClick={() => {
+              void commit(draft);
+            }}
+            className="hover:underline"
+            style={{ color: "var(--color-error)" }}
+          >
+            Couldn&apos;t save — retry
+          </button>
+        ) : saving ? (
+          <span>Saving…</span>
+        ) : dirty ? (
+          <span style={{ opacity: 0.7 }}>Unsaved changes</span>
+        ) : savedAt ? (
+          <span>
+            Saved
+            {" · "}
+            {formatRelativeDate(savedAt) || "just now"}
+          </span>
+        ) : null}
+      </div>
+    </section>
   );
 }
 

--- a/apps/web/app/components/crm/person-profile.tsx
+++ b/apps/web/app/components/crm/person-profile.tsx
@@ -706,9 +706,9 @@ function ActivityTab({
 //   - Escape reverts the draft to the last persisted value.
 //   - "Saved · just now" / "Saving…" / red retry button under the editor.
 //
-// `data.person.notes` is the source of truth; we sync `draft` to it whenever
-// the parent reloads the person (e.g., after a name save) so we don't clobber
-// fresh server state with a stale local draft.
+// `data.person.notes` and `data.person.updated_at` are the source of truth; we
+// sync local editor state whenever the parent reloads the person so we don't
+// clobber fresh server state or show stale save timestamps.
 function NotesTab({
   data,
   onSave,
@@ -717,9 +717,10 @@ function NotesTab({
   onSave: (next: string) => Promise<void>;
 }) {
   const persisted = data.person.notes ?? "";
+  const persistedSavedAt = data.person.updated_at;
   const [draft, setDraft] = useState(persisted);
   const [saving, setSaving] = useState(false);
-  const [savedAt, setSavedAt] = useState<string | null>(data.person.updated_at);
+  const [savedAt, setSavedAt] = useState<string | null>(persistedSavedAt);
   const [error, setError] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   // Used to short-circuit `commit()` if the value matches what's already
@@ -734,7 +735,8 @@ function NotesTab({
       lastSavedRef.current = persisted;
       setDraft(persisted);
     }
-  }, [persisted]);
+    setSavedAt(persistedSavedAt);
+  }, [persisted, persistedSavedAt]);
 
   // Auto-grow: reset to `auto` first so the textarea can shrink, then snap
   // to scrollHeight. Re-runs every time the draft changes.

--- a/apps/web/app/components/workspace/column-header-menu.test.tsx
+++ b/apps/web/app/components/workspace/column-header-menu.test.tsx
@@ -49,7 +49,7 @@ describe("AddColumnPopover", () => {
 			expect(screen.getByRole("option", { name: "Email" })).toBeInTheDocument();
 		});
 		expect(inputSelect).toHaveValue("Email");
-		expect(screen.getByText(/Will enrich using.*Email.*column/)).toBeInTheDocument();
+		expect(screen.queryByText(/Will enrich using.*Email.*column/)).not.toBeInTheDocument();
 	});
 
 	it("does not render the old column-name search field in the add-column popover", async () => {

--- a/apps/web/app/components/workspace/column-header-menu.tsx
+++ b/apps/web/app/components/workspace/column-header-menu.tsx
@@ -834,12 +834,7 @@ export function AddColumnPopover({
 										))}
 									</select>
 								</div>
-								{enrichInputField && (
-									<div className="flex items-center gap-1.5 text-xs px-1" style={{ color: "var(--color-text-muted)" }}>
-										<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z" /></svg>
-										Will enrich using &ldquo;{enrichInputField}&rdquo; column
-									</div>
-								)}
+
 								{selectedOutputExists && (
 									<div className="flex items-center gap-1.5 text-xs px-1" style={{ color: "var(--color-accent)" }}>
 										<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6 9 17l-5-5" /></svg>
@@ -1010,10 +1005,6 @@ export function AddColumnPopover({
 									/>
 								</div>
 							)}
-
-							<div className="px-3 pb-2 text-[11px]" style={{ color: "var(--color-text-muted)" }}>
-								Creates &ldquo;{nextDefaultFieldName(fieldTypeLabel(type), fieldsRef.current)}&rdquo;. Rename it from the column menu after creating.
-							</div>
 
 							{error && (
 								<div className="px-3 pb-2">

--- a/apps/web/app/components/workspace/data-table.tsx
+++ b/apps/web/app/components/workspace/data-table.tsx
@@ -717,7 +717,7 @@ export function DataTable<TData, TValue>({
 				{/* Search */}
 				{enableGlobalFilter && (
 					<div
-						className="flex items-center gap-2 h-8 px-3 backdrop-blur-sm rounded-full focus-within:ring-2 focus-within:ring-(--color-accent)/30 transition-shadow max-w-[260px] min-w-[140px] shadow-[0_0_21px_0_rgba(0,0,0,0.05)]"
+						className="flex min-w-[140px] max-w-[260px] flex-[1_1_180px] items-center gap-2 h-8 px-3 backdrop-blur-sm rounded-full focus-within:ring-2 focus-within:ring-(--color-accent)/30 transition-shadow shadow-[0_0_21px_0_rgba(0,0,0,0.05)]"
 						style={{ border: "1px solid var(--color-border)", background: "var(--color-surface)" }}
 					>
 						<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0" style={{ color: "var(--color-text-muted)", opacity: 0.5 }}>
@@ -757,75 +757,75 @@ export function DataTable<TData, TValue>({
 					</div>
 				)}
 
-				<div className="flex-1" />
+				<div className="ml-auto flex min-w-0 max-w-full flex-[1_1_220px] flex-wrap items-center justify-end gap-2">
+					{toolbarExtra}
 
-				{toolbarExtra}
-
-				{/* Columns menu */}
-				<DropdownMenu>
-					<DropdownMenuTrigger
-						className="h-8 px-3 flex items-center gap-1.5 rounded-full text-xs cursor-pointer transition-colors backdrop-blur-sm shadow-[0_0_21px_0_rgba(0,0,0,0.05)] outline-none focus:outline-none"
-						style={{ color: "var(--color-text-muted)", border: "1px solid var(--color-border)", background: "var(--color-surface)" }}
-					>
-						<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-							<rect width="18" height="18" x="3" y="3" rx="2" /><path d="M9 3v18" /><path d="M15 3v18" />
-						</svg>
-						Columns
-					</DropdownMenuTrigger>
-					<DropdownMenuContent align="end" sideOffset={6}>
-						<DropdownMenuCheckboxItem
-							checked={stickyFirstColumn}
-							onSelect={() => setStickyFirstColumn((v) => !v)}
+					{/* Columns menu */}
+					<DropdownMenu>
+						<DropdownMenuTrigger
+							className="h-8 px-3 flex items-center gap-1.5 rounded-full text-xs cursor-pointer transition-colors backdrop-blur-sm shadow-[0_0_21px_0_rgba(0,0,0,0.05)] outline-none focus:outline-none"
+							style={{ color: "var(--color-text-muted)", border: "1px solid var(--color-border)", background: "var(--color-surface)" }}
 						>
-							Freeze first column
-						</DropdownMenuCheckboxItem>
-						<DropdownMenuSeparator />
-						{visibleColumns.length === 0 ? (
-							<div className="px-2 py-1.5 text-xs opacity-50">No toggleable columns</div>
-						) : (
-							table.getAllLeafColumns()
-								.filter((c) => c.id !== "__rownum" && c.id !== "select" && c.id !== "actions" && c.id !== "__add_column" && c.getCanHide())
-								.map((column) => (
-									<DropdownMenuCheckboxItem
-										key={column.id}
-										checked={column.getIsVisible()}
-										onSelect={() => column.toggleVisibility(!column.getIsVisible())}
-									>
-										{typeof column.columnDef.header === "string"
-											? column.columnDef.header
-											: String((column.columnDef.meta as Record<string, string> | undefined)?.label ?? column.id)}
-									</DropdownMenuCheckboxItem>
-								))
-						)}
-					</DropdownMenuContent>
-				</DropdownMenu>
+							<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+								<rect width="18" height="18" x="3" y="3" rx="2" /><path d="M9 3v18" /><path d="M15 3v18" />
+							</svg>
+							Columns
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end" sideOffset={6}>
+							<DropdownMenuCheckboxItem
+								checked={stickyFirstColumn}
+								onSelect={() => setStickyFirstColumn((v) => !v)}
+							>
+								Freeze first column
+							</DropdownMenuCheckboxItem>
+							<DropdownMenuSeparator />
+							{visibleColumns.length === 0 ? (
+								<div className="px-2 py-1.5 text-xs opacity-50">No toggleable columns</div>
+							) : (
+								table.getAllLeafColumns()
+									.filter((c) => c.id !== "__rownum" && c.id !== "select" && c.id !== "actions" && c.id !== "__add_column" && c.getCanHide())
+									.map((column) => (
+										<DropdownMenuCheckboxItem
+											key={column.id}
+											checked={column.getIsVisible()}
+											onSelect={() => column.toggleVisibility(!column.getIsVisible())}
+										>
+											{typeof column.columnDef.header === "string"
+												? column.columnDef.header
+												: String((column.columnDef.meta as Record<string, string> | undefined)?.label ?? column.id)}
+										</DropdownMenuCheckboxItem>
+									))
+							)}
+						</DropdownMenuContent>
+					</DropdownMenu>
 
-				{/* Refresh button */}
-				{onRefresh && (
-					<button
-						type="button"
-						onClick={onRefresh}
-						className="h-8 w-8 rounded-full flex items-center justify-center cursor-pointer transition-colors backdrop-blur-sm shadow-[0_0_21px_0_rgba(0,0,0,0.05)]"
-						style={{ border: "1px solid var(--color-border)", background: "var(--color-surface)", color: "var(--color-text-muted)" }}
-					>
-						<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" /><path d="M3 3v5h5" /><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16" /><path d="M16 21h5v-5" /></svg>
-					</button>
-				)}
+					{/* Refresh button */}
+					{onRefresh && (
+						<button
+							type="button"
+							onClick={onRefresh}
+							className="h-8 w-8 rounded-full flex items-center justify-center cursor-pointer transition-colors backdrop-blur-sm shadow-[0_0_21px_0_rgba(0,0,0,0.05)]"
+							style={{ border: "1px solid var(--color-border)", background: "var(--color-surface)", color: "var(--color-text-muted)" }}
+						>
+							<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" /><path d="M3 3v5h5" /><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16" /><path d="M16 21h5v-5" /></svg>
+						</button>
+					)}
 
-				{/* Add button */}
-				{onAdd && (
-					<button
-						type="button"
-						onClick={onAdd}
-						className="h-8 px-3 flex items-center gap-1.5 rounded-full text-xs font-medium cursor-pointer transition-colors shadow-[0_0_21px_0_rgba(0,0,0,0.05)]"
-						style={{
-							background: "var(--color-accent)",
-							color: "#fff",
-						}}
-					>
-						{addButtonLabel}
-					</button>
-				)}
+					{/* Add button */}
+					{onAdd && (
+						<button
+							type="button"
+							onClick={onAdd}
+							className="h-8 px-3 flex items-center gap-1.5 rounded-full text-xs font-medium cursor-pointer transition-colors shadow-[0_0_21px_0_rgba(0,0,0,0.05)]"
+							style={{
+								background: "var(--color-accent)",
+								color: "#fff",
+							}}
+						>
+							{addButtonLabel}
+						</button>
+					)}
+				</div>
 			</div>
 			)}
 

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -900,10 +900,7 @@ function WorkspacePageInner() {
   // Whether the left sidebar is in compact (icon-only) mode.
   const isLeftSidebarCompact = leftSidebarWidth < LEFT_SIDEBAR_FULL_MIN;
   const reservedLeftSidebarWidth = !isMobile && !leftSidebarCollapsed ? leftSidebarWidth : 0;
-  const maxUsableRightPanelWidth = useMemo(() => {
-    if (rightPanelCollapsed) {
-      return 0;
-    }
+  const availableRightPanelMaxWidth = useMemo(() => {
     const totalWidth = layoutWidth || (typeof window !== "undefined" ? window.innerWidth : 0);
     if (!totalWidth) {
       return rightPanelWidth;
@@ -913,10 +910,10 @@ function WorkspacePageInner() {
       RIGHT_PANEL_MIN,
       RIGHT_PANEL_MAX,
     );
-  }, [isMobile, layoutWidth, reservedLeftSidebarWidth, rightPanelCollapsed, rightPanelWidth]);
+  }, [layoutWidth, reservedLeftSidebarWidth, rightPanelWidth]);
   const effectiveRightPanelWidth = rightPanelCollapsed
     ? 0
-    : Math.min(rightPanelWidth, maxUsableRightPanelWidth);
+    : Math.min(rightPanelWidth, availableRightPanelMaxWidth);
 
   // Snap-aware resize handler: dragging below the compact threshold snaps to icon mode;
   // dragging into the gap between threshold and full min snaps to full min.
@@ -2618,7 +2615,7 @@ function WorkspacePageInner() {
               mode="right"
               containerRef={layoutRef}
               min={RIGHT_PANEL_MIN}
-              max={maxUsableRightPanelWidth || RIGHT_PANEL_MAX}
+              max={availableRightPanelMaxWidth}
               onResize={setRightPanelWidth}
             />
             <RightPanel>

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -162,6 +162,7 @@ const LEFT_SIDEBAR_FULL_MIN = 200;
 const LEFT_SIDEBAR_FULL_DEFAULT = 260;
 const LEFT_SIDEBAR_MIN = LEFT_SIDEBAR_COMPACT_WIDTH;
 const LEFT_SIDEBAR_MAX = 480;
+const CENTER_PANEL_MIN = 300;
 const RIGHT_PANEL_MIN = 360;
 const RIGHT_PANEL_MAX = 2000;
 const STORAGE_LEFT = "dench-workspace-left-sidebar-width";
@@ -488,6 +489,7 @@ function WorkspacePageInner() {
   const chatPanelRefs = useRef<Record<string, ChatPanelHandle | null>>({});
   // Root layout ref for resize handle position (handle follows cursor)
   const layoutRef = useRef<HTMLDivElement>(null);
+  const [layoutWidth, setLayoutWidth] = useState(0);
 
   // Live-reactive tree via SSE watcher (with browse-mode support)
   const {
@@ -564,6 +566,26 @@ function WorkspacePageInner() {
   const [terminalOpen, setTerminalOpen] = useState(false);
   const [pendingComposioAction, setPendingComposioAction] = useState<ComposioChatAction | null>(null);
   const [tableSelectionContext, setTableSelectionContext] = useState<TableSelectionContext | null>(null);
+
+  useEffect(() => {
+    const updateLayoutWidth = () => {
+      setLayoutWidth(layoutRef.current?.clientWidth ?? window.innerWidth);
+    };
+    updateLayoutWidth();
+
+    const observer =
+      typeof ResizeObserver !== "undefined" && layoutRef.current
+        ? new ResizeObserver(updateLayoutWidth)
+        : null;
+    if (layoutRef.current) {
+      observer?.observe(layoutRef.current);
+    }
+    window.addEventListener("resize", updateLayoutWidth);
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener("resize", updateLayoutWidth);
+    };
+  }, []);
 
   // Tabs state — single source of truth for content + chat tabs.
   // Replaces the older tabState/activePath/content/activeContentTabId quartet
@@ -877,6 +899,24 @@ function WorkspacePageInner() {
 
   // Whether the left sidebar is in compact (icon-only) mode.
   const isLeftSidebarCompact = leftSidebarWidth < LEFT_SIDEBAR_FULL_MIN;
+  const reservedLeftSidebarWidth = !isMobile && !leftSidebarCollapsed ? leftSidebarWidth : 0;
+  const maxUsableRightPanelWidth = useMemo(() => {
+    if (rightPanelCollapsed) {
+      return 0;
+    }
+    const totalWidth = layoutWidth || (typeof window !== "undefined" ? window.innerWidth : 0);
+    if (!totalWidth) {
+      return rightPanelWidth;
+    }
+    return clamp(
+      totalWidth - reservedLeftSidebarWidth - CENTER_PANEL_MIN,
+      RIGHT_PANEL_MIN,
+      RIGHT_PANEL_MAX,
+    );
+  }, [isMobile, layoutWidth, reservedLeftSidebarWidth, rightPanelCollapsed, rightPanelWidth]);
+  const effectiveRightPanelWidth = rightPanelCollapsed
+    ? 0
+    : Math.min(rightPanelWidth, maxUsableRightPanelWidth);
 
   // Snap-aware resize handler: dragging below the compact threshold snaps to icon mode;
   // dragging into the gap between threshold and full min snaps to full min.
@@ -1214,8 +1254,8 @@ function WorkspacePageInner() {
       setRightPanelCollapsed(false);
       return;
     }
-    const CHAT_MIN = 420;
-    const ideal = window.innerWidth - leftSidebarWidth - CHAT_MIN;
+    const totalWidth = layoutRef.current?.clientWidth ?? window.innerWidth;
+    const ideal = totalWidth - leftSidebarWidth - CENTER_PANEL_MIN;
     const wideTarget = clamp(ideal, RIGHT_PANEL_MIN, RIGHT_PANEL_MAX);
     setRightPanelCollapsed(false);
     setRightPanelWidth((current) => Math.max(current, wideTarget));
@@ -2409,7 +2449,7 @@ function WorkspacePageInner() {
 
 
       {/* ── Center: chat panel ── */}
-      <main className="flex-1 flex flex-col min-w-[420px] overflow-hidden relative" style={{ background: "var(--color-main-bg)" }}>
+      <main className="flex-1 flex flex-col min-w-[300px] overflow-hidden relative" style={{ background: "var(--color-main-bg)" }}>
         {/* Mobile top bar */}
         {isMobile && (
           <div
@@ -2566,19 +2606,19 @@ function WorkspacePageInner() {
         <aside
           className={`sidebar-animate flex-shrink-0 min-h-0 flex flex-col relative ${rightPanelCollapsed ? "overflow-hidden" : "border-l overflow-hidden"}`}
           style={{
-            width: rightPanelCollapsed ? 0 : rightPanelWidth,
-            minWidth: rightPanelCollapsed ? 0 : rightPanelWidth,
+            width: effectiveRightPanelWidth,
+            minWidth: effectiveRightPanelWidth,
             borderColor: "var(--color-border)",
             background: "var(--color-bg)",
             transition: "width 200ms ease, min-width 200ms ease",
           }}
         >
-          <div className="flex h-full min-h-0 flex-col relative overflow-hidden" style={{ width: rightPanelWidth, minWidth: rightPanelWidth }}>
+          <div className="flex h-full min-h-0 flex-col relative overflow-hidden" style={{ width: effectiveRightPanelWidth, minWidth: effectiveRightPanelWidth }}>
             <ResizeHandle
               mode="right"
               containerRef={layoutRef}
               min={RIGHT_PANEL_MIN}
-              max={RIGHT_PANEL_MAX}
+              max={maxUsableRightPanelWidth || RIGHT_PANEL_MAX}
               onResize={setRightPanelWidth}
             />
             <RightPanel>
@@ -3676,14 +3716,13 @@ function ObjectView({
         {/* Right: search, filter, views, settings, refresh, +Add.
             `ml-auto` pushes this cluster to the right edge whether the row
             wraps or not. */}
-        <div className="ml-auto flex items-center gap-1.5 flex-shrink-0">
-          {/* Search input — hidden on narrow widths so the rest of the toolbar fits */}
+        <div className="ml-auto flex min-w-0 max-w-full flex-[1_1_280px] flex-wrap items-center justify-end gap-1.5">
+          {/* Search input — shrinks/wraps before core actions disappear. */}
           <div
-            className="hidden md:flex items-center gap-1.5 h-7 px-2 rounded-md focus-within:ring-2 focus-within:ring-(--color-accent)/30 transition-shadow"
+            className="flex min-w-[128px] max-w-[180px] flex-[1_1_150px] items-center gap-1.5 h-7 px-2 rounded-md focus-within:ring-2 focus-within:ring-(--color-accent)/30 transition-shadow"
             style={{
               border: "1px solid var(--color-border)",
               background: "var(--color-surface)",
-              width: 180,
             }}
           >
             <svg

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -1255,11 +1255,11 @@ function WorkspacePageInner() {
       return;
     }
     const totalWidth = layoutRef.current?.clientWidth ?? window.innerWidth;
-    const ideal = totalWidth - leftSidebarWidth - CENTER_PANEL_MIN;
+    const ideal = totalWidth - reservedLeftSidebarWidth - CENTER_PANEL_MIN;
     const wideTarget = clamp(ideal, RIGHT_PANEL_MIN, RIGHT_PANEL_MAX);
     setRightPanelCollapsed(false);
     setRightPanelWidth((current) => Math.max(current, wideTarget));
-  }, [leftSidebarWidth]);
+  }, [reservedLeftSidebarWidth]);
 
   const handleNavigate = useCallback(
     (
@@ -2613,7 +2613,7 @@ function WorkspacePageInner() {
             transition: "width 200ms ease, min-width 200ms ease",
           }}
         >
-          <div className="flex h-full min-h-0 flex-col relative overflow-hidden" style={{ width: effectiveRightPanelWidth, minWidth: effectiveRightPanelWidth }}>
+          <div className="flex h-full min-h-0 flex-col relative overflow-hidden" style={{ width: rightPanelWidth, minWidth: rightPanelWidth }}>
             <ResizeHandle
               mode="right"
               containerRef={layoutRef}

--- a/apps/web/lib/agent-message.test.ts
+++ b/apps/web/lib/agent-message.test.ts
@@ -50,6 +50,28 @@ describe("buildAgentMessage", () => {
 		);
 	});
 
+	it("does NOT apply the workspace prefix to directory context paths", () => {
+		// The legacy server regex only matched `workspace file '...'`, so
+		// directory paths (especially virtual surfaces like `~crm/people`)
+		// were always passed through unprefixed. Prefixing them would
+		// produce nonsensical paths like `<workspaceRoot>/~crm/people`.
+		expect(
+			buildAgentMessage({
+				userText: "list",
+				workspaceContext: { filePath: "~crm/people", isDirectory: true },
+				workspacePrefix: "/home/user/.openclaw/work",
+			}),
+		).toBe("[Context: workspace directory '~crm/people']\n\nlist");
+
+		expect(
+			buildAgentMessage({
+				userText: "list",
+				workspaceContext: { filePath: "subdir", isDirectory: true },
+				workspacePrefix: "/home/user/.openclaw/work",
+			}),
+		).toBe("[Context: workspace directory 'subdir']\n\nlist");
+	});
+
 	it("prepends a [Selected table ...] block when tableSelection is provided", () => {
 		const selection: TableSelectionContext = {
 			objectName: "people",

--- a/apps/web/lib/agent-message.test.ts
+++ b/apps/web/lib/agent-message.test.ts
@@ -7,13 +7,15 @@ describe("buildAgentMessage", () => {
 		expect(buildAgentMessage({ userText: "hello" })).toBe("hello");
 	});
 
-	it("prepends [Attached files: ...] when attachments are listed", () => {
+	it("does not touch [Attached files: ...] already in userText", () => {
+		// [Attached files: ...] stays in the message text (chat-message.tsx
+		// parses it for the AttachedFilesCard); buildAgentMessage only
+		// layers agent-only prefixes on top.
 		expect(
 			buildAgentMessage({
-				userText: "summarize",
-				workspaceContext: { attachedFilePaths: ["a.md", "b.md"] },
+				userText: "[Attached files: a.md]\n\nsummarize",
 			}),
-		).toBe("[Attached files: a.md, b.md]\n\nsummarize");
+		).toBe("[Attached files: a.md]\n\nsummarize");
 	});
 
 	it("prepends [Context: workspace file '...'] when filePath is provided", () => {
@@ -72,7 +74,7 @@ describe("buildAgentMessage", () => {
 		expect(out).toContain("anything weird?");
 	});
 
-	it("orders prefixes: tableSelection > filePath > attachedFiles > userText", () => {
+	it("orders prefixes: tableSelection > filePath > attachedFiles in userText", () => {
 		const selection: TableSelectionContext = {
 			objectName: "people",
 			kind: "cells",
@@ -84,10 +86,11 @@ describe("buildAgentMessage", () => {
 			],
 			updatedAt: 0,
 		};
+		// userText carries the attachments prefix that the client builds
+		// inline; buildAgentMessage layers Context + Selected table on top.
 		const out = buildAgentMessage({
-			userText: "go",
+			userText: "[Attached files: a.md]\n\ngo",
 			workspaceContext: {
-				attachedFilePaths: ["a.md"],
 				filePath: "doc.md",
 				isDirectory: false,
 				tableSelection: selection,

--- a/apps/web/lib/agent-message.test.ts
+++ b/apps/web/lib/agent-message.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { buildAgentMessage } from "./agent-message";
+import type { TableSelectionContext } from "./table-selection";
+
+describe("buildAgentMessage", () => {
+	it("returns userText unchanged when no context is provided", () => {
+		expect(buildAgentMessage({ userText: "hello" })).toBe("hello");
+	});
+
+	it("prepends [Attached files: ...] when attachments are listed", () => {
+		expect(
+			buildAgentMessage({
+				userText: "summarize",
+				workspaceContext: { attachedFilePaths: ["a.md", "b.md"] },
+			}),
+		).toBe("[Attached files: a.md, b.md]\n\nsummarize");
+	});
+
+	it("prepends [Context: workspace file '...'] when filePath is provided", () => {
+		expect(
+			buildAgentMessage({
+				userText: "what is this?",
+				workspaceContext: { filePath: "doc.md", isDirectory: false },
+			}),
+		).toBe("[Context: workspace file 'doc.md']\n\nwhat is this?");
+	});
+
+	it("uses 'directory' label for directory contexts", () => {
+		expect(
+			buildAgentMessage({
+				userText: "list everyone",
+				workspaceContext: { filePath: "~crm/people", isDirectory: true },
+			}),
+		).toBe(
+			"[Context: workspace directory '~crm/people']\n\nlist everyone",
+		);
+	});
+
+	it("applies the workspace prefix to file context paths", () => {
+		expect(
+			buildAgentMessage({
+				userText: "ok",
+				workspaceContext: { filePath: "doc.md", isDirectory: false },
+				workspacePrefix: "/home/user/.openclaw/work",
+			}),
+		).toBe(
+			"[Context: workspace file '/home/user/.openclaw/work/doc.md']\n\nok",
+		);
+	});
+
+	it("prepends a [Selected table ...] block when tableSelection is provided", () => {
+		const selection: TableSelectionContext = {
+			objectName: "people",
+			kind: "rows",
+			rowCount: 1,
+			columnCount: 2,
+			columns: ["name", "email"],
+			rows: [
+				{
+					rowIndex: 0,
+					entryId: "p1",
+					values: { name: "Ada", email: "ada@example.com" },
+				},
+			],
+			updatedAt: 0,
+		};
+		const out = buildAgentMessage({
+			userText: "anything weird?",
+			workspaceContext: { tableSelection: selection },
+		});
+		expect(out).toContain("[Selected table rows: people]");
+		expect(out).toContain("anything weird?");
+	});
+
+	it("orders prefixes: tableSelection > filePath > attachedFiles > userText", () => {
+		const selection: TableSelectionContext = {
+			objectName: "people",
+			kind: "cells",
+			rowCount: 1,
+			columnCount: 1,
+			columns: ["email"],
+			cells: [
+				{ rowIndex: 0, entryId: "p1", fieldName: "email", value: "x" },
+			],
+			updatedAt: 0,
+		};
+		const out = buildAgentMessage({
+			userText: "go",
+			workspaceContext: {
+				attachedFilePaths: ["a.md"],
+				filePath: "doc.md",
+				isDirectory: false,
+				tableSelection: selection,
+			},
+		});
+
+		const tableIdx = out.indexOf("[Selected table");
+		const ctxIdx = out.indexOf("[Context: workspace");
+		const attIdx = out.indexOf("[Attached files:");
+		const goIdx = out.indexOf("go");
+
+		expect(tableIdx).toBeGreaterThanOrEqual(0);
+		expect(tableIdx).toBeLessThan(ctxIdx);
+		expect(ctxIdx).toBeLessThan(attIdx);
+		expect(attIdx).toBeLessThan(goIdx);
+	});
+});

--- a/apps/web/lib/agent-message.ts
+++ b/apps/web/lib/agent-message.ts
@@ -1,0 +1,67 @@
+import {
+	formatTableSelectionContext,
+	type TableSelectionContext,
+} from "@/lib/table-selection";
+
+/**
+ * Workspace context attached to a chat message in addition to the user's
+ * typed text. The client sends this as a separate body field on POST /api/chat
+ * so the persisted user message stays clean (no `[Context: ...]` /
+ * `[Attached files: ...]` / `[Selected table ...]` prefixes baked in), while
+ * the agent still receives the full prefixed prompt it expects.
+ *
+ * Each field is optional — clients only include a piece when it should
+ * actually be announced to the agent on this turn (e.g. `filePath` is
+ * omitted on subsequent turns once the path was already announced).
+ */
+export type WorkspaceContext = {
+	/** Path of the active workspace file/directory the user is viewing. */
+	filePath?: string;
+	/** True when `filePath` is a directory or virtual surface (~crm/...). */
+	isDirectory?: boolean;
+	/** Paths of files mentioned in the editor or attached as uploads. */
+	attachedFilePaths?: string[];
+	/** Snapshot of selected table rows/cells, formatted into prompt text. */
+	tableSelection?: TableSelectionContext;
+};
+
+/**
+ * Build the prompt the agent actually sees, by prepending the same
+ * bracketed metadata blocks the client used to assemble inline. Order
+ * matches the legacy client implementation so behavior is identical from
+ * the agent's perspective.
+ */
+export function buildAgentMessage(args: {
+	userText: string;
+	workspaceContext?: WorkspaceContext;
+	/** Optional workspace-root prefix (e.g. /home/ubuntu/.openclaw/work). */
+	workspacePrefix?: string | null;
+}): string {
+	const { userText, workspaceContext, workspacePrefix } = args;
+	let message = userText;
+
+	const ctx = workspaceContext;
+	if (!ctx) {
+		return message;
+	}
+
+	const attached = ctx.attachedFilePaths?.filter(Boolean) ?? [];
+	if (attached.length > 0) {
+		const attachedPrefix = `[Attached files: ${attached.join(", ")}]`;
+		message = message ? `${attachedPrefix}\n\n${message}` : attachedPrefix;
+	}
+
+	if (ctx.filePath) {
+		const label = ctx.isDirectory ? "directory" : "file";
+		const fullPath = workspacePrefix
+			? `${workspacePrefix}/${ctx.filePath}`
+			: ctx.filePath;
+		message = `[Context: workspace ${label} '${fullPath}']\n\n${message}`;
+	}
+
+	if (ctx.tableSelection) {
+		message = `${formatTableSelectionContext(ctx.tableSelection)}\n\n${message}`;
+	}
+
+	return message;
+}

--- a/apps/web/lib/agent-message.ts
+++ b/apps/web/lib/agent-message.ts
@@ -52,9 +52,14 @@ export function buildAgentMessage(args: {
 
 	if (ctx.filePath) {
 		const label = ctx.isDirectory ? "directory" : "file";
-		const fullPath = workspacePrefix
-			? `${workspacePrefix}/${ctx.filePath}`
-			: ctx.filePath;
+		// Match the legacy server regex which only rewrote `workspace file`
+		// paths. Directory paths (including virtual surfaces like `~crm/...`)
+		// were never prefixed — prefixing them produces nonsensical paths
+		// like `<workspaceRoot>/~crm/people` that the agent can't resolve.
+		const fullPath =
+			workspacePrefix && !ctx.isDirectory
+				? `${workspacePrefix}/${ctx.filePath}`
+				: ctx.filePath;
 		message = `[Context: workspace ${label} '${fullPath}']\n\n${message}`;
 	}
 

--- a/apps/web/lib/agent-message.ts
+++ b/apps/web/lib/agent-message.ts
@@ -6,9 +6,13 @@ import {
 /**
  * Workspace context attached to a chat message in addition to the user's
  * typed text. The client sends this as a separate body field on POST /api/chat
- * so the persisted user message stays clean (no `[Context: ...]` /
- * `[Attached files: ...]` / `[Selected table ...]` prefixes baked in), while
- * the agent still receives the full prefixed prompt it expects.
+ * so these agent-only signals (`[Context: ...]`, `[Selected table ...]`)
+ * never get baked into the persisted user message — that's what produced
+ * ugly chat titles in the sidebar like `[Context: workspace file 'company']`.
+ *
+ * Note that `[Attached files: ...]` is intentionally NOT here: it stays in
+ * the user message text because chat-message.tsx parses that prefix to
+ * render the AttachedFilesCard. The session-title cleaner strips it.
  *
  * Each field is optional — clients only include a piece when it should
  * actually be announced to the agent on this turn (e.g. `filePath` is
@@ -19,8 +23,6 @@ export type WorkspaceContext = {
 	filePath?: string;
 	/** True when `filePath` is a directory or virtual surface (~crm/...). */
 	isDirectory?: boolean;
-	/** Paths of files mentioned in the editor or attached as uploads. */
-	attachedFilePaths?: string[];
 	/** Snapshot of selected table rows/cells, formatted into prompt text. */
 	tableSelection?: TableSelectionContext;
 };
@@ -30,6 +32,9 @@ export type WorkspaceContext = {
  * bracketed metadata blocks the client used to assemble inline. Order
  * matches the legacy client implementation so behavior is identical from
  * the agent's perspective.
+ *
+ * `[Attached files: ...]` (when present) is already in `userText`; this
+ * helper only layers on the agent-only prefixes from `workspaceContext`.
  */
 export function buildAgentMessage(args: {
 	userText: string;
@@ -43,12 +48,6 @@ export function buildAgentMessage(args: {
 	const ctx = workspaceContext;
 	if (!ctx) {
 		return message;
-	}
-
-	const attached = ctx.attachedFilePaths?.filter(Boolean) ?? [];
-	if (attached.length > 0) {
-		const attachedPrefix = `[Attached files: ${attached.join(", ")}]`;
-		message = message ? `${attachedPrefix}\n\n${message}` : attachedPrefix;
 	}
 
 	if (ctx.filePath) {


### PR DESCRIPTION
## Summary

Fixes three regressions reported after the v3 chat refactor:

1. **Chat titles in the sidebar leaked workspace context** — they showed up as `[Context: workspace file 'company']` instead of what the user actually typed.
2. **Empty 'New Chat' rows accumulated in the sidebar** — every time a user opened the + tab and walked away without typing, a server-side session was created.
3. **Active conversations could be invisible in the sidebar** — chats started while viewing a CRM page or any content tab got marked file-scoped, and the sidebar filter hid them. Closing the tab made the conversation unreachable.

The root cause for (1) and (3) was the same: the chat client was conflating the prompt sent to the agent with the message persisted to disk and with the file the session is "scoped to". Once those three concerns were separated, all three issues collapsed into focused fixes. Issue (4) (slow 'Thinking…' phase) is intentionally out of scope for this PR — it's deeper and the user asked to defer it.

## Root causes & fixes

### Issue 1 — chat title context prefix

**Cause**: the client baked `[Context: workspace file '...']`, `[Attached files: ...]`, and `[Selected table ...]` prefixes directly into the user message string before sending. The server then persisted that augmented string as the user's first message, and the title-backfill code read from that — so titles in the sidebar were the prefixed text, not the user's actual prompt.

**Fix** (commit `b7bc3a2c6`): refactor the wire format. Client sends raw `userText` plus a structured `workspaceContext` body field (`{ filePath, isDirectory, attachedFilePaths, tableSelection }`). New `buildAgentMessage` helper on the server reconstructs the prefixed prompt so the agent sees an identical string to before, but `persistUserMessage` writes only the raw text. Drops the brittle regex that tried to recover and rewrite the file path out of an inline prefix.

**Backfill** (commit `673844e68`): old chats still have the prefixed text on disk. Extracted a `cleanTitleText` helper that strips all three prefix shapes, used by both `summarizeSessionFile` and `deriveTitleFromMessages`. `readIndex` now also re-derives titles for any indexed session whose stored title still contains a bracketed prefix — so existing bad titles fix themselves on the next sidebar fetch.

### Issue 2 — empty chats created prematurely

**Cause**: a `useEffect` in `chat-panel.tsx` called `POST /api/web-sessions` the moment a panel became visible with no session yet, to "warm up" `createSession` ahead of the first submit. If the user opened a + tab and walked away without typing, the empty session row stayed in the sidebar forever.

**Fix** (commit `c4b6fac17`): drop the warmup effect entirely. Sessions are now created lazily inside `handleEditorSubmit`'s first-submit branch. The trade-off (one extra roundtrip on the first submit) is barely noticeable and matches user expectation.

### Issue 3 — chats invisible in the sidebar

**Cause**: the chat sessions sidebar filters out any session with `s.filePath` set. That filter was correct (it hides legacy file-scoped sessions), but the chat panel was setting `filePath` on every new session whenever any content tab was active, including virtual CRM tabs. So a chat started from a CRM view got marked file-scoped, the sidebar hid it, and closing the tab made it unreachable.

**Fix** (commit `3df6c07bf`): drop `body.filePath` from `createSession`. Workspace context is now per-message (Issue 1's refactor), so the session itself can stay unscoped. Removes dead state that only existed to support the old file-scoped flow: `fileSessions`, `fetchFileSessionsRef`, the `FileScopedSession` type, and a no-op `useEffect`. Server still accepts `filePath` so legacy sessions remain hideable.

## Test plan

Automated:
- [x] `pnpm vitest run` (apps/web) — 1765 passing, 5 skipped, 0 failures.
- [x] `pnpm tsc --noEmit` — clean.
- [x] `pnpm oxlint` on changed files — no new issues (one fewer than baseline).
- [x] New unit tests:
  - `lib/agent-message.test.ts` — 7 tests covering prefix ordering, workspace prefix application, directory vs file labels, table selection blocks, and pass-through.
  - `app/api/chat/chat.test.ts` — added "rebuilds agent message from raw user text + structured workspace context" verifying agent gets prefixed prompt while persisted text stays clean.
  - `app/api/web-sessions/web-sessions.test.ts` — `cleanTitleText` regex coverage (7 cases) plus a regression test asserting `POST /api/web-sessions` returns a session without `filePath` when none is supplied.

Manual user flow (to verify after merge):
- [ ] Fresh workspace → sidebar shows no empty 'New Chat' rows.
- [ ] Click + → no row appears in sidebar yet.
- [ ] Type 'hello' → row appears with title 'hello'.
- [ ] Open a CRM table → start a chat → row appears (not hidden).
- [ ] Reload — both chats are still visible.
- [ ] Old chats whose titles previously read `[Context: workspace file '...']` now show the actual first message text.

## Out of scope

Issue 4 (slow 'Thinking…' phase) is a separate performance regression and deserves its own investigation — likely involves the `ensureFullToolVerbose` retry logic in `agent-runner.ts` blocking the first `chat.send`. The user explicitly asked to defer it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches chat request/response wiring and session metadata/title derivation, so regressions could affect message persistence and sidebar visibility. Changes are localized and covered by new unit tests, reducing risk.
> 
> **Overview**
> Fixes v3 chat regressions by sending per-message `workspaceContext` separately from the user’s visible text and reconstructing the agent prompt server-side via new `buildAgentMessage`, preserving legacy prefix ordering while keeping persisted messages clean.
> 
> Improves session UX by **creating web sessions only on first submit** (removing hero-screen warmup) and ensuring new sessions are **workspace-level** (no `filePath`), so active chats remain visible in the sidebar.
> 
> Adds `cleanTitleText` and applies it when deriving/backfilling titles (including retitling indexed sessions whose titles contain leaked bracketed prefixes), with expanded tests for context/attachment/table-selection cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7210223d67886b2d509f766dbb33f9536ce77572. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->