### PR TITLE
fix(workspace): show new columns immediately after Create / enrichment

### DIFF
--- a/apps/web/app/components/workspace/right-panel-content.tsx
+++ b/apps/web/app/components/workspace/right-panel-content.tsx
@@ -17,7 +17,7 @@
  * the active tab.
  */
 
-import { useCallback, type ReactNode } from "react";
+import { useCallback, useEffect, type ReactNode } from "react";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -82,6 +82,17 @@ export type RightPanelContentProps = {
 
   // upstream signals
   onDuckDBMissing?: () => void;
+  /**
+   * Hand the active tab's `refreshActive` callback back up to the parent so
+   * upstream code (e.g. column creation, entry mutations) can force a
+   * re-fetch of the cached content payload after a successful write.
+   *
+   * Without this wire, `useTabContent`'s cache would never be invalidated
+   * for things like a newly-created field — the row data updates via the
+   * separate paginated entries fetch, but the schema (fields list) stays
+   * stale and new columns never render.
+   */
+  onRefreshActiveChange?: (refresh: () => void) => void;
 
   /**
    * Render the resolved content body. The parent passes its own
@@ -126,16 +137,21 @@ export function RightPanelContent(props: RightPanelContentProps) {
     onCloseContentToRight,
     onCloseAllContent,
     onDuckDBMissing,
+    onRefreshActiveChange,
     renderContent,
     renderEntryDetail,
     renderPlaceholder,
   } = props;
 
-  const { content } = useTabContent(activeContentTab, {
+  const { content, refreshActive } = useTabContent(activeContentTab, {
     tree,
     cronJobs,
     onDuckDBMissing,
   });
+
+  useEffect(() => {
+    onRefreshActiveChange?.(refreshActive);
+  }, [refreshActive, onRefreshActiveChange]);
 
   const activePath = activeContentTab?.path ?? null;
 

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -2014,6 +2014,9 @@ function WorkspacePageInner() {
   const refreshCurrentObject = useCallback(async () => {
     refreshActiveRef.current();
   }, []);
+  const handleRefreshActiveChange = useCallback((refresh: () => void) => {
+    refreshActiveRef.current = refresh;
+  }, []);
 
   // Auto-refresh the active object tab when the workspace tree updates.
   const prevTreeRef = useRef(tree);
@@ -2657,6 +2660,7 @@ function WorkspacePageInner() {
                 onCloseContentToRight={handleTabCloseToRight}
                 onCloseAllContent={handleTabCloseAll}
                 onDuckDBMissing={handleDuckDBMissing}
+                onRefreshActiveChange={handleRefreshActiveChange}
                 renderContent={renderRightPanelContentBody}
                 renderEntryDetail={renderRightPanelEntryDetail}
                 renderPlaceholder={renderRightPanelPlaceholder}
@@ -2698,6 +2702,7 @@ function WorkspacePageInner() {
                   onCloseContentToRight={handleTabCloseToRight}
                   onCloseAllContent={handleTabCloseAll}
                   onDuckDBMissing={handleDuckDBMissing}
+                  onRefreshActiveChange={handleRefreshActiveChange}
                   renderContent={renderRightPanelContentBody}
                   renderEntryDetail={renderRightPanelEntryDetail}
                   renderPlaceholder={renderRightPanelPlaceholder}


### PR DESCRIPTION
## Why

Creating a column via the **+ Add column** popover (regular or enrichment) wrote
the new field to DuckDB and `/api/workspace/objects/<name>` returned it, but the
UI never re-rendered the column header. The new column was effectively invisible
until a hard reload — even though row data still refreshed.

## Root cause

`refreshActiveRef` in `apps/web/app/workspace/workspace-content.tsx:2013` is
created as a no-op `() => {}` and **never assigned** to the real `refreshActive`
callback returned by `useTabContent` inside `RightPanelContent`. The hook owns
the cached content payload that holds the fields list for the active object
tab. With the ref stuck at the default no-op, `refreshCurrentObject()` (called
from `column-header-menu.tsx`'s `onCreated → onRefresh` path) was a silent
no-op for that cache, so the schema stayed stale.

The row data path was unaffected — `handleRefresh` in `object-table.tsx` calls
`fetchEntries()` separately, which is why row mutations always looked fine.

## Fix

- Add an `onRefreshActiveChange?: (refresh: () => void) => void` prop on
  `RightPanelContent`. Inside the component, a single `useEffect` calls it
  whenever `useTabContent` returns a new `refreshActive` callback.
- In `workspace-content.tsx`, add `handleRefreshActiveChange` that assigns
  the latest `refreshActive` to `refreshActiveRef.current`, and pass it to
  both `<RightPanelContent>` instances (desktop + mobile drawer).

No behavior change for any other path. Tiny, well-scoped wire-up.

## Verification

Reproduce on `workspace-fffa`:

| Step | Before fix | After fix |
|------|-----------|-----------|
| API field count after Create | 13 | 14 |
| UI header `<th>` count after Create | **17 (unchanged)** | **18 (matches API)** |
| Visible header text includes new column | no | yes |

Tested live with both regular column types (Text, Number) and the enrichment
flow (Headline column from the Enrichment section). Both update immediately.

```
Cols before: 17, fields before: 12
Cols after:  18, fields after:  13   ← new col visible
```

Targeted vitest: `data-table.test.tsx`, `object-table.test.tsx`,
`column-header-menu.test.tsx` all pass (10/10). `tsc --noEmit` shows the same
two pre-existing errors that exist on `main` (chat-panel.tsx:2828,
column-header-menu.tsx:690 missing `requiredFields`) — neither touched by this
PR.

## Test plan

- [x] Reproduce the bug on workspace-fffa (column created in DB, not in UI)
- [x] Apply fix
- [x] Re-test: new column appears immediately after Create
- [x] Re-test: enrichment "Headline" column appears immediately
- [x] Run targeted vitest (data-table, object-table, column-header-menu) → all pass
- [x] No new tsc errors introduced

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small prop/effect wire-up to expose `useTabContent`’s `refreshActive` to the parent, with minimal behavioral impact outside triggering a refresh when invoked.
> 
> **Overview**
> Fixes stale object schemas in the right panel by wiring `useTabContent`’s `refreshActive` callback up to `workspace-content.tsx`, so upstream actions (e.g. column creation/enrichment) can invalidate the active tab’s cached payload.
> 
> `RightPanelContent` now exposes `onRefreshActiveChange` and reports the latest `refreshActive` via an effect; `workspace-content.tsx` stores it in `refreshActiveRef` and passes the handler to both desktop and mobile right-panel instances.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad9c60e47c01cd2deb5a404a343e2411700b1a5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->