### PR TITLE
fix(web): keep chat pinned to bottom during streaming

### DIFF
--- a/apps/web/app/components/chat-panel.stream-parser.test.ts
+++ b/apps/web/app/components/chat-panel.stream-parser.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { createStreamParser } from "./chat-panel";
+import {
+  createStreamParser,
+  getChatDistanceFromBottom,
+  isChatScrolledAwayFromBottom,
+  scrollChatToBottom,
+} from "./chat-panel";
 
 describe("createStreamParser", () => {
   it("treats user-message as turn boundary and keeps user/assistant sequence stable", () => {
@@ -120,5 +125,26 @@ describe("createStreamParser", () => {
     parser.processEvent({ type: "text-end" });
 
     expect(parser.getParts()).toEqual([{ type: "text", text: "Stable output" }]);
+  });
+});
+
+describe("chat scroll helpers", () => {
+  it("treats reserved bottom padding as still away from the true bottom", () => {
+    const metrics = { clientHeight: 600, scrollHeight: 1400, scrollTop: 660 };
+
+    expect(getChatDistanceFromBottom(metrics)).toBe(140);
+    expect(isChatScrolledAwayFromBottom(metrics)).toBe(true);
+  });
+
+  it("scrolls the chat container itself to the real bottom", () => {
+    const calls: ScrollToOptions[] = [];
+    const el = {
+      scrollHeight: 1400,
+      scrollTo: (options: ScrollToOptions) => calls.push(options),
+    };
+
+    scrollChatToBottom(el, "auto");
+
+    expect(calls).toEqual([{ top: 1400, behavior: "auto" }]);
   });
 });

--- a/apps/web/app/components/chat-panel.tsx
+++ b/apps/web/app/components/chat-panel.tsx
@@ -63,6 +63,36 @@ type ChatCloudState = {
 	models: ChatModelOption[];
 };
 
+const CHAT_BOTTOM_THRESHOLD_PX = 80;
+
+type ChatScrollMetrics = Pick<HTMLElement, "clientHeight" | "scrollHeight" | "scrollTop">;
+type ChatScrollTarget = {
+	scrollHeight: number;
+	scrollTo: (options: ScrollToOptions) => void;
+};
+
+export function getChatDistanceFromBottom({
+	clientHeight,
+	scrollHeight,
+	scrollTop,
+}: ChatScrollMetrics): number {
+	return scrollHeight - scrollTop - clientHeight;
+}
+
+export function isChatScrolledAwayFromBottom(
+	metrics: ChatScrollMetrics,
+	threshold = CHAT_BOTTOM_THRESHOLD_PX,
+): boolean {
+	return getChatDistanceFromBottom(metrics) > threshold;
+}
+
+export function scrollChatToBottom(
+	el: ChatScrollTarget,
+	behavior: ScrollBehavior = "auto",
+): void {
+	el.scrollTo({ top: el.scrollHeight, behavior });
+}
+
 function asRecord(value: unknown): Record<string, unknown> | null {
 	if (!value || typeof value !== "object" || Array.isArray(value)) {
 		return null;
@@ -898,27 +928,12 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 			headerRightSlot,
 			onRuntimeStateChange,
 			onConversationActivity,
-			onOpenCloudSettings,
 			gatewaySessionKey,
 			gatewaySessionId,
 			gatewayChannel: _gatewayChannel,
 			visible,
 			searchFn,
-			historySessions,
-			historyStreamingSessionIds,
-			historySubagents,
-			historyActiveSubagentKey,
-			historyLoading,
-			historyGatewaySessions,
-			historyActiveGatewaySessionKey,
-			onSelectHistorySession,
 			onNewChatSession,
-			onSelectHistorySubagent,
-			onSelectHistoryGatewaySession,
-			onRenameHistorySession,
-			onDeleteHistorySession,
-			onStopHistorySession,
-			onStopHistorySubagent,
 		},
 		ref,
 	) {
@@ -930,7 +945,6 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 			string | null
 		>(null);
 		const [loadingSession, setLoadingSession] = useState(false);
-		const messagesEndRef = useRef<HTMLDivElement>(null);
 
 		// ── Attachment state ──
 		const [attachedFiles, setAttachedFiles] = useState<
@@ -942,7 +956,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 		useEffect(() => { setMounted(true); }, []);
 
 		useEffect(() => {
-			if (visible === false) return;
+			if (visible === false) {return;}
 			const timer = setTimeout(() => {
 				editorRef.current?.focus();
 			}, 150);
@@ -1196,9 +1210,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 			if (!el) {return;}
 
 			const onScroll = () => {
-				const distanceFromBottom =
-					el.scrollHeight - el.scrollTop - el.clientHeight;
-				const away = distanceFromBottom > 80;
+				const away = isChatScrolledAwayFromBottom(el);
 				userScrolledAwayRef.current = away;
 				setShowScrollButton(away);
 			};
@@ -1207,8 +1219,12 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 			return () => el.removeEventListener("scroll", onScroll);
 		}, []);
 
-		const scrollToBottom = useCallback(() => {
-			messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+		const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
+			const el = scrollContainerRef.current;
+			if (!el) {return;}
+			userScrolledAwayRef.current = false;
+			setShowScrollButton(false);
+			scrollChatToBottom(el, behavior);
 		}, []);
 
 		// Auto-scroll effect — skips when user has scrolled away.
@@ -1217,11 +1233,9 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 			if (scrollRafRef.current) {return;}
 			scrollRafRef.current = requestAnimationFrame(() => {
 				scrollRafRef.current = 0;
-				messagesEndRef.current?.scrollIntoView({
-					behavior: "smooth",
-				});
+				scrollToBottom("auto");
 			});
-		}, [messages]);
+		}, [messages, scrollToBottom]);
 
 		// ── Session persistence helpers ──
 
@@ -1490,7 +1504,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 
 		// ── Gateway session mode: load transcript + reconnect to active stream ──
 		useEffect(() => {
-			if (!gatewaySessionKey || !gatewaySessionId) return;
+			if (!gatewaySessionKey || !gatewaySessionId) {return;}
 			let cancelled = false;
 
 			reconnectAbortRef.current?.abort();
@@ -1503,7 +1517,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 				let baseMessages: Array<{ id: string; role: "user" | "assistant"; parts: UIMessage["parts"] }> = [];
 				try {
 					const res = await fetch(`/api/gateway/sessions/${encodeURIComponent(gatewaySessionId)}`);
-					if (cancelled) return;
+					if (cancelled) {return;}
 					if (res.ok) {
 						const data = await res.json();
 						const sessionMessages: Array<{
@@ -1522,7 +1536,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 							};
 						});
 						baseMessages = uiMessages;
-						if (!cancelled) setMessages(baseMessages);
+						if (!cancelled) {setMessages(baseMessages);}
 					}
 				} catch { /* ignore */ }
 
@@ -2257,7 +2271,6 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 		// ── Active stream status row ──
 
 		const lastMsg = messages.length > 0 ? messages[messages.length - 1] : null;
-		const lastAssistantHasText = hasAssistantText(lastMsg);
 		const streamActivityLabel = getStreamActivityLabel({
 			loadingSession,
 			isReconnecting,
@@ -2741,7 +2754,6 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 								</div>
 							</div>
 						)}
-							<div ref={messagesEndRef} />
 						</div>
 					)}
 				</div>


### PR DESCRIPTION
## Summary
- Replaces message-end `scrollIntoView` autoscroll with container-level scrolling to the true bottom.
- Uses instant autoscroll during streaming so repeated token updates do not queue smooth-scroll animations.
- Adds regression coverage for bottom-distance detection and container scroll targeting.

## Verification
- `pnpm --dir apps/web test app/components/chat-panel.stream-parser.test.ts`
- `pnpm exec oxlint --type-aware apps/web/app/components/chat-panel.tsx apps/web/app/components/chat-panel.stream-parser.test.ts`
- Browser QA at `http://localhost:3100/?chat=71f221da-de92-49af-97c5-31df4189fb27`: sent `scroll verification ping`; confirmed `distanceFromBottom: 0`, no scroll-to-bottom button, and latest reply visible above composer.

## Notes
- Full `pnpm --dir apps/web test` currently fails in unrelated `app/components/workspace/sync-health-banner.test.tsx` (`dismiss hides the banner...`).
- Global `pnpm format:check` currently fails in unrelated `extensions/apollo-enrichment/index.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change focused on scroll positioning; main risk is minor regressions in auto-scroll/scroll-button behavior across browsers.
> 
> **Overview**
> Keeps the chat view reliably pinned to the *true* bottom while streaming by replacing `scrollIntoView` (end sentinel) with container-level `scrollTo` logic.
> 
> Adds reusable scroll helper utilities (`getChatDistanceFromBottom`, `isChatScrolledAwayFromBottom`, `scrollChatToBottom`) with a bottom threshold, uses instant (`"auto"`) scrolling for token-by-token updates, and updates tests to cover bottom-distance detection and container scroll targeting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afbd2167fac3e0a3bfdf9ac02b535c6ed54bbe15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->