### PR TITLE
fix(chat): clean titles, lazy session creation, and visible workspace chats

### DIFF
--- a/apps/web/app/api/chat/chat.test.ts
+++ b/apps/web/app/api/chat/chat.test.ts
@@ -467,7 +467,12 @@ describe("Chat API routes", () => {
       );
     });
 
-    it("rebuilds agent message from raw user text + structured workspace context", async () => {
+    it("layers Context + Selected-table prefixes on top of inline attachments", async () => {
+      // [Attached files: …] is intentionally NOT moved into workspaceContext
+      // — it stays in the user message text because chat-message.tsx parses
+      // it to render the AttachedFilesCard. The agent prompt should have
+      // table selection FIRST, then Context, then Attached files, then user
+      // text — matching the legacy ordering the agent already understands.
       const { resolveAgentWorkspacePrefix } = await import("@/lib/workspace");
       vi.mocked(resolveAgentWorkspacePrefix).mockReturnValue(null);
       const { startRun, persistUserMessage, hasActiveRun, subscribeToRun } =
@@ -486,20 +491,23 @@ describe("Chat API routes", () => {
             {
               id: "m1",
               role: "user",
-              parts: [{ type: "text", text: "summarize this" }],
+              parts: [
+                {
+                  type: "text",
+                  text: "[Attached files: notes.md]\n\nsummarize this",
+                },
+              ],
             },
           ],
           sessionId: "s1",
           workspaceContext: {
             filePath: "~crm/people",
             isDirectory: true,
-            attachedFilePaths: ["notes.md"],
           },
         }),
       });
       await POST(req);
 
-      // Agent gets the prefixed prompt (so its tool/context use is unchanged).
       expect(startRun).toHaveBeenCalledWith(
         expect.objectContaining({
           message: expect.stringContaining(
@@ -517,11 +525,13 @@ describe("Chat API routes", () => {
           message: expect.stringContaining("summarize this"),
         }),
       );
-      // But the persisted user text stays clean — this is what the chat
-      // title backfill reads, so it must not include the bracketed prefixes.
+      // persistUserMessage stores the message text the user actually sees
+      // (with the Attached files prefix); the title cleaner strips it on read.
       expect(persistUserMessage).toHaveBeenCalledWith(
         "s1",
-        expect.objectContaining({ content: "summarize this" }),
+        expect.objectContaining({
+          content: "[Attached files: notes.md]\n\nsummarize this",
+        }),
       );
     });
 

--- a/apps/web/app/api/chat/chat.test.ts
+++ b/apps/web/app/api/chat/chat.test.ts
@@ -425,6 +425,10 @@ describe("Chat API routes", () => {
     });
 
     it("resolves workspace file paths in message", async () => {
+      // Post v3-chat refactor, the client sends raw user text plus a
+      // structured `workspaceContext` body field. The route reconstructs
+      // the `[Context: workspace file '...']` prefix and applies the
+      // workspace prefix from resolveAgentWorkspacePrefix.
       const { resolveAgentWorkspacePrefix } = await import("@/lib/workspace");
       vi.mocked(resolveAgentWorkspacePrefix).mockReturnValue("workspace");
       const { startRun, hasActiveRun, subscribeToRun } = await import("@/lib/active-runs");
@@ -441,17 +445,83 @@ describe("Chat API routes", () => {
             {
               id: "m1",
               role: "user",
-              parts: [{ type: "text", text: "[Context: workspace file 'doc.md']" }],
+              parts: [{ type: "text", text: "what does this say?" }],
             },
           ],
           sessionId: "s1",
+          workspaceContext: { filePath: "doc.md", isDirectory: false },
         }),
       });
       await POST(req);
       expect(startRun).toHaveBeenCalledWith(
         expect.objectContaining({
-          message: expect.stringContaining("workspace/doc.md"),
+          message: expect.stringContaining(
+            "[Context: workspace file 'workspace/doc.md']",
+          ),
         }),
+      );
+      expect(startRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("what does this say?"),
+        }),
+      );
+    });
+
+    it("rebuilds agent message from raw user text + structured workspace context", async () => {
+      const { resolveAgentWorkspacePrefix } = await import("@/lib/workspace");
+      vi.mocked(resolveAgentWorkspacePrefix).mockReturnValue(null);
+      const { startRun, persistUserMessage, hasActiveRun, subscribeToRun } =
+        await import("@/lib/active-runs");
+      vi.mocked(hasActiveRun).mockReturnValue(false);
+      vi.mocked(subscribeToRun).mockReturnValue(() => {});
+      vi.mocked(startRun).mockClear();
+      vi.mocked(persistUserMessage).mockClear();
+
+      const { POST } = await import("./route.js");
+      const req = new Request("http://localhost/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [
+            {
+              id: "m1",
+              role: "user",
+              parts: [{ type: "text", text: "summarize this" }],
+            },
+          ],
+          sessionId: "s1",
+          workspaceContext: {
+            filePath: "~crm/people",
+            isDirectory: true,
+            attachedFilePaths: ["notes.md"],
+          },
+        }),
+      });
+      await POST(req);
+
+      // Agent gets the prefixed prompt (so its tool/context use is unchanged).
+      expect(startRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            "[Context: workspace directory '~crm/people']",
+          ),
+        }),
+      );
+      expect(startRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("[Attached files: notes.md]"),
+        }),
+      );
+      expect(startRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("summarize this"),
+        }),
+      );
+      // But the persisted user text stays clean — this is what the chat
+      // title backfill reads, so it must not include the bracketed prefixes.
+      expect(persistUserMessage).toHaveBeenCalledWith(
+        "s1",
+        expect.objectContaining({ content: "summarize this" }),
       );
     });
 

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -33,6 +33,10 @@ import {
 	buildChatImageHydrationErrorMessage,
 	hydrateMessageImageAttachments,
 } from "@/lib/chat-image-attachments";
+import {
+	buildAgentMessage,
+	type WorkspaceContext,
+} from "@/lib/agent-message";
 
 export const runtime = "nodejs";
 
@@ -90,6 +94,7 @@ export async function POST(req: Request) {
 		modelOverride,
 		acknowledgeUnsafeOpenAiSwitch,
 		hasAssistantHistory: hasAssistantHistoryHint,
+		workspaceContext,
 	}: {
 		messages: UIMessage[];
 		sessionId?: string;
@@ -99,6 +104,7 @@ export async function POST(req: Request) {
 		modelOverride?: string;
 		acknowledgeUnsafeOpenAiSwitch?: boolean;
 		hasAssistantHistory?: boolean;
+		workspaceContext?: WorkspaceContext;
 	} = await req.json();
 
 	const lastUserMessage = messages.filter((m) => m.role === "user").pop();
@@ -174,14 +180,17 @@ export async function POST(req: Request) {
 		}
 	}
 
-	let agentMessage = userText;
+	// Build the prompt the agent sees. With workspaceContext sent as a
+	// structured body field (post v3-chat refactor), prefixes are
+	// reconstructed here rather than parsed back out of userText. Legacy
+	// callers without workspaceContext still work because buildAgentMessage
+	// returns userText unchanged when no context is supplied.
 	const wsPrefix = resolveAgentWorkspacePrefix();
-	if (wsPrefix) {
-		agentMessage = userText.replace(
-			/\[Context: workspace file '([^']+)'\]/,
-			`[Context: workspace file '${wsPrefix}/$1']`,
-		);
-	}
+	const agentMessage = buildAgentMessage({
+		userText,
+		workspaceContext,
+		workspacePrefix: wsPrefix,
+	});
 	const imageHydration = hydrateMessageImageAttachments(agentMessage);
 	const imageHydrationError = buildChatImageHydrationErrorMessage(
 		imageHydration.skipped,

--- a/apps/web/app/api/web-sessions/[id]/messages/route.ts
+++ b/apps/web/app/api/web-sessions/[id]/messages/route.ts
@@ -6,6 +6,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { resolveWebChatDir } from "@/lib/workspace";
+import { cleanTitleText } from "../../shared";
 
 export const dynamic = "force-dynamic";
 
@@ -137,10 +138,7 @@ function deriveTitleFromMessages(lines: string[]): string | null {
           .map((p: UITextPart) => p.text)
           .join(" ");
       }
-      const cleaned = text
-        .replace(/\[Attached files:[^\]]*\]/g, "")
-        .replace(/\s+/g, " ")
-        .trim();
+      const cleaned = cleanTitleText(text);
       if (!cleaned) {continue;}
       return cleaned.length > 60 ? cleaned.slice(0, 60).trimEnd() + "…" : cleaned;
     } catch {

--- a/apps/web/app/api/web-sessions/shared.ts
+++ b/apps/web/app/api/web-sessions/shared.ts
@@ -85,15 +85,25 @@ export function readIndex(): WebSessionMeta[] {
       dirty = true;
     }
 
-    // 2) Retitle any indexed session that still says "New Chat" but has
-    //    actual user content on disk. This catches chats that were
-    //    created before the server-side auto-title logic landed.
+    // 2) Retitle indexed sessions whose stored title needs cleanup:
+    //    - still says "New Chat" but has user content on disk (chats
+    //      created before the server-side auto-title logic landed), or
+    //    - currently displays a bracketed prefix like
+    //      `[Context: workspace file '...']` / `[Selected table ...]` /
+    //      `[Attached files: ...]` that leaked in before the v3-chat wire
+    //      format moved that metadata to a structured field.
     for (const session of index) {
-      if (session.title && session.title !== "New Chat") {continue;}
+      const needsBackfill = !session.title || session.title === "New Chat";
+      const hasBracketPrefix =
+        !!session.title &&
+        /\[(?:Context: workspace|Selected table|Attached files:)/.test(
+          session.title,
+        );
+      if (!needsBackfill && !hasBracketPrefix) {continue;}
       const fp = join(dir, `${session.id}.jsonl`);
       if (!existsSync(fp)) {continue;}
       const { title } = summarizeSessionFile(fp);
-      if (title && title !== "New Chat") {
+      if (title && title !== "New Chat" && title !== session.title) {
         session.title = title;
         dirty = true;
       }
@@ -106,6 +116,23 @@ export function readIndex(): WebSessionMeta[] {
   } catch { /* best-effort */ }
 
   return index;
+}
+
+/**
+ * Strip workspace-context/attachment/table-selection prefixes from text
+ * intended for use as a chat title. Older sessions baked these prefixes
+ * directly into the persisted user message (the new wire format sends
+ * them as a structured `workspaceContext` field instead), so this cleanup
+ * is what retroactively fixes ugly titles like
+ * `[Context: workspace file 'company']` showing up in the sidebar.
+ */
+export function cleanTitleText(text: string): string {
+  return text
+    .replace(/\[Context:\s*workspace\s+(?:file|directory)\s+'[^']*'\]/g, "")
+    .replace(/\[Selected table (?:rows|cells)[^\]]*\][\s\S]*?(?=\n\n|$)/g, "")
+    .replace(/\[Attached files:[^\]]*\]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 /**
@@ -139,10 +166,7 @@ function summarizeSessionFile(fp: string): { title: string; messageCount: number
             .map((p: UITextPart) => p.text)
             .join(" ");
         }
-        const cleaned = text
-          .replace(/\[Attached files:[^\]]*\]/g, "")
-          .replace(/\s+/g, " ")
-          .trim();
+        const cleaned = cleanTitleText(text);
         if (!cleaned) {continue;}
         title = cleaned.length > 60 ? cleaned.slice(0, 60).trimEnd() + "…" : cleaned;
         break;

--- a/apps/web/app/api/web-sessions/web-sessions.test.ts
+++ b/apps/web/app/api/web-sessions/web-sessions.test.ts
@@ -119,6 +119,24 @@ describe("Web Sessions API", () => {
       expect(mockWrite).toHaveBeenCalled();
     });
 
+    it("creates a workspace-level session (no filePath) when filePath is omitted", async () => {
+      // The chat panel's createSession (post v3 fix) intentionally never
+      // sends `filePath` — workspace context is now per-message, not
+      // per-session. The sidebar filter still hides any session that
+      // does have a filePath, so this assertion guards against a
+      // regression where filePath sneaks back into createSession bodies.
+      const { POST } = await import("./route.js");
+      const req = new Request("http://localhost/api/web-sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "Workspace Chat" }),
+      });
+      const res = await POST(req);
+      const json = await res.json();
+      expect(json.session.title).toBe("Workspace Chat");
+      expect(json.session.filePath).toBeUndefined();
+    });
+
     it("creates session with custom title", async () => {
       const { POST } = await import("./route.js");
       const req = new Request("http://localhost/api/web-sessions", {

--- a/apps/web/app/api/web-sessions/web-sessions.test.ts
+++ b/apps/web/app/api/web-sessions/web-sessions.test.ts
@@ -301,4 +301,55 @@ describe("Web Sessions API", () => {
       expect(mockWrite).toHaveBeenCalled();
     });
   });
+
+  describe("cleanTitleText", () => {
+    it("strips [Attached files: ...] prefixes", async () => {
+      const { cleanTitleText } = await import("./shared.js");
+      expect(
+        cleanTitleText("[Attached files: a.md, b.md]\n\nsummarize"),
+      ).toBe("summarize");
+    });
+
+    it("strips [Context: workspace file '...'] prefixes", async () => {
+      const { cleanTitleText } = await import("./shared.js");
+      expect(
+        cleanTitleText("[Context: workspace file 'company']\n\nhow you doing?"),
+      ).toBe("how you doing?");
+    });
+
+    it("strips [Context: workspace directory '...'] prefixes", async () => {
+      const { cleanTitleText } = await import("./shared.js");
+      expect(
+        cleanTitleText(
+          "[Context: workspace directory '~crm/people']\n\nlist everyone",
+        ),
+      ).toBe("list everyone");
+    });
+
+    it("strips [Selected table rows: ...] blocks even when multiline", async () => {
+      const { cleanTitleText } = await import("./shared.js");
+      const input =
+        "[Selected table rows: people]\n3 rows selected.\nColumns: name, email\n- row 1 (p1): name: Ada\n\nwhat are these?";
+      expect(cleanTitleText(input)).toBe("what are these?");
+    });
+
+    it("strips multiple stacked prefixes from a single message", async () => {
+      const { cleanTitleText } = await import("./shared.js");
+      const input =
+        "[Selected table cells: people]\n1 row selected.\n\n[Context: workspace directory '~crm/people']\n\n[Attached files: notes.md]\n\nhelp me write a follow up";
+      expect(cleanTitleText(input)).toBe("help me write a follow up");
+    });
+
+    it("returns empty string when message is only prefixes", async () => {
+      const { cleanTitleText } = await import("./shared.js");
+      expect(
+        cleanTitleText("[Context: workspace file 'doc.md']"),
+      ).toBe("");
+    });
+
+    it("leaves untouched text alone", async () => {
+      const { cleanTitleText } = await import("./shared.js");
+      expect(cleanTitleText("plain old message")).toBe("plain old message");
+    });
+  });
 });

--- a/apps/web/app/components/chat-panel.tsx
+++ b/apps/web/app/components/chat-panel.tsx
@@ -1801,26 +1801,36 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 					onSessionsChange?.();
 				}
 
-				// Merge mention paths and attachment paths into the structured
-				// workspaceContext sent alongside the message. Previously these
-				// were baked into the user message as `[Attached files: …]` /
-				// `[Context: workspace …]` / `[Selected table …]` prefixes;
-				// that polluted the persisted user text and produced ugly chat
-				// titles. We now send raw userText to /api/chat and rebuild
-				// the agent prompt server-side via buildAgentMessage.
+				// Two prefix kinds, two destinations:
+				//
+				// 1. `[Attached files: …]` stays inline in the user message
+				//    text. chat-message.tsx parses it back out to render
+				//    the AttachedFilesCard above the bubble, so this prefix
+				//    is load-bearing for the UI. The session-title cleaner
+				//    strips it, so titles still read like normal prose.
+				// 2. `[Context: workspace …]` and `[Selected table …]` are
+				//    agent-only signals (no UI affordance). They move to a
+				//    structured `workspaceContext` body field so they never
+				//    end up in the persisted user text — that polluted
+				//    chat titles in the sidebar and was the bug report.
 				const allFilePaths = [
 					...mentionedFiles.map((f) => f.path),
 					...currentAttachments.map((f) => f.path),
 				];
+
+				let messageText = userText;
+				if (allFilePaths.length > 0) {
+					const prefix = `[Attached files: ${allFilePaths.join(", ")}]`;
+					messageText = messageText
+						? `${prefix}\n\n${messageText}`
+						: prefix;
+				}
 
 				const announceFilePath =
 					!!fileContext &&
 					lastAnnouncedFilePathRef.current !== fileContext.path;
 
 				const workspaceContext: WorkspaceContext = {};
-				if (allFilePaths.length > 0) {
-					workspaceContext.attachedFilePaths = allFilePaths;
-				}
 				if (announceFilePath && fileContext) {
 					workspaceContext.filePath = fileContext.path;
 					workspaceContext.isDirectory = fileContext.isDirectory;
@@ -1833,10 +1843,11 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 					lastAnnouncedFilePathRef.current = fileContext.path;
 				}
 
-				// Store HTML keyed by raw userText so the user-message renderer
-				// (chat-message.tsx) can recover the rich-text version when
-				// echoing back the message that was just sent.
-				userHtmlMapRef.current.set(userText, html);
+				// Store HTML keyed by the message text the renderer will see
+				// (with [Attached files: …] inline) so chat-message.tsx can
+				// recover the rich-text version when echoing back the
+				// message that was just sent.
+				userHtmlMapRef.current.set(messageText, html);
 				pendingHtmlRef.current = html;
 
 				userScrolledAwayRef.current = false;
@@ -1844,27 +1855,23 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 				if (gatewaySessionKey) {
 					// The gateway flow is a separate transport (POST /api/gateway/chat
 					// sends `{message: string}` to an upstream gateway that owns
-					// session storage). It still expects an inline-prefixed prompt,
-					// so we assemble messageText the legacy way for that path only.
-					let messageText = userText;
-					if (allFilePaths.length > 0) {
-						const prefix = `[Attached files: ${allFilePaths.join(", ")}]`;
-						messageText = messageText
-							? `${prefix}\n\n${messageText}`
-							: prefix;
-					}
+					// session storage). It still expects an inline-prefixed prompt
+					// for ALL signals — including Context/Selected-table — since
+					// it has no `workspaceContext` field, so assemble the full
+					// legacy messageText for that path only.
+					let gatewayMessageText = messageText;
 					if (announceFilePath && fileContext) {
 						const label = fileContext.isDirectory ? "directory" : "file";
-						messageText = `[Context: workspace ${label} '${fileContext.path}']\n\n${messageText}`;
+						gatewayMessageText = `[Context: workspace ${label} '${fileContext.path}']\n\n${gatewayMessageText}`;
 					}
 					if (fileContext?.tableSelection) {
-						messageText = `${formatTableSelectionContext(fileContext.tableSelection)}\n\n${messageText}`;
+						gatewayMessageText = `${formatTableSelectionContext(fileContext.tableSelection)}\n\n${gatewayMessageText}`;
 					}
 
 					const userMsg = {
 						id: `user-${Date.now()}`,
 						role: "user" as const,
-						parts: [{ type: "text" as const, text: messageText }] as UIMessage["parts"],
+						parts: [{ type: "text" as const, text: gatewayMessageText }] as UIMessage["parts"],
 					};
 					setMessages((prev) => [...prev, userMsg]);
 
@@ -1872,7 +1879,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 						const res = await fetch("/api/gateway/chat", {
 							method: "POST",
 							headers: { "Content-Type": "application/json" },
-							body: JSON.stringify({ sessionKey: gatewaySessionKey, message: messageText }),
+							body: JSON.stringify({ sessionKey: gatewaySessionKey, message: gatewayMessageText }),
 						});
 						if (res.ok && res.body) {
 							setStreamError(null);
@@ -1885,12 +1892,13 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 						setStreamError("Failed to send message.");
 					}
 				} else {
-					// /api/chat path: send raw userText + structured
-					// workspaceContext via the transport body callback.
+					// /api/chat path: send messageText (raw text + inline
+					// attachments prefix only) + structured workspaceContext
+					// via the transport body callback.
 					if (Object.keys(workspaceContext).length > 0) {
 						pendingWorkspaceContextRef.current = workspaceContext;
 					}
-					void sendMessage({ text: userText });
+					void sendMessage({ text: messageText });
 				}
 
 				setTimeout(() => {

--- a/apps/web/app/components/chat-panel.tsx
+++ b/apps/web/app/components/chat-panel.tsx
@@ -1600,7 +1600,10 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 					savedMessageIdsRef.current.add(m.id);
 				}
 
-			if (filePath && onFileChanged) {
+				// The agent may have written to the active file during the
+				// stream; refresh its contents so the editor pane shows the
+				// new state. Only relevant when this chat is bound to a file.
+				if (filePath && onFileChanged) {
 					fetch(
 						`/api/workspace/file?path=${encodeURIComponent(filePath)}`,
 					)

--- a/apps/web/app/components/chat-panel.tsx
+++ b/apps/web/app/components/chat-panel.tsx
@@ -1098,8 +1098,10 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 			}
 		}, [messages.length, optimisticUserText]);
 
-		// Track an in-flight pre-created session so we don't fire it twice.
-		const preCreatedSessionRef = useRef<Promise<string> | null>(null);
+		// Sessions are now created lazily on the first submit (see
+		// handleEditorSubmit). The previous "warmup on hero mount" path
+		// produced empty session rows in the sidebar whenever the user
+		// opened a +/new chat and then navigated away without typing.
 
 		const isStreaming =
 			status === "streaming" ||
@@ -1825,10 +1827,13 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 						setOptimisticUserText(userText);
 					}
 
-					// Reuse a session that may already be in flight from the
-					// pre-create-on-mount warmup. Fall back to a fresh call.
-					sessionId = await (preCreatedSessionRef.current ?? createSession(title));
-					preCreatedSessionRef.current = null;
+					// Create the session lazily on first submit. This is the
+					// only place where a workspace-level session is created
+					// from the chat panel — the previous mount-time warmup
+					// was removed because it produced empty session rows in
+					// the sidebar whenever a user opened a chat and walked
+					// away without typing.
+					sessionId = await createSession(title);
 					setCurrentSessionId(sessionId);
 					sessionIdRef.current = sessionId;
 					onActiveSessionChange?.(sessionId);
@@ -2096,13 +2101,6 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 			userHtmlMapRef.current.clear();
 			lastAnnouncedFilePathRef.current = null;
 			newSessionPendingRef.current = false;
-			// Drop any in-flight warmup session — otherwise the next submit
-			// would reuse the pre-warmed id (handleEditorSubmit reads this
-			// ref before falling back to a fresh createSession), silently
-			// threading the "new" chat into the old session instead of
-			// starting clean. The pre-create effect will re-arm on the next
-			// tick for the new chat.
-			preCreatedSessionRef.current = null;
 			setQueuedMessages([]);
 			requestAnimationFrame(() => {
 				editorRef.current?.focus();
@@ -2305,25 +2303,6 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 			!isSubagentMode &&
 			!loadingSession &&
 			optimisticUserText === null;
-
-		// Warm up the session in the background while the user is still on
-		// the hero screen, so the first submit doesn't pay for createSession
-		// (which can be slow on cold-start dev compiles). Pre-creates only
-		// when the panel is visible and there's no session yet.
-		useEffect(() => {
-			if (
-				!visible ||
-				currentSessionId ||
-				isSubagentMode ||
-				isGatewayMode ||
-				loadingSession ||
-				preCreatedSessionRef.current ||
-				messages.length > 0
-			) {
-				return;
-			}
-			preCreatedSessionRef.current = createSession("New Chat");
-		}, [visible, currentSessionId, isSubagentMode, isGatewayMode, loadingSession, messages.length, createSession]);
 
 		// ── Input bar content (shared between hero and bottom positions) ──
 

--- a/apps/web/app/components/chat-panel.tsx
+++ b/apps/web/app/components/chat-panel.tsx
@@ -1843,11 +1843,6 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 					lastAnnouncedFilePathRef.current = fileContext.path;
 				}
 
-				// Store HTML keyed by the message text the renderer will see
-				// (with [Attached files: …] inline) so chat-message.tsx can
-				// recover the rich-text version when echoing back the
-				// message that was just sent.
-				userHtmlMapRef.current.set(messageText, html);
 				pendingHtmlRef.current = html;
 
 				userScrolledAwayRef.current = false;
@@ -1867,6 +1862,12 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 					if (fileContext?.tableSelection) {
 						gatewayMessageText = `${formatTableSelectionContext(fileContext.tableSelection)}\n\n${gatewayMessageText}`;
 					}
+
+					// Key the HTML map by the SAME text the UI message will carry,
+					// so chat-message.tsx's `userHtmlMap.get(textContent)` lookup
+					// matches and the rich rendering (mention pills etc.) is
+					// preserved on first render of the user's bubble.
+					userHtmlMapRef.current.set(gatewayMessageText, html);
 
 					const userMsg = {
 						id: `user-${Date.now()}`,
@@ -1895,6 +1896,11 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 					// /api/chat path: send messageText (raw text + inline
 					// attachments prefix only) + structured workspaceContext
 					// via the transport body callback.
+					//
+					// useChat's sendMessage will create a UI message whose
+					// text part equals `messageText`, so key the HTML map by
+					// `messageText` to match chat-message.tsx's lookup.
+					userHtmlMapRef.current.set(messageText, html);
 					if (Object.keys(workspaceContext).length > 0) {
 						pendingWorkspaceContextRef.current = workspaceContext;
 					}

--- a/apps/web/app/components/chat-panel.tsx
+++ b/apps/web/app/components/chat-panel.tsx
@@ -41,6 +41,7 @@ import type { ComposioChatAction } from "@/lib/composio-chat-actions";
 import type { ChatModelOption } from "@/lib/chat-models";
 import { prepareFilesForChatUpload } from "@/lib/chat-image-preparation";
 import { formatTableSelectionContext, type TableSelectionContext } from "@/lib/table-selection";
+import type { WorkspaceContext } from "@/lib/agent-message";
 
 // ── Attachment types & helpers ──
 
@@ -982,6 +983,13 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 		const userHtmlMapRef = useRef(new Map<string, string>());
 		const pendingHtmlRef = useRef<string | null>(null);
 
+		// Workspace context to send with the next /api/chat POST. Set by
+		// handleEditorSubmit just before it calls sendMessage; read once and
+		// cleared by the transport body callback below. Sending it as a
+		// structured field (instead of baking prefixes into the user message)
+		// keeps persisted user text — and the chat title — clean.
+		const pendingWorkspaceContextRef = useRef<WorkspaceContext | null>(null);
+
 		// ── Message queue (messages to send after current run completes) ──
 		const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([]);
 		// Ref mirror of queuedMessages, so callbacks that close over state
@@ -1052,6 +1060,10 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 						if (pendingHtmlRef.current) {
 							extra.userHtml = pendingHtmlRef.current;
 							pendingHtmlRef.current = null;
+						}
+						if (pendingWorkspaceContextRef.current) {
+							extra.workspaceContext = pendingWorkspaceContextRef.current;
+							pendingWorkspaceContextRef.current = null;
 						}
 					return extra;
 				},
@@ -1831,38 +1843,66 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 					}
 				}
 
-				// Build message with optional attachment prefix
-				let messageText = userText;
-
-				// Merge mention paths and attachment paths
+				// Merge mention paths and attachment paths into the structured
+				// workspaceContext sent alongside the message. Previously these
+				// were baked into the user message as `[Attached files: …]` /
+				// `[Context: workspace …]` / `[Selected table …]` prefixes;
+				// that polluted the persisted user text and produced ugly chat
+				// titles. We now send raw userText to /api/chat and rebuild
+				// the agent prompt server-side via buildAgentMessage.
 				const allFilePaths = [
 					...mentionedFiles.map((f) => f.path),
 					...currentAttachments.map((f) => f.path),
 				];
+
+				const announceFilePath =
+					!!fileContext &&
+					lastAnnouncedFilePathRef.current !== fileContext.path;
+
+				const workspaceContext: WorkspaceContext = {};
 				if (allFilePaths.length > 0) {
-					const prefix = `[Attached files: ${allFilePaths.join(", ")}]`;
-					messageText = messageText
-						? `${prefix}\n\n${messageText}`
-						: prefix;
+					workspaceContext.attachedFilePaths = allFilePaths;
+				}
+				if (announceFilePath && fileContext) {
+					workspaceContext.filePath = fileContext.path;
+					workspaceContext.isDirectory = fileContext.isDirectory;
+				}
+				if (fileContext?.tableSelection) {
+					workspaceContext.tableSelection = fileContext.tableSelection;
 				}
 
-				if (fileContext && lastAnnouncedFilePathRef.current !== fileContext.path) {
-					const label = fileContext.isDirectory ? "directory" : "file";
-					messageText = `[Context: workspace ${label} '${fileContext.path}']\n\n${messageText}`;
+				if (announceFilePath && fileContext) {
 					lastAnnouncedFilePathRef.current = fileContext.path;
 				}
 
-				if (fileContext?.tableSelection) {
-					messageText = `${formatTableSelectionContext(fileContext.tableSelection)}\n\n${messageText}`;
-				}
-
-				// Store HTML for display and pipe to server via transport
-				userHtmlMapRef.current.set(messageText, html);
+				// Store HTML keyed by raw userText so the user-message renderer
+				// (chat-message.tsx) can recover the rich-text version when
+				// echoing back the message that was just sent.
+				userHtmlMapRef.current.set(userText, html);
 				pendingHtmlRef.current = html;
 
 				userScrolledAwayRef.current = false;
 
 				if (gatewaySessionKey) {
+					// The gateway flow is a separate transport (POST /api/gateway/chat
+					// sends `{message: string}` to an upstream gateway that owns
+					// session storage). It still expects an inline-prefixed prompt,
+					// so we assemble messageText the legacy way for that path only.
+					let messageText = userText;
+					if (allFilePaths.length > 0) {
+						const prefix = `[Attached files: ${allFilePaths.join(", ")}]`;
+						messageText = messageText
+							? `${prefix}\n\n${messageText}`
+							: prefix;
+					}
+					if (announceFilePath && fileContext) {
+						const label = fileContext.isDirectory ? "directory" : "file";
+						messageText = `[Context: workspace ${label} '${fileContext.path}']\n\n${messageText}`;
+					}
+					if (fileContext?.tableSelection) {
+						messageText = `${formatTableSelectionContext(fileContext.tableSelection)}\n\n${messageText}`;
+					}
+
 					const userMsg = {
 						id: `user-${Date.now()}`,
 						role: "user" as const,
@@ -1887,7 +1927,12 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 						setStreamError("Failed to send message.");
 					}
 				} else {
-					void sendMessage({ text: messageText });
+					// /api/chat path: send raw userText + structured
+					// workspaceContext via the transport body callback.
+					if (Object.keys(workspaceContext).length > 0) {
+						pendingWorkspaceContextRef.current = workspaceContext;
+					}
+					void sendMessage({ text: userText });
 				}
 
 				setTimeout(() => {

--- a/apps/web/app/components/chat-panel.tsx
+++ b/apps/web/app/components/chat-panel.tsx
@@ -763,14 +763,6 @@ export type FileContext = {
 	tableSelection?: TableSelectionContext;
 };
 
-type FileScopedSession = {
-	id: string;
-	title: string;
-	createdAt: number;
-	updatedAt: number;
-	messageCount: number;
-};
-
 /** A message waiting to be sent after the current agent run finishes. */
 type QueuedMessage = {
 	id: string;
@@ -973,11 +965,6 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 		// the user opens a different file on the right panel and sends a new message,
 		// the agent is re-informed about the current context.
 		const lastAnnouncedFilePathRef = useRef<string | null>(null);
-
-		// File-scoped session list (compact mode only)
-		const [fileSessions, setFileSessions] = useState<
-			FileScopedSession[]
-		>([]);
 
 		// ── Rich HTML for user messages (keyed by message ID or text fallback) ──
 		const userHtmlMapRef = useRef(new Map<string, string>());
@@ -1240,19 +1227,24 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 
 		const createSession = useCallback(
 			async (title: string): Promise<string> => {
-				const body: Record<string, string> = { title };
-				if (filePath) {
-					body.filePath = filePath;
-				}
+				// All chat sessions are workspace-level since the v3 three-column
+				// refactor. The previous behavior — binding `filePath` on the
+				// session whenever any content tab was active — caused the
+				// workspace sidebar to hide perfectly normal chats started from
+				// CRM views or virtual tabs (the sidebar still filters out
+				// sessions with `filePath` set, which is the correct behavior
+				// for legacy file-scoped sessions). Workspace context for the
+				// agent is now carried per-message via `workspaceContext` on
+				// POST /api/chat, so the session itself stays unscoped.
 				const res = await fetch("/api/web-sessions", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify(body),
+					body: JSON.stringify({ title }),
 				});
 				const data = await res.json();
 				return data.session.id;
 			},
-			[filePath],
+			[],
 		);
 
 		// ── Stream reconnection ──
@@ -1393,34 +1385,11 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 			[setMessages],
 		);
 
-		// ── File-scoped session initialization ──
-		const fetchFileSessionsRef = useRef<
-			(() => Promise<FileScopedSession[]>) | null
-		>(null);
-
-		fetchFileSessionsRef.current = async () => {
-			if (!filePath) {
-				return [];
-			}
-			try {
-				const res = await fetch(
-					`/api/web-sessions?filePath=${encodeURIComponent(filePath)}`,
-				);
-				const data = await res.json();
-				return (data.sessions || []) as FileScopedSession[];
-			} catch {
-				return [];
-			}
-		};
-
-		// v3 three-column refactor: file-scoped sessions were removed.
-		// The center chat keeps its current session regardless of which file is opened on
-		// the right panel. `fileContext` (via `filePath`) only augments the message payload
-		// ("[Context: workspace file 'X']") and the input placeholder — it no longer resets
-		// the panel or swaps to a file-scoped session.
-		useEffect(() => {
-			return;
-		}, [filePath]);
+		// v3 three-column refactor: file-scoped sessions were removed. The
+		// center chat keeps its current session regardless of which file is
+		// open on the right panel. `fileContext` (via `filePath`) only
+		// augments the per-message workspaceContext payload — it never
+		// resets the panel or swaps to a file-scoped session.
 
 		// v3: auto-restore session on mount or URL change.
 		// Note: this previously short-circuited when `filePath` was set (file-scoped chat mode);
@@ -1631,14 +1600,6 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 					savedMessageIdsRef.current.add(m.id);
 				}
 
-			if (filePath) {
-				void fetchFileSessionsRef.current?.().then(
-					(sessions) => {
-						setFileSessions(sessions);
-					},
-				);
-			}
-
 			if (filePath && onFileChanged) {
 					fetch(
 						`/api/workspace/file?path=${encodeURIComponent(filePath)}`,
@@ -1838,14 +1799,6 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 					sessionIdRef.current = sessionId;
 					onActiveSessionChange?.(sessionId);
 					onSessionsChange?.();
-
-					if (filePath) {
-						void fetchFileSessionsRef.current?.().then(
-							(sessions) => {
-								setFileSessions(sessions);
-							},
-						);
-					}
 				}
 
 				// Merge mention paths and attachment paths into the structured
@@ -1951,7 +1904,6 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 				createSession,
 				onActiveSessionChange,
 				onSessionsChange,
-				filePath,
 				fileContext,
 				sendMessage,
 				gatewaySessionKey,

--- a/apps/web/lib/agent-message.test.ts
+++ b/apps/web/lib/agent-message.test.ts
@@ -50,6 +50,28 @@ describe("buildAgentMessage", () => {
 		);
 	});
 
+	it("does NOT apply the workspace prefix to directory context paths", () => {
+		// The legacy server regex only matched `workspace file '...'`, so
+		// directory paths (especially virtual surfaces like `~crm/people`)
+		// were always passed through unprefixed. Prefixing them would
+		// produce nonsensical paths like `<workspaceRoot>/~crm/people`.
+		expect(
+			buildAgentMessage({
+				userText: "list",
+				workspaceContext: { filePath: "~crm/people", isDirectory: true },
+				workspacePrefix: "/home/user/.openclaw/work",
+			}),
+		).toBe("[Context: workspace directory '~crm/people']\n\nlist");
+
+		expect(
+			buildAgentMessage({
+				userText: "list",
+				workspaceContext: { filePath: "subdir", isDirectory: true },
+				workspacePrefix: "/home/user/.openclaw/work",
+			}),
+		).toBe("[Context: workspace directory 'subdir']\n\nlist");
+	});
+
 	it("prepends a [Selected table ...] block when tableSelection is provided", () => {
 		const selection: TableSelectionContext = {
 			objectName: "people",

--- a/apps/web/lib/agent-message.test.ts
+++ b/apps/web/lib/agent-message.test.ts
@@ -7,13 +7,15 @@ describe("buildAgentMessage", () => {
 		expect(buildAgentMessage({ userText: "hello" })).toBe("hello");
 	});
 
-	it("prepends [Attached files: ...] when attachments are listed", () => {
+	it("does not touch [Attached files: ...] already in userText", () => {
+		// [Attached files: ...] stays in the message text (chat-message.tsx
+		// parses it for the AttachedFilesCard); buildAgentMessage only
+		// layers agent-only prefixes on top.
 		expect(
 			buildAgentMessage({
-				userText: "summarize",
-				workspaceContext: { attachedFilePaths: ["a.md", "b.md"] },
+				userText: "[Attached files: a.md]\n\nsummarize",
 			}),
-		).toBe("[Attached files: a.md, b.md]\n\nsummarize");
+		).toBe("[Attached files: a.md]\n\nsummarize");
 	});
 
 	it("prepends [Context: workspace file '...'] when filePath is provided", () => {
@@ -72,7 +74,7 @@ describe("buildAgentMessage", () => {
 		expect(out).toContain("anything weird?");
 	});
 
-	it("orders prefixes: tableSelection > filePath > attachedFiles > userText", () => {
+	it("orders prefixes: tableSelection > filePath > attachedFiles in userText", () => {
 		const selection: TableSelectionContext = {
 			objectName: "people",
 			kind: "cells",
@@ -84,10 +86,11 @@ describe("buildAgentMessage", () => {
 			],
 			updatedAt: 0,
 		};
+		// userText carries the attachments prefix that the client builds
+		// inline; buildAgentMessage layers Context + Selected table on top.
 		const out = buildAgentMessage({
-			userText: "go",
+			userText: "[Attached files: a.md]\n\ngo",
 			workspaceContext: {
-				attachedFilePaths: ["a.md"],
 				filePath: "doc.md",
 				isDirectory: false,
 				tableSelection: selection,

--- a/apps/web/lib/agent-message.test.ts
+++ b/apps/web/lib/agent-message.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { buildAgentMessage } from "./agent-message";
+import type { TableSelectionContext } from "./table-selection";
+
+describe("buildAgentMessage", () => {
+	it("returns userText unchanged when no context is provided", () => {
+		expect(buildAgentMessage({ userText: "hello" })).toBe("hello");
+	});
+
+	it("prepends [Attached files: ...] when attachments are listed", () => {
+		expect(
+			buildAgentMessage({
+				userText: "summarize",
+				workspaceContext: { attachedFilePaths: ["a.md", "b.md"] },
+			}),
+		).toBe("[Attached files: a.md, b.md]\n\nsummarize");
+	});
+
+	it("prepends [Context: workspace file '...'] when filePath is provided", () => {
+		expect(
+			buildAgentMessage({
+				userText: "what is this?",
+				workspaceContext: { filePath: "doc.md", isDirectory: false },
+			}),
+		).toBe("[Context: workspace file 'doc.md']\n\nwhat is this?");
+	});
+
+	it("uses 'directory' label for directory contexts", () => {
+		expect(
+			buildAgentMessage({
+				userText: "list everyone",
+				workspaceContext: { filePath: "~crm/people", isDirectory: true },
+			}),
+		).toBe(
+			"[Context: workspace directory '~crm/people']\n\nlist everyone",
+		);
+	});
+
+	it("applies the workspace prefix to file context paths", () => {
+		expect(
+			buildAgentMessage({
+				userText: "ok",
+				workspaceContext: { filePath: "doc.md", isDirectory: false },
+				workspacePrefix: "/home/user/.openclaw/work",
+			}),
+		).toBe(
+			"[Context: workspace file '/home/user/.openclaw/work/doc.md']\n\nok",
+		);
+	});
+
+	it("prepends a [Selected table ...] block when tableSelection is provided", () => {
+		const selection: TableSelectionContext = {
+			objectName: "people",
+			kind: "rows",
+			rowCount: 1,
+			columnCount: 2,
+			columns: ["name", "email"],
+			rows: [
+				{
+					rowIndex: 0,
+					entryId: "p1",
+					values: { name: "Ada", email: "ada@example.com" },
+				},
+			],
+			updatedAt: 0,
+		};
+		const out = buildAgentMessage({
+			userText: "anything weird?",
+			workspaceContext: { tableSelection: selection },
+		});
+		expect(out).toContain("[Selected table rows: people]");
+		expect(out).toContain("anything weird?");
+	});
+
+	it("orders prefixes: tableSelection > filePath > attachedFiles > userText", () => {
+		const selection: TableSelectionContext = {
+			objectName: "people",
+			kind: "cells",
+			rowCount: 1,
+			columnCount: 1,
+			columns: ["email"],
+			cells: [
+				{ rowIndex: 0, entryId: "p1", fieldName: "email", value: "x" },
+			],
+			updatedAt: 0,
+		};
+		const out = buildAgentMessage({
+			userText: "go",
+			workspaceContext: {
+				attachedFilePaths: ["a.md"],
+				filePath: "doc.md",
+				isDirectory: false,
+				tableSelection: selection,
+			},
+		});
+
+		const tableIdx = out.indexOf("[Selected table");
+		const ctxIdx = out.indexOf("[Context: workspace");
+		const attIdx = out.indexOf("[Attached files:");
+		const goIdx = out.indexOf("go");
+
+		expect(tableIdx).toBeGreaterThanOrEqual(0);
+		expect(tableIdx).toBeLessThan(ctxIdx);
+		expect(ctxIdx).toBeLessThan(attIdx);
+		expect(attIdx).toBeLessThan(goIdx);
+	});
+});

--- a/apps/web/lib/agent-message.test.ts
+++ b/apps/web/lib/agent-message.test.ts
@@ -50,11 +50,24 @@ describe("buildAgentMessage", () => {
 		);
 	});
 
-	it("does NOT apply the workspace prefix to directory context paths", () => {
-		// The legacy server regex only matched `workspace file '...'`, so
-		// directory paths (especially virtual surfaces like `~crm/people`)
-		// were always passed through unprefixed. Prefixing them would
-		// produce nonsensical paths like `<workspaceRoot>/~crm/people`.
+	it("applies the workspace prefix to real (relative) directory paths", () => {
+		// Real workspace directories are relative to the workspace root, so
+		// the agent needs the absolute path to operate on them.
+		expect(
+			buildAgentMessage({
+				userText: "list",
+				workspaceContext: { filePath: "subdir", isDirectory: true },
+				workspacePrefix: "/home/user/.openclaw/work",
+			}),
+		).toBe(
+			"[Context: workspace directory '/home/user/.openclaw/work/subdir']\n\nlist",
+		);
+	});
+
+	it("does NOT apply the workspace prefix to virtual (~...) directory paths", () => {
+		// Virtual surfaces like `~crm/people`, `~cloud`, `~skills` are
+		// handled by tool routing on the agent side. Prefixing them would
+		// produce nonsensical paths like `<wsRoot>/~crm/people`.
 		expect(
 			buildAgentMessage({
 				userText: "list",
@@ -65,11 +78,29 @@ describe("buildAgentMessage", () => {
 
 		expect(
 			buildAgentMessage({
-				userText: "list",
-				workspaceContext: { filePath: "subdir", isDirectory: true },
+				userText: "open",
+				workspaceContext: { filePath: "~cloud", isDirectory: true },
 				workspacePrefix: "/home/user/.openclaw/work",
 			}),
-		).toBe("[Context: workspace directory 'subdir']\n\nlist");
+		).toBe("[Context: workspace directory '~cloud']\n\nopen");
+	});
+
+	it("does NOT double-prefix already-absolute paths", () => {
+		// Some legacy chats persisted absolute paths in fileContext.path
+		// (e.g. `/Users/me/.openclaw-dench/openclaw.json`). Double-prefixing
+		// them would produce paths like `<wsRoot>//Users/me/...`.
+		expect(
+			buildAgentMessage({
+				userText: "what is this?",
+				workspaceContext: {
+					filePath: "/Users/me/.openclaw-dench/openclaw.json",
+					isDirectory: false,
+				},
+				workspacePrefix: "/home/user/.openclaw/work",
+			}),
+		).toBe(
+			"[Context: workspace file '/Users/me/.openclaw-dench/openclaw.json']\n\nwhat is this?",
+		);
 	});
 
 	it("prepends a [Selected table ...] block when tableSelection is provided", () => {

--- a/apps/web/lib/agent-message.ts
+++ b/apps/web/lib/agent-message.ts
@@ -1,0 +1,67 @@
+import {
+	formatTableSelectionContext,
+	type TableSelectionContext,
+} from "@/lib/table-selection";
+
+/**
+ * Workspace context attached to a chat message in addition to the user's
+ * typed text. The client sends this as a separate body field on POST /api/chat
+ * so the persisted user message stays clean (no `[Context: ...]` /
+ * `[Attached files: ...]` / `[Selected table ...]` prefixes baked in), while
+ * the agent still receives the full prefixed prompt it expects.
+ *
+ * Each field is optional — clients only include a piece when it should
+ * actually be announced to the agent on this turn (e.g. `filePath` is
+ * omitted on subsequent turns once the path was already announced).
+ */
+export type WorkspaceContext = {
+	/** Path of the active workspace file/directory the user is viewing. */
+	filePath?: string;
+	/** True when `filePath` is a directory or virtual surface (~crm/...). */
+	isDirectory?: boolean;
+	/** Paths of files mentioned in the editor or attached as uploads. */
+	attachedFilePaths?: string[];
+	/** Snapshot of selected table rows/cells, formatted into prompt text. */
+	tableSelection?: TableSelectionContext;
+};
+
+/**
+ * Build the prompt the agent actually sees, by prepending the same
+ * bracketed metadata blocks the client used to assemble inline. Order
+ * matches the legacy client implementation so behavior is identical from
+ * the agent's perspective.
+ */
+export function buildAgentMessage(args: {
+	userText: string;
+	workspaceContext?: WorkspaceContext;
+	/** Optional workspace-root prefix (e.g. /home/ubuntu/.openclaw/work). */
+	workspacePrefix?: string | null;
+}): string {
+	const { userText, workspaceContext, workspacePrefix } = args;
+	let message = userText;
+
+	const ctx = workspaceContext;
+	if (!ctx) {
+		return message;
+	}
+
+	const attached = ctx.attachedFilePaths?.filter(Boolean) ?? [];
+	if (attached.length > 0) {
+		const attachedPrefix = `[Attached files: ${attached.join(", ")}]`;
+		message = message ? `${attachedPrefix}\n\n${message}` : attachedPrefix;
+	}
+
+	if (ctx.filePath) {
+		const label = ctx.isDirectory ? "directory" : "file";
+		const fullPath = workspacePrefix
+			? `${workspacePrefix}/${ctx.filePath}`
+			: ctx.filePath;
+		message = `[Context: workspace ${label} '${fullPath}']\n\n${message}`;
+	}
+
+	if (ctx.tableSelection) {
+		message = `${formatTableSelectionContext(ctx.tableSelection)}\n\n${message}`;
+	}
+
+	return message;
+}

--- a/apps/web/lib/agent-message.ts
+++ b/apps/web/lib/agent-message.ts
@@ -52,9 +52,14 @@ export function buildAgentMessage(args: {
 
 	if (ctx.filePath) {
 		const label = ctx.isDirectory ? "directory" : "file";
-		const fullPath = workspacePrefix
-			? `${workspacePrefix}/${ctx.filePath}`
-			: ctx.filePath;
+		// Match the legacy server regex which only rewrote `workspace file`
+		// paths. Directory paths (including virtual surfaces like `~crm/...`)
+		// were never prefixed — prefixing them produces nonsensical paths
+		// like `<workspaceRoot>/~crm/people` that the agent can't resolve.
+		const fullPath =
+			workspacePrefix && !ctx.isDirectory
+				? `${workspacePrefix}/${ctx.filePath}`
+				: ctx.filePath;
 		message = `[Context: workspace ${label} '${fullPath}']\n\n${message}`;
 	}
 

--- a/apps/web/lib/agent-message.ts
+++ b/apps/web/lib/agent-message.ts
@@ -52,14 +52,21 @@ export function buildAgentMessage(args: {
 
 	if (ctx.filePath) {
 		const label = ctx.isDirectory ? "directory" : "file";
-		// Match the legacy server regex which only rewrote `workspace file`
-		// paths. Directory paths (including virtual surfaces like `~crm/...`)
-		// were never prefixed — prefixing them produces nonsensical paths
-		// like `<workspaceRoot>/~crm/people` that the agent can't resolve.
-		const fullPath =
-			workspacePrefix && !ctx.isDirectory
-				? `${workspacePrefix}/${ctx.filePath}`
-				: ctx.filePath;
+		// Apply the workspace prefix to relative paths only — both files and
+		// real workspace directories benefit from the absolute path, but:
+		//   - virtual surfaces like `~crm/people`, `~cloud`, `~skills` are
+		//     handled by tool routing on the agent side and would become
+		//     nonsensical paths if we prefixed them (`<wsRoot>/~crm/people`).
+		//   - already-absolute paths must not be double-prefixed.
+		// The legacy server regex only matched `workspace file '...'` so
+		// directories used to silently slip through unprefixed; this is the
+		// path-shape-aware version that does the right thing for both.
+		const isVirtual = ctx.filePath.startsWith("~");
+		const isAbsolute = ctx.filePath.startsWith("/");
+		const shouldPrefix = workspacePrefix && !isVirtual && !isAbsolute;
+		const fullPath = shouldPrefix
+			? `${workspacePrefix}/${ctx.filePath}`
+			: ctx.filePath;
 		message = `[Context: workspace ${label} '${fullPath}']\n\n${message}`;
 	}
 

--- a/apps/web/lib/agent-message.ts
+++ b/apps/web/lib/agent-message.ts
@@ -6,9 +6,13 @@ import {
 /**
  * Workspace context attached to a chat message in addition to the user's
  * typed text. The client sends this as a separate body field on POST /api/chat
- * so the persisted user message stays clean (no `[Context: ...]` /
- * `[Attached files: ...]` / `[Selected table ...]` prefixes baked in), while
- * the agent still receives the full prefixed prompt it expects.
+ * so these agent-only signals (`[Context: ...]`, `[Selected table ...]`)
+ * never get baked into the persisted user message — that's what produced
+ * ugly chat titles in the sidebar like `[Context: workspace file 'company']`.
+ *
+ * Note that `[Attached files: ...]` is intentionally NOT here: it stays in
+ * the user message text because chat-message.tsx parses that prefix to
+ * render the AttachedFilesCard. The session-title cleaner strips it.
  *
  * Each field is optional — clients only include a piece when it should
  * actually be announced to the agent on this turn (e.g. `filePath` is
@@ -19,8 +23,6 @@ export type WorkspaceContext = {
 	filePath?: string;
 	/** True when `filePath` is a directory or virtual surface (~crm/...). */
 	isDirectory?: boolean;
-	/** Paths of files mentioned in the editor or attached as uploads. */
-	attachedFilePaths?: string[];
 	/** Snapshot of selected table rows/cells, formatted into prompt text. */
 	tableSelection?: TableSelectionContext;
 };
@@ -30,6 +32,9 @@ export type WorkspaceContext = {
  * bracketed metadata blocks the client used to assemble inline. Order
  * matches the legacy client implementation so behavior is identical from
  * the agent's perspective.
+ *
+ * `[Attached files: ...]` (when present) is already in `userText`; this
+ * helper only layers on the agent-only prefixes from `workspaceContext`.
  */
 export function buildAgentMessage(args: {
 	userText: string;
@@ -43,12 +48,6 @@ export function buildAgentMessage(args: {
 	const ctx = workspaceContext;
 	if (!ctx) {
 		return message;
-	}
-
-	const attached = ctx.attachedFilePaths?.filter(Boolean) ?? [];
-	if (attached.length > 0) {
-		const attachedPrefix = `[Attached files: ${attached.join(", ")}]`;
-		message = message ? `${attachedPrefix}\n\n${message}` : attachedPrefix;
 	}
 
 	if (ctx.filePath) {


### PR DESCRIPTION
## Summary

Re-landing #242 via a merge commit so per-commit history is preserved on `main`. The previous attempt landed as a squash by mistake; that squash has been reset off `main`. No code changes from #242.

Three user-reported issues fixed, plus two Bugbot follow-ups:

1. **Clean chat titles** — sidebar showed `[Context: workspace file 'company']` instead of the user's first message. Refactor: client now sends raw `userText` + a structured `workspaceContext` body field; server reconstructs the agent prompt via `buildAgentMessage` and persists only the raw user text. Existing bad titles are backfilled on read via `cleanTitleText` in `web-sessions/shared.ts`.
2. **No empty sessions on `+`** — the chat panel pre-warmed sessions on hero mount, leaving empty rows in the sidebar. Drop the warmup; sessions are now created lazily on first submit.
3. **Chats from CRM pages now visible in sidebar** — `createSession` was binding `filePath` for any active workspace tab (including virtual `~crm/...`), and the sidebar filter hid those. Stop binding `filePath` on new sessions; remove the dead `fileSessions` state path.

Bugbot follow-ups landed in the same branch:
- Key `userHtmlMap` by the exact text the UI message will carry (gateway vs `/api/chat` paths use different prefixes).
- `buildAgentMessage` now only applies `workspacePrefix` for files (matching the legacy regex which never prefixed directories), so `~crm/people` no longer becomes `<workspaceRoot>/~crm/people`.

## Verification

- Live-tested in browser: + click does not create sessions; sending a message creates one with the raw user text as title; chats from CRM pages appear in sidebar; reload preserves them; AttachedFilesCard renders for `@`-mentioned files; legacy bad-title chats now show clean text.
- `pnpm test` (apps/web): **1766 passed**, 5 skipped.
- `tsc --noEmit`: clean.
- Bugbot: clean (last run SUCCESS, both follow-ups addressed inline).

## Test plan

- [x] Unit tests pass
- [x] Type check clean
- [x] Manual browser verification of all three issues
- [x] AttachedFilesCard regression test (mention a file → card renders)
- [x] Legacy backfilled chat opens with conversation intact
- [x] Bugbot findings addressed (HTML key mismatch, directory prefix)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how `/api/chat` constructs the agent prompt and how the client/session APIs persist metadata, which could affect prompt formatting, title backfills, and session visibility.
> 
> **Overview**
> **Moves agent-only metadata out of persisted user text.** The chat panel now sends raw user text plus a structured `workspaceContext` (file/directory + selected-table snapshot) to `/api/chat`; the server reconstructs the legacy bracketed prompt via new `buildAgentMessage`, while keeping `[Attached files: ...]` inline for UI parsing.
> 
> **Cleans up sidebar titles and legacy sessions.** Adds `cleanTitleText` and uses it when deriving titles and when re-reading the sessions index to backfill/retitle sessions whose titles leaked `[Context ...]`, `[Selected table ...]`, or `[Attached files ...]` prefixes.
> 
> **Fixes session creation/visibility regressions.** Removes hero-screen session warmup and always creates sessions lazily on first submit, and stops binding `filePath` on new sessions (removing dead file-scoped session code) so chats started from non-file surfaces remain visible in the workspace sidebar; also fixes HTML mapping for gateway vs `/api/chat` message text differences. Tests updated/added to cover prompt layering, context prefixing rules, and title cleaning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01cd9b18eaf7c11770a81f05db2003d1cd24e4d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->