### PR TITLE
Migrate enrichment to Dench gateway requiredFields (remove mode=max)

### DIFF
--- a/apps/web/app/api/onboarding/dench-cloud/route.test.ts
+++ b/apps/web/app/api/onboarding/dench-cloud/route.test.ts
@@ -50,7 +50,6 @@ const cloudState = {
   selectedDenchModel: null,
   selectedVoiceId: null,
   elevenLabsEnabled: false,
-  enrichmentMaxModeEnabled: false,
   models: [
     {
       id: "dench-claude-sonnet",

--- a/apps/web/app/api/settings/cloud/route.test.ts
+++ b/apps/web/app/api/settings/cloud/route.test.ts
@@ -32,7 +32,6 @@ const validState = {
   selectedDenchModel: "anthropic.claude-opus-4-6-v1",
   selectedVoiceId: "voice_123",
   elevenLabsEnabled: true,
-  enrichmentMaxModeEnabled: false,
   models: [
     {
       id: "claude-opus-4.6",
@@ -206,7 +205,6 @@ describe("cloud settings API", () => {
         action: "save_active_settings",
         stableId: "gpt-5.4",
         voiceId: "voice_123",
-        enrichmentMaxModeEnabled: true,
         integrations: {
           exa: true,
           apollo: true,
@@ -219,7 +217,6 @@ describe("cloud settings API", () => {
     expect(mockedSaveActive).toHaveBeenCalledWith({
       stableId: "gpt-5.4",
       voiceId: "voice_123",
-      enrichmentMaxModeEnabled: true,
       integrations: {
         exa: true,
         apollo: true,
@@ -237,19 +234,6 @@ describe("cloud settings API", () => {
         integrations: {
           exa: "yes",
         },
-      }),
-    });
-    const res = await POST(req);
-    expect(res.status).toBe(400);
-  });
-
-  it("POST save_active_settings rejects invalid max mode payloads", async () => {
-    const req = new Request("http://localhost/api/settings/cloud", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        action: "save_active_settings",
-        enrichmentMaxModeEnabled: "yes",
       }),
     });
     const res = await POST(req);

--- a/apps/web/app/api/settings/cloud/route.ts
+++ b/apps/web/app/api/settings/cloud/route.ts
@@ -28,7 +28,6 @@ type PostBody = {
   stableId?: string;
   voiceId?: string | null;
   integrations?: DenchIntegrationToggleDraft;
-  enrichmentMaxModeEnabled?: boolean;
 };
 
 function isSupportedIntegration(id: string): id is DenchIntegrationId {
@@ -117,12 +116,6 @@ export async function POST(request: Request) {
       if (voiceId === undefined) {
         return Response.json({ error: "Field 'voiceId' must be a string or null." }, { status: 400 });
       }
-      if (body.enrichmentMaxModeEnabled !== undefined && typeof body.enrichmentMaxModeEnabled !== "boolean") {
-        return Response.json(
-          { error: "Field 'enrichmentMaxModeEnabled' must be a boolean." },
-          { status: 400 },
-        );
-      }
       if (body.integrations !== undefined && (!body.integrations || typeof body.integrations !== "object" || Array.isArray(body.integrations))) {
         return Response.json({ error: "Field 'integrations' must be an object." }, { status: 400 });
       }
@@ -142,7 +135,6 @@ export async function POST(request: Request) {
         stableId,
         voiceId,
         integrations,
-        enrichmentMaxModeEnabled: body.enrichmentMaxModeEnabled === true,
       });
       if (result.error) {
         return Response.json({ error: result.error, ...result }, { status: 409 });

--- a/apps/web/app/api/workspace/objects/[name]/enrich/route.test.ts
+++ b/apps/web/app/api/workspace/objects/[name]/enrich/route.test.ts
@@ -24,7 +24,6 @@ vi.mock("@/lib/integrations", () => ({
   resolveDenchGatewayCredentials: vi.fn(() => ({
     apiKey: "dc-key",
     gatewayUrl: "https://gateway.example.com",
-    enrichmentMaxModeEnabled: true,
   })),
 }));
 
@@ -36,7 +35,7 @@ describe("workspace enrichment route", () => {
     vi.mocked(duckdbQueryOnFile).mockReset();
   });
 
-  it("forwards mode=max for people enrichment requests when enabled", async () => {
+  it("forwards requiredFields for people enrichment derived from the apollo path", async () => {
     const { duckdbQueryOnFile } = await import("@/lib/workspace");
     vi.mocked(duckdbQueryOnFile).mockImplementation((_dbFile: string, sql: string) => {
       if (sql.includes("SELECT id FROM objects WHERE name")) {
@@ -60,10 +59,12 @@ describe("workspace enrichment route", () => {
     global.fetch = vi.fn(async (input, init) => {
       expect(String(input)).toBe("https://gateway.example.com/v1/enrichment/people");
       expect(init?.method).toBe("POST");
-      expect(JSON.parse(String(init?.body))).toMatchObject({
+      const body = JSON.parse(String(init?.body));
+      expect(body).toMatchObject({
         email: "jane@acme.com",
-        mode: "max",
+        requiredFields: ["fullName"],
       });
+      expect(body.mode).toBeUndefined();
       return new Response(JSON.stringify({ person: { name: "Jane Doe" } }), {
         status: 200,
         headers: { "content-type": "application/json" },
@@ -113,10 +114,12 @@ describe("workspace enrichment route", () => {
     });
 
     global.fetch = vi.fn(async (_input, init) => {
-      expect(JSON.parse(String(init?.body))).toMatchObject({
+      const body = JSON.parse(String(init?.body));
+      expect(body).toMatchObject({
         linkedin_url: "https://www.linkedin.com/in/markrachapoom",
-        mode: "max",
+        requiredFields: ["fullName"],
       });
+      expect(body.mode).toBeUndefined();
       return new Response(JSON.stringify({ person: { name: "Mark Rachapoom" } }), {
         status: 200,
         headers: { "content-type": "application/json" },
@@ -144,7 +147,7 @@ describe("workspace enrichment route", () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
-  it("forwards mode=max for company enrichment requests when enabled", async () => {
+  it("forwards requiredFields as a CSV query param for company enrichment", async () => {
     const { duckdbQueryOnFile } = await import("@/lib/workspace");
     vi.mocked(duckdbQueryOnFile).mockImplementation((_dbFile: string, sql: string) => {
       if (sql.includes("SELECT id FROM objects WHERE name")) {
@@ -169,7 +172,8 @@ describe("workspace enrichment route", () => {
       const url = new URL(String(input));
       expect(url.origin + url.pathname).toBe("https://gateway.example.com/v1/enrichment/company");
       expect(url.searchParams.get("domain")).toBe("acme.com");
-      expect(url.searchParams.get("mode")).toBe("max");
+      expect(url.searchParams.get("requiredFields")).toBe("name");
+      expect(url.searchParams.get("mode")).toBeNull();
       expect(init?.method).toBe("GET");
       return new Response(JSON.stringify({ organization: { name: "Acme" } }), {
         status: 200,
@@ -265,5 +269,59 @@ describe("workspace enrichment route", () => {
     expect(response.status).toBe(200);
     await response.text();
     expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("surfaces gateway invalid_required_field errors in SSE error events", async () => {
+    const { duckdbQueryOnFile } = await import("@/lib/workspace");
+    vi.mocked(duckdbQueryOnFile).mockImplementation((_dbFile: string, sql: string) => {
+      if (sql.includes("SELECT id FROM objects WHERE name")) {
+        return [{ id: "obj_1" }] as never;
+      }
+      if (sql.includes("SELECT id, name, type FROM fields")) {
+        return [{ id: "input_1", name: "email", type: "email" }] as never;
+      }
+      if (sql.includes("SELECT id FROM fields WHERE id")) {
+        return [{ id: "field_1" }] as never;
+      }
+      if (sql.includes("FROM entries e")) {
+        return [{ entry_id: "entry_1", input_value: "jane@acme.com" }] as never;
+      }
+      if (sql.includes("COUNT(*) as cnt")) {
+        return [{ cnt: 0 }] as never;
+      }
+      return [] as never;
+    });
+
+    global.fetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          error: {
+            code: "invalid_required_field",
+            message: "Unknown required fields: foo",
+          },
+        }),
+        { status: 400, headers: { "content-type": "application/json" } },
+      ),
+    ) as typeof fetch;
+
+    const { POST } = await import("./route.js");
+    const response = await POST(
+      new Request("http://localhost/api/workspace/objects/leads/enrich", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          fieldId: "field_1",
+          apolloPath: "person.name",
+          category: "people",
+          inputFieldName: "email",
+          scope: 1,
+        }),
+      }),
+      { params: Promise.resolve({ name: "leads" }) },
+    );
+
+    expect(response.status).toBe(200);
+    const text = await response.text();
+    expect(text).toContain("Unknown required fields: foo");
   });
 });

--- a/apps/web/app/api/workspace/objects/[name]/enrich/route.ts
+++ b/apps/web/app/api/workspace/objects/[name]/enrich/route.ts
@@ -8,9 +8,12 @@ import {
 	resolveDenchGatewayCredentials,
 } from "@/lib/integrations";
 import {
-	extractApolloValue,
 	extractDomain,
+	extractEnrichmentValue,
+	getEnrichmentColumns,
+	getRequiredFieldsForApolloPath,
 	isEligibleInputField,
+	type EnrichmentColumnDef,
 } from "@/lib/enrichment-columns";
 
 export const dynamic = "force-dynamic";
@@ -58,7 +61,7 @@ export async function POST(
 		return Response.json({ error: "Apollo integration is not enabled." }, { status: 403 });
 	}
 
-	const { apiKey, gatewayUrl, enrichmentMaxModeEnabled } = resolveDenchGatewayCredentials();
+	const { apiKey, gatewayUrl } = resolveDenchGatewayCredentials();
 	if (!apiKey || !gatewayUrl) {
 		return Response.json({ error: "Gateway credentials unavailable." }, { status: 500 });
 	}
@@ -73,6 +76,19 @@ export async function POST(
 	if (category !== "people" && category !== "company") {
 		return Response.json({ error: "Invalid category." }, { status: 400 });
 	}
+
+	// Resolve the canonical column def (for requiredFields + extraction fallbacks).
+	// Falls back to a synthetic column when callers pass a custom apolloPath so
+	// existing integrations keep working without bypassing extraction.
+	const matchedColumn: EnrichmentColumnDef = getEnrichmentColumns(category).find(
+		(candidate) => candidate.apolloPath === apolloPath,
+	) ?? {
+		label: "",
+		key: apolloPath,
+		fieldType: "text",
+		apolloPath,
+		requiredFields: getRequiredFieldsForApolloPath(category, apolloPath),
+	};
 
 	if (
 		scope !== "all"
@@ -183,30 +199,30 @@ export async function POST(
 				}
 
 				try {
-					const payload = await callApolloGateway(
+					const result = await callApolloGateway(
 						gatewayUrl,
 						apiKey,
 						category,
 						inputValue,
-						enrichmentMaxModeEnabled,
+						matchedColumn.requiredFields,
 					);
 					if (cancelled) break;
 
-					if (!payload) {
+					if (!result.ok) {
 						failed++;
 						send({
 							type: "error",
 							entryId: entry.entry_id,
-							error: "No data returned",
+							error: result.error,
 							current: i + 1,
 							total,
 						});
 						continue;
 					}
 
-					const value = extractApolloValue(
-						payload as Record<string, unknown>,
-						apolloPath,
+					const value = extractEnrichmentValue(
+						result.payload as Record<string, unknown>,
+						matchedColumn,
 					);
 
 					if (value == null) {
@@ -263,25 +279,29 @@ export async function POST(
 	});
 }
 
+type GatewayCallResult =
+	| { ok: true; payload: unknown }
+	| { ok: false; error: string };
+
 async function callApolloGateway(
 	gatewayUrl: string,
 	apiKey: string,
 	category: "people" | "company",
 	inputValue: string,
-	enrichmentMaxModeEnabled: boolean,
-): Promise<unknown> {
+	requiredFields: string[],
+): Promise<GatewayCallResult> {
 	if (category === "people") {
-		const body: Record<string, string> = {};
+		const body: Record<string, unknown> = {};
 
 		if (inputValue.includes("linkedin.com")) {
 			body.linkedin_url = inputValue;
 		} else if (inputValue.includes("@")) {
 			body.email = inputValue;
 		} else {
-			return null;
+			return { ok: false, error: "Unsupported people identifier" };
 		}
-		if (enrichmentMaxModeEnabled) {
-			body.mode = "max";
+		if (requiredFields.length > 0) {
+			body.requiredFields = requiredFields;
 		}
 
 		const response = await fetch(
@@ -296,26 +316,55 @@ async function callApolloGateway(
 			},
 		);
 
-		if (!response.ok) return null;
-		return response.json();
+		if (!response.ok) {
+			return { ok: false, error: await formatGatewayError(response) };
+		}
+		return { ok: true, payload: await response.json() };
 	}
 
-	// Company enrichment
 	const domain = extractDomain(inputValue);
-	if (!domain) return null;
+	if (!domain) {
+		return { ok: false, error: "Could not extract domain" };
+	}
 
 	const url = new URL(`${gatewayUrl}${ENRICHMENT_BASE_PATH}/company`);
 	url.searchParams.set("domain", domain);
-	if (enrichmentMaxModeEnabled) {
-		url.searchParams.set("mode", "max");
+	if (requiredFields.length > 0) {
+		url.searchParams.set("requiredFields", requiredFields.join(","));
 	}
 	const response = await fetch(url, {
 		method: "GET",
 		headers: { authorization: `Bearer ${apiKey}` },
 	});
 
-	if (!response.ok) return null;
-	return response.json();
+	if (!response.ok) {
+		return { ok: false, error: await formatGatewayError(response) };
+	}
+	return { ok: true, payload: await response.json() };
+}
+
+async function formatGatewayError(response: Response): Promise<string> {
+	let body: unknown = null;
+	try {
+		body = await response.json();
+	} catch {
+		// Body not JSON; fall back to status-only messages below.
+	}
+	const error = (body as { error?: { code?: string; message?: string } } | null)?.error;
+	const code = error?.code;
+	const message = error?.message;
+
+	if (response.status === 404 || code === "not_found") {
+		return "No data returned";
+	}
+	if (response.status === 503 || code === "provider_unavailable") {
+		return "Gateway providers unavailable";
+	}
+	if (code === "invalid_required_field") {
+		return message ?? "Invalid required field";
+	}
+	if (message) return message;
+	return `Gateway request failed (HTTP ${response.status})`;
 }
 
 function patchEntryField(

--- a/apps/web/app/components/settings/cloud-settings-panel.test.tsx
+++ b/apps/web/app/components/settings/cloud-settings-panel.test.tsx
@@ -38,7 +38,6 @@ const baseState = {
   selectedDenchModel: null,
   selectedVoiceId: null,
   elevenLabsEnabled: true,
-  enrichmentMaxModeEnabled: false,
   models: [
     {
       id: "claude-opus-4.6",
@@ -214,14 +213,12 @@ describe("CloudSettingsPanel", () => {
           action: string;
           stableId: string;
           voiceId: string;
-        enrichmentMaxModeEnabled: boolean;
           integrations: Record<string, boolean>;
         };
         expect(body).toEqual({
           action: "save_active_settings",
           stableId: "anthropic.claude-opus-4-6-v1",
           voiceId: "voice_123",
-        enrichmentMaxModeEnabled: true,
           integrations: {
             exa: true,
             apollo: false,
@@ -234,7 +231,6 @@ describe("CloudSettingsPanel", () => {
             isDenchPrimary: true,
             selectedDenchModel: "anthropic.claude-opus-4-6-v1",
             selectedVoiceId: "voice_123",
-            enrichmentMaxModeEnabled: true,
           },
           integrationsState: {
             ...integrationsState,
@@ -277,7 +273,6 @@ describe("CloudSettingsPanel", () => {
     });
     await user.click(voiceTrigger);
     await user.click(await screen.findByRole("menuitemradio", { name: /Rachel/ }));
-    await user.click(screen.getByRole("switch", { name: "Enable enrichment max mode" }));
     await user.click(screen.getByRole("button", { name: "Exa:off:open" }));
 
     expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
@@ -291,7 +286,7 @@ describe("CloudSettingsPanel", () => {
     expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
   });
 
-  it("shows the full provider logo lineup on the max mode card", async () => {
+  it("shows the full provider logo lineup on the enrichment waterfall card", async () => {
     global.fetch = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();
       if (url === "/api/settings/cloud") {
@@ -311,7 +306,10 @@ describe("CloudSettingsPanel", () => {
 
     render(<CloudSettingsPanel />);
 
-    await screen.findByRole("switch", { name: "Enable enrichment max mode" });
+    await waitFor(() => {
+      expect(screen.getByText("Dench Enrichment")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Waterfall providers")).toBeInTheDocument();
 
     expect(screen.getByTitle("Dench")).toBeInTheDocument();
     expect(screen.getByTitle("Aviato")).toBeInTheDocument();

--- a/apps/web/app/components/settings/cloud-settings-panel.tsx
+++ b/apps/web/app/components/settings/cloud-settings-panel.tsx
@@ -14,7 +14,6 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
-import { Switch } from "../ui/switch";
 
 type CloudStatus = "no_key" | "invalid_key" | "valid";
 
@@ -44,7 +43,6 @@ type CloudState = {
   selectedDenchModel: string | null;
   selectedVoiceId: string | null;
   elevenLabsEnabled: boolean;
-  enrichmentMaxModeEnabled: boolean;
   models: CatalogModel[];
   recommendedModelId: string;
   validationError?: string;
@@ -64,7 +62,7 @@ type ActionNotice = {
 
 type IntegrationDraftState = Record<DenchIntegrationId, boolean>;
 
-const MAX_MODE_PROVIDER_LOGOS = [
+const ENRICHMENT_WATERFALL_PROVIDERS = [
   { id: "dench", name: "Dench", src: "/dench-workspace-icon.png", rounded: true },
   { id: "aviato", name: "Aviato", src: "/integrations/aviato.ico", rounded: true },
   { id: "apollo", name: "Apollo", src: "/integrations/apollo.ico", rounded: true },
@@ -154,39 +152,22 @@ function NoticeBanner({ notice }: { notice: ActionNotice }) {
   );
 }
 
-function EnrichmentMaxModeCard({
-  enabled,
-  disabled,
-  onToggle,
-}: {
-  enabled: boolean;
-  disabled: boolean;
-  onToggle: (enabled: boolean) => void;
-}) {
+function EnrichmentWaterfallCard() {
   return (
     <div
       className="rounded-xl border px-4 py-4"
       style={{ borderColor: "var(--color-border)", background: "var(--color-surface)" }}
     >
-      <div className="flex items-start justify-between gap-4">
-        <div className="space-y-1">
-          <div className="text-sm font-medium" style={{ color: "var(--color-text)" }}>
-            Enrichment Max Mode
-          </div>
-          <div className="max-w-[42rem] text-xs leading-5" style={{ color: "var(--color-text-muted)" }}>
-            Run the full Dench enrichment waterfall for people and company requests, even after an early hit.
-            This gives you richer merged results, but it can take longer and use more credits.
-          </div>
+      <div className="space-y-1">
+        <div className="text-sm font-medium" style={{ color: "var(--color-text)" }}>
+          Dench Enrichment
         </div>
-        <Switch
-          aria-label="Enable enrichment max mode"
-          checked={enabled}
-          disabled={disabled}
-          onCheckedChange={onToggle}
-        />
+        <div className="max-w-[42rem] text-xs leading-5" style={{ color: "var(--color-text-muted)" }}>
+          Waterfall providers
+        </div>
       </div>
       <div className="mt-4 flex flex-wrap items-center gap-3">
-        {MAX_MODE_PROVIDER_LOGOS.map((provider) => (
+        {ENRICHMENT_WATERFALL_PROVIDERS.map((provider) => (
           <div
             key={provider.id}
             className="flex h-8 w-8 items-center justify-center"
@@ -538,7 +519,6 @@ export function CloudSettingsPanel() {
   const [notice, setNotice] = useState<ActionNotice | null>(null);
   const [draftModel, setDraftModel] = useState<string | null>(null);
   const [draftVoiceId, setDraftVoiceId] = useState<string | null>(null);
-  const [draftEnrichmentMaxModeEnabled, setDraftEnrichmentMaxModeEnabled] = useState(false);
   const [draftIntegrations, setDraftIntegrations] = useState<IntegrationDraftState>({
     exa: false,
     apollo: false,
@@ -642,10 +622,8 @@ export function CloudSettingsPanel() {
     }
     setDraftModel(data.isDenchPrimary ? data.selectedDenchModel : null);
     setDraftVoiceId(data.selectedVoiceId);
-    setDraftEnrichmentMaxModeEnabled(data.enrichmentMaxModeEnabled);
     setDraftIntegrations(buildIntegrationDraft(integrationsDataRef.current));
   }, [
-    data?.enrichmentMaxModeEnabled,
     data?.status,
     data?.isDenchPrimary,
     data?.selectedDenchModel,
@@ -705,11 +683,6 @@ export function CloudSettingsPanel() {
     setDraftVoiceId(voiceId);
   }, []);
 
-  const handleDraftEnrichmentMaxModeChange = useCallback((enabled: boolean) => {
-    setNotice(null);
-    setDraftEnrichmentMaxModeEnabled(enabled);
-  }, []);
-
   const handleDraftIntegrationToggle = useCallback((integration: DenchIntegrationState, enabled: boolean) => {
     setNotice(null);
     setDraftIntegrations((current) => ({
@@ -725,15 +698,11 @@ export function CloudSettingsPanel() {
     setNotice(null);
     setDraftModel(data.isDenchPrimary ? data.selectedDenchModel : null);
     setDraftVoiceId(data.selectedVoiceId);
-    setDraftEnrichmentMaxModeEnabled(data.enrichmentMaxModeEnabled);
     setDraftIntegrations(buildIntegrationDraft(integrationsData));
   }, [data, integrationsData]);
 
   const baselineModel = data?.status === "valid" && data.isDenchPrimary ? data.selectedDenchModel : null;
   const baselineVoiceId = data?.status === "valid" ? data.selectedVoiceId : null;
-  const baselineEnrichmentMaxModeEnabled = data?.status === "valid"
-    ? data.enrichmentMaxModeEnabled
-    : false;
   const baselineIntegrations = useMemo(
     () => buildIntegrationDraft(integrationsData),
     [integrationsData],
@@ -741,7 +710,6 @@ export function CloudSettingsPanel() {
   const hasUnsavedChanges = Boolean(data?.status === "valid" && (
     draftModel !== baselineModel
     || draftVoiceId !== baselineVoiceId
-    || draftEnrichmentMaxModeEnabled !== baselineEnrichmentMaxModeEnabled
     || draftIntegrations.exa !== baselineIntegrations.exa
     || draftIntegrations.apollo !== baselineIntegrations.apollo
     || draftIntegrations.elevenlabs !== baselineIntegrations.elevenlabs
@@ -765,7 +733,6 @@ export function CloudSettingsPanel() {
           action: "save_active_settings",
           stableId: draftModel,
           voiceId: draftVoiceId,
-          enrichmentMaxModeEnabled: draftEnrichmentMaxModeEnabled,
           integrations: draftIntegrations,
         }),
       });
@@ -811,7 +778,7 @@ export function CloudSettingsPanel() {
     } finally {
       setSavingActive(false);
     }
-  }, [draftEnrichmentMaxModeEnabled, draftIntegrations, draftModel, draftVoiceId, fetchIntegrations]);
+  }, [draftIntegrations, draftModel, draftVoiceId, fetchIntegrations]);
 
   const handleRepairIntegrations = useCallback(async () => {
     setRepairingIntegrations(true);
@@ -933,11 +900,7 @@ export function CloudSettingsPanel() {
           onRepair={() => void handleRepairIntegrations()}
         />
       </div>
-      <EnrichmentMaxModeCard
-        enabled={draftEnrichmentMaxModeEnabled}
-        disabled={savingActive}
-        onToggle={handleDraftEnrichmentMaxModeChange}
-      />
+      <EnrichmentWaterfallCard />
       <McpServersSection />
       <div className="flex items-center justify-end gap-2 pt-2">
         <Button

--- a/apps/web/lib/dench-cloud-settings.test.ts
+++ b/apps/web/lib/dench-cloud-settings.test.ts
@@ -395,39 +395,17 @@ describe("dench cloud settings", () => {
     expect(written.messages.tts.providers.elevenlabs.voiceId).toBe("voice_456");
   });
 
-  it("returns the stored enrichment max mode setting in cloud state", async () => {
+  it("strips legacy enrichment max-mode metadata when saving active settings", async () => {
     vi.mocked(readIntegrationsMetadata).mockReturnValue({
       schemaVersion: 1,
-      apollo: { enrichmentMaxMode: true },
+      apollo: { enrichmentMaxMode: true } as never,
     });
     mocks.state.configText = JSON.stringify({
       models: {
         providers: {
           "dench-cloud": {
             apiKey: "dc-key",
-          },
-        },
-      },
-      agents: {
-        defaults: {
-          model: {
-            primary: "dench-cloud/claude-sonnet-4.6",
-          },
-        },
-      },
-    });
-
-    const state = await getCloudSettingsState();
-
-    expect(state.enrichmentMaxModeEnabled).toBe(true);
-  });
-
-  it("persists enrichment max mode through save_active_settings without restarting by itself", async () => {
-    mocks.state.configText = JSON.stringify({
-      models: {
-        providers: {
-          "dench-cloud": {
-            apiKey: "dc-key",
+            enrichmentMaxMode: true,
           },
         },
       },
@@ -436,23 +414,15 @@ describe("dench cloud settings", () => {
     const result = await saveActiveCloudSettings({
       stableId: null,
       voiceId: null,
-      enrichmentMaxModeEnabled: true,
       integrations: {},
     });
 
     expect(result.changed).toBe(true);
-    expect(result.refresh).toEqual({
-      attempted: false,
-      restarted: false,
-      error: null,
-      profile: "default",
-    });
-
-    const written = JSON.parse(mocks.state.configText);
     expect(writeIntegrationsMetadata).toHaveBeenCalledWith({
       schemaVersion: 1,
-      apollo: { enrichmentMaxMode: true },
+      apollo: {},
     });
+    const written = JSON.parse(mocks.state.configText);
     expect(written.models.providers["dench-cloud"].enrichmentMaxMode).toBeUndefined();
   });
 });

--- a/apps/web/lib/dench-cloud-settings.ts
+++ b/apps/web/lib/dench-cloud-settings.ts
@@ -79,20 +79,6 @@ function resolveDenchApiKey(config: UnknownRecord): string | null {
   return null;
 }
 
-function readDenchEnrichmentMaxModeEnabled(config: UnknownRecord): boolean {
-  try {
-    const metadataValue = readIntegrationsMetadata().apollo?.enrichmentMaxMode;
-    if (typeof metadataValue === "boolean") {
-      return metadataValue;
-    }
-  } catch {
-    // Fall back to the legacy config location if metadata is unavailable.
-  }
-  const models = asRecord(config.models);
-  const provider = asRecord(asRecord(models?.providers)?.["dench-cloud"]);
-  return provider?.enrichmentMaxMode === true;
-}
-
 function resolveGatewayUrl(config: UnknownRecord): string {
   const settings = readConfiguredDenchCloudSettings(config);
   return settings.gatewayUrl ?? normalizeDenchGatewayUrl(
@@ -260,7 +246,6 @@ export type CloudSettingsState = {
   selectedDenchModel: string | null;
   selectedVoiceId: string | null;
   elevenLabsEnabled: boolean;
-  enrichmentMaxModeEnabled: boolean;
   models: DenchCloudCatalogModel[];
   recommendedModelId: string;
   validationError?: string;
@@ -278,7 +263,6 @@ export type SaveActiveCloudSettingsInput = {
   stableId: string | null;
   voiceId: string | null;
   integrations: DenchIntegrationToggleDraft;
-  enrichmentMaxModeEnabled: boolean;
 };
 
 type SaveApiKeyOptions = {
@@ -340,7 +324,6 @@ export async function getCloudSettingsState(): Promise<CloudSettingsState> {
   const isDenchPrimary = Boolean(primaryModel?.startsWith("dench-cloud/"));
   const settings = readConfiguredDenchCloudSettings(config);
   const voiceState = await getCloudVoiceState();
-  const enrichmentMaxModeEnabled = readDenchEnrichmentMaxModeEnabled(config);
 
   if (voiceState.status === "no_key") {
     return {
@@ -352,7 +335,6 @@ export async function getCloudSettingsState(): Promise<CloudSettingsState> {
       selectedDenchModel: null,
       selectedVoiceId: voiceState.selectedVoiceId,
       elevenLabsEnabled: voiceState.elevenLabsEnabled,
-      enrichmentMaxModeEnabled,
       models: [],
       recommendedModelId: RECOMMENDED_DENCH_CLOUD_MODEL_ID,
     };
@@ -368,7 +350,6 @@ export async function getCloudSettingsState(): Promise<CloudSettingsState> {
       selectedDenchModel: null,
       selectedVoiceId: voiceState.selectedVoiceId,
       elevenLabsEnabled: voiceState.elevenLabsEnabled,
-      enrichmentMaxModeEnabled,
       models: [],
       recommendedModelId: RECOMMENDED_DENCH_CLOUD_MODEL_ID,
       validationError: voiceState.validationError,
@@ -386,7 +367,6 @@ export async function getCloudSettingsState(): Promise<CloudSettingsState> {
     selectedDenchModel: settings.selectedModel ?? null,
     selectedVoiceId: voiceState.selectedVoiceId,
     elevenLabsEnabled: voiceState.elevenLabsEnabled,
-    enrichmentMaxModeEnabled,
     models: catalog.models,
     recommendedModelId: RECOMMENDED_DENCH_CLOUD_MODEL_ID,
   };
@@ -557,9 +537,7 @@ export async function saveActiveCloudSettings(
   const currentPrimaryModel = resolvePrimaryModel(config);
   const desiredPrimaryModel = input.stableId ? `dench-cloud/${input.stableId}` : currentPrimaryModel;
   const currentVoiceId = readSelectedVoiceId(config);
-  const currentEnrichmentMaxModeEnabled = readDenchEnrichmentMaxModeEnabled(config);
   const nextVoiceId = input.voiceId?.trim() || null;
-  const nextEnrichmentMaxModeEnabled = input.enrichmentMaxModeEnabled === true;
   const metadata = readIntegrationsMetadata();
   let nextMetadata = metadata;
   let changed = false;
@@ -627,21 +605,18 @@ export async function saveActiveCloudSettings(
     changed = true;
   }
 
+  // Strip legacy enrichment max-mode fields if they are still present.
   const legacyDenchProvider = asRecord(asRecord(asRecord(config.models)?.providers)?.["dench-cloud"]);
-  if (
-    currentEnrichmentMaxModeEnabled !== nextEnrichmentMaxModeEnabled ||
-    legacyDenchProvider?.enrichmentMaxMode !== undefined
-  ) {
+  if (legacyDenchProvider?.enrichmentMaxMode !== undefined) {
+    delete legacyDenchProvider.enrichmentMaxMode;
+    changed = true;
+  }
+  if (nextMetadata.apollo?.enrichmentMaxMode !== undefined) {
     nextMetadata = {
       ...nextMetadata,
       schemaVersion: 1,
-      apollo: nextEnrichmentMaxModeEnabled
-        ? { ...(nextMetadata.apollo ?? {}), enrichmentMaxMode: true }
-        : {},
+      apollo: {},
     };
-    if (legacyDenchProvider) {
-      delete legacyDenchProvider.enrichmentMaxMode;
-    }
     changed = true;
   }
 

--- a/apps/web/lib/enrichment-columns.test.ts
+++ b/apps/web/lib/enrichment-columns.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { getAvailableEnrichmentCategories, getEligibleInputFields } from "./enrichment-columns";
+import {
+	COMPANY_ENRICHMENT_COLUMNS,
+	PEOPLE_ENRICHMENT_COLUMNS,
+	extractEnrichmentValue,
+	getAvailableEnrichmentCategories,
+	getEligibleInputFields,
+	getRequiredFieldsForApolloPath,
+} from "./enrichment-columns";
 
 describe("getEligibleInputFields", () => {
 	it("limits people enrichment inputs to email and LinkedIn fields", () => {
@@ -55,5 +62,46 @@ describe("getEligibleInputFields", () => {
 		expect(getAvailableEnrichmentCategories("custom_table", [
 			{ id: "notes", name: "Notes", type: "text" },
 		])).toEqual(["people", "company"]);
+	});
+});
+
+describe("requiredFields mapping", () => {
+	it("attaches a non-empty canonical requiredFields list to every column", () => {
+		for (const column of [...PEOPLE_ENRICHMENT_COLUMNS, ...COMPANY_ENRICHMENT_COLUMNS]) {
+			expect(column.requiredFields.length).toBeGreaterThan(0);
+		}
+	});
+
+	it("resolves canonical requiredFields from an apolloPath", () => {
+		expect(getRequiredFieldsForApolloPath("people", "person.contact.phone_numbers.0.sanitized_number"))
+			.toEqual(["phone"]);
+		expect(getRequiredFieldsForApolloPath("people", "person.headline")).toEqual(["headline"]);
+		expect(getRequiredFieldsForApolloPath("company", "organization.industry")).toEqual(["industryList"]);
+		expect(getRequiredFieldsForApolloPath("company", "organization.website_url")).toEqual(["website"]);
+	});
+
+	it("returns an empty list for unknown apolloPaths so the gateway uses default backfill", () => {
+		expect(getRequiredFieldsForApolloPath("people", "person.unknown")).toEqual([]);
+	});
+});
+
+describe("extractEnrichmentValue", () => {
+	const phoneColumn = PEOPLE_ENRICHMENT_COLUMNS.find((column) => column.label === "Phone");
+
+	it("prefers the legacy Apollo path when both shapes are present", () => {
+		const payload = {
+			person: { contact: { phone_numbers: [{ sanitized_number: "+1234" }] } },
+			phone: "+9999",
+		};
+		expect(extractEnrichmentValue(payload, phoneColumn!)).toBe("+1234");
+	});
+
+	it("falls back to the canonical top-level field when the legacy path is missing", () => {
+		const payload = { phone: "+9999" };
+		expect(extractEnrichmentValue(payload, phoneColumn!)).toBe("+9999");
+	});
+
+	it("returns null when no path resolves", () => {
+		expect(extractEnrichmentValue({}, phoneColumn!)).toBeNull();
 	});
 });

--- a/apps/web/lib/enrichment-columns.ts
+++ b/apps/web/lib/enrichment-columns.ts
@@ -13,6 +13,16 @@ export type EnrichmentColumnDef = {
 	fieldType: string;
 	/** Dot-path into the Apollo response payload to extract the value. */
 	apolloPath: string;
+	/**
+	 * Canonical Dench gateway field names sent in the `requiredFields` contract.
+	 * Must match entries in the gateway's people/company allowlist.
+	 */
+	requiredFields: string[];
+	/**
+	 * Additional dot-paths to try if `apolloPath` returns null. Lets the gateway
+	 * evolve toward canonical merged responses without breaking extraction.
+	 */
+	extractionFallbacks?: string[];
 };
 
 export type EnrichmentInputDef = {
@@ -41,23 +51,121 @@ export function detectEnrichmentCategory(
 // ---------------------------------------------------------------------------
 
 export const PEOPLE_ENRICHMENT_COLUMNS: EnrichmentColumnDef[] = [
-	{ label: "Full Name", key: "person.name", fieldType: "text", apolloPath: "person.name" },
-	{ label: "Email", key: "person.email", fieldType: "email", apolloPath: "person.email" },
-	{ label: "Headline", key: "person.headline", fieldType: "text", apolloPath: "person.headline" },
-	{ label: "LinkedIn URL", key: "person.linkedin_url", fieldType: "url", apolloPath: "person.linkedin_url" },
-	{ label: "Twitter URL", key: "person.twitter_url", fieldType: "url", apolloPath: "person.twitter_url" },
-	{ label: "Phone", key: "person.phone", fieldType: "phone", apolloPath: "person.contact.phone_numbers.0.sanitized_number" },
-	{ label: "Title", key: "person.title", fieldType: "text", apolloPath: "person.title" },
-	{ label: "Location", key: "person.location", fieldType: "text", apolloPath: "__computed.location" },
+	{
+		label: "Full Name",
+		key: "person.name",
+		fieldType: "text",
+		apolloPath: "person.name",
+		requiredFields: ["fullName"],
+		extractionFallbacks: ["fullName", "person.fullName"],
+	},
+	{
+		label: "Email",
+		key: "person.email",
+		fieldType: "email",
+		apolloPath: "person.email",
+		requiredFields: ["email"],
+		extractionFallbacks: ["email"],
+	},
+	{
+		label: "Headline",
+		key: "person.headline",
+		fieldType: "text",
+		apolloPath: "person.headline",
+		requiredFields: ["headline"],
+		extractionFallbacks: ["headline"],
+	},
+	{
+		label: "LinkedIn URL",
+		key: "person.linkedin_url",
+		fieldType: "url",
+		apolloPath: "person.linkedin_url",
+		requiredFields: ["linkedinID"],
+		extractionFallbacks: ["linkedin_url", "URLs.linkedin", "person.URLs.linkedin"],
+	},
+	{
+		label: "Twitter URL",
+		key: "person.twitter_url",
+		fieldType: "url",
+		apolloPath: "person.twitter_url",
+		requiredFields: ["URLs"],
+		extractionFallbacks: ["twitter_url", "URLs.twitter", "person.URLs.twitter"],
+	},
+	{
+		label: "Phone",
+		key: "person.phone",
+		fieldType: "phone",
+		apolloPath: "person.contact.phone_numbers.0.sanitized_number",
+		requiredFields: ["phone"],
+		extractionFallbacks: ["phone", "person.phone"],
+	},
+	{
+		label: "Title",
+		key: "person.title",
+		fieldType: "text",
+		apolloPath: "person.title",
+		requiredFields: ["headline"],
+		extractionFallbacks: ["headline", "person.headline"],
+	},
+	{
+		label: "Location",
+		key: "person.location",
+		fieldType: "text",
+		apolloPath: "__computed.location",
+		requiredFields: ["location"],
+		extractionFallbacks: ["location", "person.location"],
+	},
 ];
 
 export const COMPANY_ENRICHMENT_COLUMNS: EnrichmentColumnDef[] = [
-	{ label: "Company Name", key: "organization.name", fieldType: "text", apolloPath: "organization.name" },
-	{ label: "Website URL", key: "organization.website_url", fieldType: "url", apolloPath: "organization.website_url" },
-	{ label: "Industry", key: "organization.industry", fieldType: "text", apolloPath: "organization.industry" },
-	{ label: "LinkedIn URL", key: "organization.linkedin_url", fieldType: "url", apolloPath: "organization.linkedin_url" },
-	{ label: "Total Funding", key: "organization.total_funding_printed", fieldType: "text", apolloPath: "organization.total_funding_printed" },
-	{ label: "Founded Year", key: "organization.founded_year", fieldType: "number", apolloPath: "organization.founded_year" },
+	{
+		label: "Company Name",
+		key: "organization.name",
+		fieldType: "text",
+		apolloPath: "organization.name",
+		requiredFields: ["name"],
+		extractionFallbacks: ["name"],
+	},
+	{
+		label: "Website URL",
+		key: "organization.website_url",
+		fieldType: "url",
+		apolloPath: "organization.website_url",
+		requiredFields: ["website"],
+		extractionFallbacks: ["website", "organization.website"],
+	},
+	{
+		label: "Industry",
+		key: "organization.industry",
+		fieldType: "text",
+		apolloPath: "organization.industry",
+		requiredFields: ["industryList"],
+		extractionFallbacks: ["industryList.0", "organization.industryList.0"],
+	},
+	{
+		label: "LinkedIn URL",
+		key: "organization.linkedin_url",
+		fieldType: "url",
+		apolloPath: "organization.linkedin_url",
+		requiredFields: ["linkedinID"],
+		extractionFallbacks: ["URLs.linkedin", "organization.URLs.linkedin"],
+	},
+	{
+		label: "Total Funding",
+		key: "organization.total_funding_printed",
+		fieldType: "text",
+		apolloPath: "organization.total_funding_printed",
+		requiredFields: ["totalFunding"],
+		extractionFallbacks: ["totalFunding", "organization.totalFunding"],
+	},
+	{
+		label: "Founded Year",
+		key: "organization.founded_year",
+		fieldType: "number",
+		apolloPath: "organization.founded_year",
+		requiredFields: ["founded"],
+		extractionFallbacks: ["founded", "organization.founded"],
+	},
 ];
 
 export function getEnrichmentColumns(
@@ -189,6 +297,38 @@ export function extractApolloValue(
 	if (current == null) return null;
 	if (typeof current === "object") return JSON.stringify(current);
 	return String(current);
+}
+
+/**
+ * Try the column's primary `apolloPath` first, then any `extractionFallbacks`
+ * in order. Returns the first non-null match or null.
+ */
+export function extractEnrichmentValue(
+	payload: Record<string, unknown>,
+	column: Pick<EnrichmentColumnDef, "apolloPath" | "extractionFallbacks">,
+): string | null {
+	const primary = extractApolloValue(payload, column.apolloPath);
+	if (primary != null) return primary;
+	for (const fallback of column.extractionFallbacks ?? []) {
+		const value = extractApolloValue(payload, fallback);
+		if (value != null) return value;
+	}
+	return null;
+}
+
+/**
+ * Resolve the canonical `requiredFields` list for the column whose primary
+ * `apolloPath` matches. Falls back to an empty array (gateway will then use
+ * its default backfill list) when no column matches.
+ */
+export function getRequiredFieldsForApolloPath(
+	category: EnrichmentCategory,
+	apolloPath: string,
+): string[] {
+	const column = getEnrichmentColumns(category).find(
+		(candidate) => candidate.apolloPath === apolloPath,
+	);
+	return column?.requiredFields ?? [];
 }
 
 function computeLocation(payload: Record<string, unknown>): string | null {

--- a/apps/web/lib/integrations.ts
+++ b/apps/web/lib/integrations.ts
@@ -27,9 +27,7 @@ export type DenchIntegrationMetadata = {
     ownsSearch?: boolean;
     fallbackProvider?: string | null;
   };
-  apollo?: {
-    enrichmentMaxMode?: boolean;
-  };
+  apollo?: Record<string, never>;
   elevenlabs?: Record<string, never>;
   future?: {
     composio?: {
@@ -1471,17 +1469,10 @@ export function setElevenLabsIntegrationEnabled(enabled: boolean): IntegrationTo
 export function resolveDenchGatewayCredentials(): {
   apiKey: string | null;
   gatewayUrl: string | null;
-  enrichmentMaxModeEnabled: boolean;
 } {
   const config = readOpenClawConfigForIntegrations();
-  const models = asRecord(config.models);
-  const provider = asRecord(asRecord(models?.providers)?.["dench-cloud"]);
-  const metadata = readIntegrationsMetadata();
   return {
     apiKey: resolveDenchApiKey(config),
     gatewayUrl: resolveGatewayBaseUrl(config),
-    enrichmentMaxModeEnabled:
-      metadata.apollo?.enrichmentMaxMode === true ||
-      readBoolean(provider?.enrichmentMaxMode) === true,
   };
 }

--- a/extensions/apollo-enrichment/index.test.ts
+++ b/extensions/apollo-enrichment/index.test.ts
@@ -18,7 +18,7 @@ function writeAuthProfiles(stateDir: string, key: string): void {
   );
 }
 
-function writeOpenClawConfig(stateDir: string, enrichmentMaxMode: boolean): void {
+function writeOpenClawConfig(stateDir: string): void {
   writeFileSync(
     path.join(stateDir, "openclaw.json"),
     JSON.stringify({
@@ -33,9 +33,7 @@ function writeOpenClawConfig(stateDir: string, enrichmentMaxMode: boolean): void
     path.join(stateDir, ".dench-integrations.json"),
     JSON.stringify({
       schemaVersion: 1,
-      apollo: {
-        enrichmentMaxMode,
-      },
+      apollo: {},
     }),
   );
 }
@@ -68,7 +66,7 @@ function createApi() {
   };
 }
 
-describe("apollo-enrichment max mode", () => {
+describe("apollo-enrichment requiredFields", () => {
   const originalFetch = globalThis.fetch;
   const originalStateDir = process.env.OPENCLAW_STATE_DIR;
   let stateDir: string | undefined;
@@ -87,19 +85,19 @@ describe("apollo-enrichment max mode", () => {
     }
   });
 
-  it("forwards mode=max to people enrichment when enabled", async () => {
+  it("omits requiredFields and mode by default for people enrichment", async () => {
     stateDir = mkdtempSync(path.join(os.tmpdir(), "apollo-enrichment-state-"));
     process.env.OPENCLAW_STATE_DIR = stateDir;
     writeAuthProfiles(stateDir, "dc-key");
-    writeOpenClawConfig(stateDir, true);
+    writeOpenClawConfig(stateDir);
 
     globalThis.fetch = vi.fn(async (input, init) => {
       expect(String(input)).toBe("https://gateway.example.com/v1/enrichment/people");
       expect(init?.method).toBe("POST");
-      expect(JSON.parse(String(init?.body))).toMatchObject({
-        email: "jane@acme.com",
-        mode: "max",
-      });
+      const body = JSON.parse(String(init?.body));
+      expect(body).toMatchObject({ email: "jane@acme.com" });
+      expect(body.mode).toBeUndefined();
+      expect(body.requiredFields).toBeUndefined();
       return new Response(JSON.stringify({ person: { id: "p1" } }), {
         status: 200,
         headers: { "content-type": "application/json" },
@@ -118,20 +116,81 @@ describe("apollo-enrichment max mode", () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
   });
 
+  it("forwards camelCase requiredFields to people enrichment when callers provide them", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "apollo-enrichment-state-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+    writeOpenClawConfig(stateDir);
+
+    globalThis.fetch = vi.fn(async (_input, init) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body).toMatchObject({
+        email: "jane@acme.com",
+        requiredFields: ["phone", "headline"],
+      });
+      expect(body.mode).toBeUndefined();
+      return new Response(JSON.stringify({ person: { id: "p1" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const { api, tools } = createApi();
+    register(api);
+
+    await tools[0].execute("call_1", {
+      action: "people",
+      email: "jane@acme.com",
+      requiredFields: ["phone", "headline"],
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts the snake_case required_fields legacy alias", async () => {
+    stateDir = mkdtempSync(path.join(os.tmpdir(), "apollo-enrichment-state-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    writeAuthProfiles(stateDir, "dc-key");
+    writeOpenClawConfig(stateDir);
+
+    globalThis.fetch = vi.fn(async (_input, init) => {
+      expect(JSON.parse(String(init?.body))).toMatchObject({
+        email: "jane@acme.com",
+        requiredFields: ["phone"],
+      });
+      return new Response(JSON.stringify({ person: { id: "p1" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const { api, tools } = createApi();
+    register(api);
+
+    await tools[0].execute("call_1", {
+      action: "people",
+      email: "jane@acme.com",
+      required_fields: ["phone"],
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
   it("sends person name inputs with gateway-compatible snake_case keys", async () => {
     stateDir = mkdtempSync(path.join(os.tmpdir(), "apollo-enrichment-state-"));
     process.env.OPENCLAW_STATE_DIR = stateDir;
     writeAuthProfiles(stateDir, "dc-key");
-    writeOpenClawConfig(stateDir, true);
+    writeOpenClawConfig(stateDir);
 
     globalThis.fetch = vi.fn(async (_input, init) => {
-      expect(JSON.parse(String(init?.body))).toMatchObject({
+      const body = JSON.parse(String(init?.body));
+      expect(body).toMatchObject({
         first_name: "Mark",
         last_name: "Rachapoom",
         organization_name: "Dench",
         linkedin_url: "https://www.linkedin.com/in/markrachapoom",
-        mode: "max",
       });
+      expect(body.mode).toBeUndefined();
       return new Response(JSON.stringify({ person: { email: "mark@dench.com" } }), {
         status: 200,
         headers: { "content-type": "application/json" },
@@ -156,7 +215,7 @@ describe("apollo-enrichment max mode", () => {
     stateDir = mkdtempSync(path.join(os.tmpdir(), "apollo-enrichment-state-"));
     process.env.OPENCLAW_STATE_DIR = stateDir;
     writeAuthProfiles(stateDir, "dc-key");
-    writeOpenClawConfig(stateDir, false);
+    writeOpenClawConfig(stateDir);
 
     globalThis.fetch = vi.fn(async (_input, init) => {
       expect(JSON.parse(String(init?.body))).toMatchObject({
@@ -185,17 +244,18 @@ describe("apollo-enrichment max mode", () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
   });
 
-  it("forwards mode=max to company enrichment when enabled", async () => {
+  it("forwards CSV requiredFields query param for company enrichment", async () => {
     stateDir = mkdtempSync(path.join(os.tmpdir(), "apollo-enrichment-state-"));
     process.env.OPENCLAW_STATE_DIR = stateDir;
     writeAuthProfiles(stateDir, "dc-key");
-    writeOpenClawConfig(stateDir, true);
+    writeOpenClawConfig(stateDir);
 
     globalThis.fetch = vi.fn(async (input, init) => {
       const url = new URL(String(input));
       expect(url.origin + url.pathname).toBe("https://gateway.example.com/v1/enrichment/company");
       expect(url.searchParams.get("domain")).toBe("acme.com");
-      expect(url.searchParams.get("mode")).toBe("max");
+      expect(url.searchParams.get("requiredFields")).toBe("description,headcount,industryList");
+      expect(url.searchParams.get("mode")).toBeNull();
       expect(init?.method).toBe("GET");
       return new Response(JSON.stringify({ organization: { id: "o1" } }), {
         status: 200,
@@ -210,6 +270,7 @@ describe("apollo-enrichment max mode", () => {
     await tools[0].execute("call_1", {
       action: "company",
       domain: "acme.com",
+      requiredFields: ["description", "headcount", "industryList"],
     });
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);

--- a/extensions/apollo-enrichment/index.ts
+++ b/extensions/apollo-enrichment/index.ts
@@ -1,7 +1,6 @@
 import type { AnyAgentTool, OpenClawPluginApi } from "openclaw/plugin-sdk";
 import {
   readDenchAuthProfileKey,
-  readDenchEnrichmentMaxModeEnabled,
   resolveDenchGatewayUrl,
 } from "../shared/dench-auth.js";
 
@@ -92,6 +91,17 @@ const ApolloEnrichParameters = {
       description: "Legacy alias for organizationDomains.",
     },
     per_page: { type: "number", description: "Legacy alias for perPage." },
+    requiredFields: {
+      type: "array",
+      items: { type: "string" },
+      description:
+        "Optional Dench gateway requiredFields contract. The waterfall stops as soon as every listed field is non-null on the merged record. Omit to use the gateway's default backfill list.",
+    },
+    required_fields: {
+      type: "array",
+      items: { type: "string" },
+      description: "Legacy alias for requiredFields.",
+    },
   },
   required: ["action"],
 };
@@ -186,12 +196,13 @@ async function executeApolloEnrich(
 
   try {
     let response: Response;
-    const enrichmentMaxModeEnabled = readDenchEnrichmentMaxModeEnabled();
+    const requiredFields =
+      readStringList(params.requiredFields) ?? readStringList(params.required_fields);
 
     if (action === "people") {
       const body = buildPeopleBody(params);
-      if (enrichmentMaxModeEnabled) {
-        body.mode = "max";
+      if (requiredFields) {
+        body.requiredFields = requiredFields;
       }
       if (!body.email && !body.linkedin_url && !body.first_name && !body.last_name) {
         return jsonResult({
@@ -213,8 +224,8 @@ async function executeApolloEnrich(
       }
       const url = new URL(`${gatewayUrl}${ENRICHMENT_BASE_PATH}/company`);
       url.searchParams.set("domain", domain);
-      if (enrichmentMaxModeEnabled) {
-        url.searchParams.set("mode", "max");
+      if (requiredFields) {
+        url.searchParams.set("requiredFields", requiredFields.join(","));
       }
       response = await fetch(url, {
         method: "GET",

--- a/extensions/shared/dench-auth.ts
+++ b/extensions/shared/dench-auth.ts
@@ -3,8 +3,6 @@ import path from "node:path";
 
 const DEFAULT_GATEWAY_URL = "https://gateway.merseoriginals.com";
 const AUTH_PROFILES_REL = path.join("agents", "main", "agent", "auth-profiles.json");
-const OPENCLAW_CONFIG_FILENAME = "openclaw.json";
-const INTEGRATIONS_METADATA_FILENAME = ".dench-integrations.json";
 
 /**
  * Read the Dench Cloud API key from the single source of truth
@@ -42,32 +40,4 @@ export function resolveDenchGatewayUrl(pluginConfig?: Record<string, unknown>): 
   const configured = pluginConfig?.gatewayUrl;
   if (typeof configured === "string" && configured.trim()) return configured.trim();
   return process.env.DENCH_GATEWAY_URL?.trim() || DEFAULT_GATEWAY_URL;
-}
-
-/**
- * Read Dench Cloud enrichment preferences from the local profile config.
- */
-export function readDenchEnrichmentMaxModeEnabled(): boolean {
-  const stateDir = process.env.OPENCLAW_STATE_DIR;
-  if (!stateDir) {
-    return false;
-  }
-
-  try {
-    const metadataPath = path.join(stateDir, INTEGRATIONS_METADATA_FILENAME);
-    if (existsSync(metadataPath)) {
-      const metadata = JSON.parse(readFileSync(metadataPath, "utf-8"));
-      const metadataValue = metadata?.apollo?.enrichmentMaxMode;
-      if (typeof metadataValue === "boolean") {
-        return metadataValue;
-      }
-    }
-
-    const configPath = path.join(stateDir, OPENCLAW_CONFIG_FILENAME);
-    if (!existsSync(configPath)) return false;
-    const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-    return raw?.models?.providers?.["dench-cloud"]?.enrichmentMaxMode === true;
-  } catch {
-    return false;
-  }
 }


### PR DESCRIPTION
### Summary

Aligns Dench Claw with the Dench gateway enrichment API change: `mode` is gone; callers use per-request **`requiredFields`** validated against gateway allowlists.

### What changed

- **Cloud settings**: Replaced the enrichment max-mode switch with a static “Dench Enrichment · Waterfall providers” card (same provider logos).
- **Cloud settings API / integrations**: Removed `enrichmentMaxModeEnabled` from state and payloads; saves strip legacy `apollo.enrichmentMaxMode` and provider `enrichmentMaxMode` when present.
- **Enrichment columns**: Each predefined column declares canonical `requiredFields` plus extraction fallbacks for merged vs legacy Apollo-shaped responses.
- **Workspace enrich route**: People POST and company GET forward `requiredFields`; gateway error codes (`invalid_required_field`, `not_found`, `provider_unavailable`) surface in SSE when possible.
- **apollo-enrichment extension**: `apollo_enrich` accepts optional `requiredFields` / `required_fields`; removes `mode=max` and the max-mode reader in `dench-auth`.

### Commits (5)

1. Static waterfall card in Cloud settings + tests  
2. Remove enrichment max-mode from settings API and metadata  
3. Column `requiredFields` mapping + helpers + tests  
4. Workspace enrich route + tests  
5. Apollo extension + shared dench-auth + tests  

### How to verify

```bash
pnpm --dir apps/web exec vitest run app/api/workspace/objects/\[name\]/enrich/route.test.ts lib/enrichment-columns.test.ts lib/dench-cloud-settings.test.ts app/api/settings/cloud/route.test.ts app/api/onboarding/dench-cloud/route.test.ts app/components/settings/cloud-settings-panel.test.tsx
pnpm exec vitest run --config extensions/vitest.config.ts extensions/apollo-enrichment/index.test.ts
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the enrichment request contract from `mode=max` to per-request `requiredFields` across the web app and Apollo extension, which can affect enrichment results and error handling if field mappings drift from gateway allowlists.
> 
> **Overview**
> Migrates Dench enrichment calls off the deprecated `mode=max` flag and onto the gateway’s per-request `requiredFields` contract, including new field-mapping helpers and extraction fallbacks for merged vs legacy Apollo-shaped responses.
> 
> Removes the user-facing “enrichment max mode” setting end-to-end (UI, settings API/state, integrations metadata) and adds cleanup that strips legacy `enrichmentMaxMode` config/metadata on save.
> 
> Updates the workspace enrichment SSE route to derive and forward `requiredFields` from the selected column, improve gateway error surfaced to clients (e.g. `invalid_required_field`, `not_found`, `provider_unavailable`), and updates the `apollo-enrichment` extension to accept optional `requiredFields`/`required_fields` instead of forcing max mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06f4e9826b418a61f438fe2c4e92628b394e5a18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->