### PR TITLE
fix(web): Bugbot follow-ups from enrichment requiredFields migration

### DIFF
--- a/apps/web/app/api/workspace/objects/[name]/enrich/route.ts
+++ b/apps/web/app/api/workspace/objects/[name]/enrich/route.ts
@@ -11,7 +11,6 @@ import {
 	extractDomain,
 	extractEnrichmentValue,
 	getEnrichmentColumns,
-	getRequiredFieldsForApolloPath,
 	isEligibleInputField,
 	type EnrichmentColumnDef,
 } from "@/lib/enrichment-columns";
@@ -87,7 +86,9 @@ export async function POST(
 		key: apolloPath,
 		fieldType: "text",
 		apolloPath,
-		requiredFields: getRequiredFieldsForApolloPath(category, apolloPath),
+		// Unknown column: never send a narrowing contract; gateway uses its default
+		// backfill list (getRequiredFieldsForApolloPath would yield [] here anyway).
+		requiredFields: [],
 	};
 
 	if (

--- a/apps/web/lib/enrichment-columns.test.ts
+++ b/apps/web/lib/enrichment-columns.test.ts
@@ -66,16 +66,20 @@ describe("getEligibleInputFields", () => {
 });
 
 describe("requiredFields mapping", () => {
-	it("attaches a non-empty canonical requiredFields list to every column", () => {
+	it("records requiredFields per catalog column (empty means gateway default backfill)", () => {
 		for (const column of [...PEOPLE_ENRICHMENT_COLUMNS, ...COMPANY_ENRICHMENT_COLUMNS]) {
-			expect(column.requiredFields.length).toBeGreaterThan(0);
+			expect(Array.isArray(column.requiredFields)).toBe(true);
 		}
+		expect(
+			PEOPLE_ENRICHMENT_COLUMNS.find((column) => column.label === "Title")?.requiredFields,
+		).toEqual([]);
 	});
 
 	it("resolves canonical requiredFields from an apolloPath", () => {
 		expect(getRequiredFieldsForApolloPath("people", "person.contact.phone_numbers.0.sanitized_number"))
 			.toEqual(["phone"]);
 		expect(getRequiredFieldsForApolloPath("people", "person.headline")).toEqual(["headline"]);
+		expect(getRequiredFieldsForApolloPath("people", "person.title")).toEqual([]);
 		expect(getRequiredFieldsForApolloPath("company", "organization.industry")).toEqual(["industryList"]);
 		expect(getRequiredFieldsForApolloPath("company", "organization.website_url")).toEqual(["website"]);
 	});
@@ -103,5 +107,15 @@ describe("extractEnrichmentValue", () => {
 
 	it("returns null when no path resolves", () => {
 		expect(extractEnrichmentValue({}, phoneColumn!)).toBeNull();
+	});
+
+	it("does not map Title to LinkedIn headline when only headline data exists", () => {
+		const titleColumn = PEOPLE_ENRICHMENT_COLUMNS.find((column) => column.label === "Title")!;
+		expect(
+			extractEnrichmentValue(
+				{ person: { headline: "CEO at Acme" }, headline: "CEO at Acme" },
+				titleColumn,
+			),
+		).toBeNull();
 	});
 });

--- a/apps/web/lib/enrichment-columns.ts
+++ b/apps/web/lib/enrichment-columns.ts
@@ -15,7 +15,8 @@ export type EnrichmentColumnDef = {
 	apolloPath: string;
 	/**
 	 * Canonical Dench gateway field names sent in the `requiredFields` contract.
-	 * Must match entries in the gateway's people/company allowlist.
+	 * Each entry must be on the gateway allowlist when non-empty.
+	 * Omit (empty array) so the gateway uses its default backfill behavior.
 	 */
 	requiredFields: string[];
 	/**
@@ -104,8 +105,12 @@ export const PEOPLE_ENRICHMENT_COLUMNS: EnrichmentColumnDef[] = [
 		key: "person.title",
 		fieldType: "text",
 		apolloPath: "person.title",
-		requiredFields: ["headline"],
-		extractionFallbacks: ["headline", "person.headline"],
+		// Do not mirror the Headline column's `requiredFields: ["headline"]` —
+		// that duplicated the gateway contract and tended to return the same
+		// string as LinkedIn headline. Omit the contract to use default backfill,
+		// then prefer legacy `person.title` and merged `title` before any headline.
+		requiredFields: [],
+		extractionFallbacks: ["title"],
 	},
 	{
 		label: "Location",
@@ -275,7 +280,7 @@ export function inferInputKind(
 // Extract a value from the Apollo response using a dot-path
 // ---------------------------------------------------------------------------
 
-export function extractApolloValue(
+function extractApolloValue(
 	payload: Record<string, unknown>,
 	apolloPath: string,
 ): string | null {


### PR DESCRIPTION
### Summary

Addresses Cursor Bugbot comments on PR #245 (merged):

- Synthetic enrich column fallback: explicit empty `requiredFields[]` + comment (same behavior as the redundant lookup).
- Title column: avoid duplicating Headline gateway contract and headline fallbacks; narrower extraction.
- Make `extractApolloValue` module-private.

### Tests

```
pnpm --dir apps/web exec vitest run lib/enrichment-columns.test.ts app/api/workspace/objects/\[name\]/enrich/route.test.ts
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small tweaks to enrichment request contracts and value extraction, plus test updates; could only affect what Apollo fields are requested/returned for a few columns.
> 
> **Overview**
> Adjusts enrichment behavior so **unknown/custom `apolloPath`s no longer send a `requiredFields` contract**, instead passing an explicit empty list to let the gateway use its default backfill.
> 
> Refines the people **`Title`** enrichment column by removing the `headline` requiredFields mapping and headline-based fallbacks to avoid returning LinkedIn headline text for title, and adds/updates tests to reflect the new `requiredFields` semantics and extraction expectations.
> 
> Makes `extractApolloValue` module-private (no longer exported).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 507f4c311c27ad42b0ad301222c323d91b6ac036. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->