### PR TITLE
fix(web): unblock build + de-flake sync-health-banner dismiss test

### DIFF
--- a/apps/web/app/components/chat-panel.tsx
+++ b/apps/web/app/components/chat-panel.tsx
@@ -2825,7 +2825,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(
 								<div className="absolute inset-x-0 -top-10 flex justify-center pointer-events-none z-30">
 									<button
 										type="button"
-										onClick={scrollToBottom}
+										onClick={() => scrollToBottom()}
 										className="pointer-events-auto w-8 h-8 rounded-full flex items-center justify-center shadow-md border transition-colors"
 										style={{
 											background: "var(--color-surface)",

--- a/apps/web/app/components/workspace/column-header-menu.tsx
+++ b/apps/web/app/components/workspace/column-header-menu.tsx
@@ -9,6 +9,7 @@ import {
 	getEligibleInputFields,
 	getEnrichmentColumns,
 	type EnrichmentCategory,
+	type EnrichmentColumnDef,
 } from "@/lib/enrichment-columns";
 import {
 	DropdownMenu,
@@ -473,11 +474,13 @@ export function InlineRenameInput({
 /* ─── Add Column Popover ─── */
 
 type AddColumnField = { id: string; name: string; type: string };
-type EnrichmentColumnOption = {
-	label: string;
-	key: string;
-	fieldType: string;
-	apolloPath: string;
+// Options carry the full `EnrichmentColumnDef` (including `requiredFields`
+// and `extractionFallbacks`) so they can be passed straight to
+// `buildEnrichmentMeta` without losing type information. The runtime
+// values come from `getEnrichmentColumns(category)` (which returns
+// `EnrichmentColumnDef[]`) plus the active `category`, so the type just
+// needs to mirror what's already there.
+type EnrichmentColumnOption = EnrichmentColumnDef & {
 	category: EnrichmentCategory;
 };
 type EnrichmentColumnGroup = {

--- a/apps/web/app/components/workspace/sync-health-banner.test.tsx
+++ b/apps/web/app/components/workspace/sync-health-banner.test.tsx
@@ -194,23 +194,38 @@ describe("SyncHealthBanner", () => {
   });
 
   it("dismiss hides the banner for the same failure mode but it returns when the mode changes", async () => {
+    // Make the failure mode flip explicit instead of call-count based.
+    // The previous version raced: with `pollIntervalMs={20}`, the next
+    // poll could fire mid-`userEvent.click`, flipping `errA → errB`
+    // before the dismiss-hides-banner assertion ran. Then the banner
+    // would re-appear with a *new* errorKey, breaking the assertion.
+    // Letting the test own the body lets us assert against a stable
+    // failure mode during the dismiss step.
     const errA = gmailGenericErrorBody("Composio HTTP 502 — bad gateway");
     const errB = gmailGenericErrorBody("Composio HTTP 503 — service unavailable");
-    global.fetch = mockStatusSequence(errA, errA, errB) as unknown as typeof fetch;
+    let currentBody: StatusBody = errA;
+    global.fetch = vi.fn(
+      async () => jsonResponse(currentBody),
+    ) as unknown as typeof fetch;
 
     const user = userEvent.setup();
-    render(<SyncHealthBanner pollIntervalMs={20} />);
+    render(<SyncHealthBanner pollIntervalMs={50} />);
 
+    // First poll → errA → banner shows.
     await waitFor(() =>
       expect(screen.getByTestId("sync-health-banner-gmail")).toBeInTheDocument(),
     );
 
+    // Dismiss the errA banner. Subsequent polls still return errA, so
+    // the dismissed errorKey keeps the banner hidden.
     await user.click(screen.getByRole("button", { name: "Dismiss" }));
     await waitFor(() =>
       expect(screen.queryByTestId("sync-health-banner-gmail")).toBeNull(),
     );
 
-    // Wait for the next poll to flip the failure mode → banner returns.
+    // Flip the failure mode → next poll picks up errB → banner returns
+    // with the new errorKey.
+    currentBody = errB;
     await waitFor(
       () => expect(screen.getByTestId("sync-health-banner-gmail")).toBeInTheDocument(),
       { timeout: 2000 },


### PR DESCRIPTION
Three independent fixes that were blocking \`pnpm web:build\` and the test suite.

## 1. \`chat-panel.tsx:2828\` — type-blocking scroll-to-bottom button

\`\`\`ts
const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => { ... }, [...]);
// ...
<button onClick={scrollToBottom}>  // ❌ MouseEvent ≠ ScrollBehavior
\`\`\`

\`tsc\` rejected this. At runtime, clicking the button would have forwarded
the \`MouseEvent\` object as the \`behavior\` argument to
\`scrollContainerRef.current.scrollTo({ behavior })\`, silently no-op'ing
the scroll. Fixed by wrapping in an arrow fn so the event is dropped:

\`\`\`ts
<button onClick={() => scrollToBottom()}>
\`\`\`

## 2. \`column-header-menu.tsx:690\` — local type drifted from imported one

\`buildEnrichmentMeta(category, colDef, inputFieldName)\` requires a full
\`EnrichmentColumnDef\` (with \`requiredFields: string[]\`), but the local
\`EnrichmentColumnOption\` type omitted that field — even though the runtime
values come straight from \`getEnrichmentColumns()\` which returns
\`EnrichmentColumnDef[]\` (i.e. they always have \`requiredFields\` at runtime).

Fixed by making the local type mirror reality:

\`\`\`ts
type EnrichmentColumnOption = EnrichmentColumnDef & {
  category: EnrichmentCategory;
};
\`\`\`

## 3. \`sync-health-banner.test.tsx\` — flaky dismiss test

The test \"dismiss hides the banner for the same failure mode but it returns
when the mode changes\" used \`pollIntervalMs={20}\` with
\`mockStatusSequence(errA, errA, errB)\` (call-count based mock).

Race condition: with 20ms polls + real timers, the next poll could fire
mid-\`userEvent.click(Dismiss)\`, flipping \`errA → errB\` *before* the
dismiss-hides-banner assertion ran. The banner would then re-appear with
a *new* errorKey — matching the documented \"different mode → banner
returns\" contract but breaking the assertion's expectation that the banner
is null right after dismiss.

Fixed by switching from call-count sequencing to a mutable \`currentBody\`
the test owns. The flip to \`errB\` happens **after** the dismiss assertion
has settled, eliminating the race entirely. Stable across 10 consecutive runs.

## Verification

- [x] \`pnpm --dir apps/web exec tsc --noEmit\` → 0 errors
- [x] \`pnpm web:build\` → production build success (44s)
- [x] \`pnpm --dir apps/web test\` → 1776 passed / 5 skipped (126 files)
- [x] sync-health-banner.test.tsx run 10× consecutively → 15/15 each time

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: fixes TypeScript type issues and a unit-test race without changing backend behavior; only minor UI handler wiring is adjusted.
> 
> **Overview**
> Fixes a type-breaking `onClick` in `chat-panel.tsx` so the scroll-to-bottom button no longer forwards the click event as the `ScrollBehavior` argument and scrolling works reliably.
> 
> Aligns `column-header-menu.tsx` enrichment column option typing with the shared `EnrichmentColumnDef` so `buildEnrichmentMeta` receives the full, correctly-typed column definition.
> 
> De-flakes `SyncHealthBanner` dismiss behavior test by replacing call-count-based fetch sequencing with an explicit, mutable response body and a less aggressive polling interval to avoid races during `Dismiss` clicks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0115d79608861f6b1d3f6c2872f0dc0371b89175. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->