### PR TITLE
Add MCP Connect flow

### DIFF
--- a/apps/web/app/api/settings/mcp/connect/callback/route.test.ts
+++ b/apps/web/app/api/settings/mcp/connect/callback/route.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+let stateDir = "";
+
+vi.mock("@/lib/workspace", () => ({
+  resolveOpenClawStateDir: vi.fn(() => stateDir),
+}));
+
+vi.mock("@/lib/mcp-servers", () => ({
+  getMcpServerConfig: vi.fn(),
+  recordServerState: vi.fn(),
+  setAuthorizationHeader: vi.fn(),
+}));
+
+vi.mock("@/lib/mcp-probe", () => ({
+  probeMcpServer: vi.fn(),
+}));
+
+vi.mock("@/lib/mcp-oauth", () => ({
+  computeTokenExpiresAt: vi.fn(() => "2026-04-29T01:00:00.000Z"),
+  discoverOAuthMetadata: vi.fn(),
+  exchangeCodeForToken: vi.fn(),
+  McpOAuthError: class MockMcpOAuthError extends Error {
+    reason: string;
+
+    constructor(reason: string, message?: string) {
+      super(message ?? reason);
+      this.reason = reason;
+    }
+  },
+}));
+
+vi.mock("@/lib/mcp-secrets", () => ({
+  clearTransientOAuthFields: vi.fn(),
+  getMcpServerSecret: vi.fn(),
+  setMcpServerSecret: vi.fn(),
+}));
+
+vi.mock("@/lib/public-origin", () => ({
+  resolveAppPublicOrigin: vi.fn(() => "http://localhost:3100"),
+}));
+
+vi.mock("@/lib/telemetry", () => ({
+  trackServer: vi.fn(),
+}));
+
+const {
+  getMcpServerConfig,
+  recordServerState,
+  setAuthorizationHeader,
+} = await import("@/lib/mcp-servers");
+const { probeMcpServer } = await import("@/lib/mcp-probe");
+const {
+  discoverOAuthMetadata,
+  exchangeCodeForToken,
+} = await import("@/lib/mcp-oauth");
+const {
+  clearTransientOAuthFields,
+  getMcpServerSecret,
+  setMcpServerSecret,
+} = await import("@/lib/mcp-secrets");
+const { trackServer } = await import("@/lib/telemetry");
+const { GET } = await import("./route");
+
+const mockedGetMcpServerConfig = vi.mocked(getMcpServerConfig);
+const mockedRecordServerState = vi.mocked(recordServerState);
+const mockedSetAuthorizationHeader = vi.mocked(setAuthorizationHeader);
+const mockedProbeMcpServer = vi.mocked(probeMcpServer);
+const mockedDiscoverOAuthMetadata = vi.mocked(discoverOAuthMetadata);
+const mockedExchangeCodeForToken = vi.mocked(exchangeCodeForToken);
+const mockedClearTransientOAuthFields = vi.mocked(clearTransientOAuthFields);
+const mockedGetMcpServerSecret = vi.mocked(getMcpServerSecret);
+const mockedSetMcpServerSecret = vi.mocked(setMcpServerSecret);
+const mockedTrackServer = vi.mocked(trackServer);
+
+function writeSecrets(contents: Record<string, unknown>) {
+  writeFileSync(
+    path.join(stateDir, ".mcp-secrets.json"),
+    JSON.stringify(contents, null, 2),
+    "utf-8",
+  );
+}
+
+describe("GET /api/settings/mcp/connect/callback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stateDir = path.join(os.tmpdir(), `dench-mcp-callback-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(stateDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("rejects unknown state", async () => {
+    writeSecrets({});
+
+    const response = await GET(new Request(
+      "http://localhost/api/settings/mcp/connect/callback?code=code-123&state=missing",
+    ));
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain("Connection failed");
+    expect(html).toContain("unknown_state");
+  });
+
+  it("persists tokens, writes Authorization header, probes, and posts success", async () => {
+    writeSecrets({
+      acme: { oauthState: "state-123" },
+    });
+    mockedGetMcpServerSecret.mockReturnValue({
+      clientId: "client-123",
+      clientSecret: null,
+      refreshToken: null,
+      tokenExpiresAt: null,
+      asMetadataUrl: "https://mcp.example.com/.well-known/oauth-protected-resource",
+      authServerIssuer: "https://auth.example.com",
+      registeredRedirectUri: "http://localhost:3100/api/settings/mcp/connect/callback",
+      codeVerifier: "verifier-123",
+      oauthState: "state-123",
+      redirectUri: "http://localhost:3100/api/settings/mcp/connect/callback",
+      scope: "mcp:read",
+    });
+    mockedDiscoverOAuthMetadata.mockResolvedValue({
+      resource: {
+        resource: "https://mcp.example.com",
+        authorizationServers: ["https://auth.example.com"],
+        scopesSupported: ["mcp:read"],
+        bearerMethodsSupported: ["header"],
+      },
+      authServer: {
+        issuer: "https://auth.example.com",
+        authorizationEndpoint: "https://auth.example.com/authorize",
+        tokenEndpoint: "https://auth.example.com/token",
+        registrationEndpoint: "https://auth.example.com/register",
+        scopesSupported: ["mcp:read"],
+        responseTypesSupported: ["code"],
+        grantTypesSupported: ["authorization_code"],
+        codeChallengeMethodsSupported: ["S256"],
+        tokenEndpointAuthMethodsSupported: ["none"],
+      },
+    });
+    mockedExchangeCodeForToken.mockResolvedValue({
+      accessToken: "access-123",
+      tokenType: "Bearer",
+      refreshToken: "refresh-123",
+      expiresIn: 3600,
+      scope: "mcp:read",
+    });
+    mockedGetMcpServerConfig.mockReturnValue({
+      url: "https://mcp.example.com",
+      transport: "streamable-http",
+      headers: { Authorization: "Bearer access-123" },
+    });
+    mockedProbeMcpServer.mockResolvedValue({
+      status: "connected",
+      toolCount: 7,
+      authChallenge: null,
+      detail: "Connected. 7 tools available.",
+      checkedAt: "2026-04-29T00:00:00.000Z",
+      httpStatus: 200,
+    });
+
+    const response = await GET(new Request(
+      "http://localhost/api/settings/mcp/connect/callback?code=code-123&state=state-123",
+    ));
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(mockedExchangeCodeForToken).toHaveBeenCalledWith(expect.objectContaining({
+      code: "code-123",
+      codeVerifier: "verifier-123",
+    }));
+    expect(mockedSetAuthorizationHeader).toHaveBeenCalledWith("acme", "Bearer access-123");
+    expect(mockedSetMcpServerSecret).toHaveBeenCalledWith("acme", expect.objectContaining({
+      refreshToken: "refresh-123",
+      tokenExpiresAt: "2026-04-29T01:00:00.000Z",
+    }));
+    expect(mockedClearTransientOAuthFields).toHaveBeenCalledWith("acme");
+    expect(mockedRecordServerState).toHaveBeenCalledWith("acme", expect.objectContaining({
+      state: "connected",
+      toolCount: 7,
+    }));
+    expect(mockedTrackServer).toHaveBeenCalledWith("mcp_connect_completed", { key: "acme" });
+    expect(html).toContain("mcp-connected");
+    expect(html).toContain("Connected acme");
+  });
+});

--- a/apps/web/app/api/settings/mcp/connect/callback/route.ts
+++ b/apps/web/app/api/settings/mcp/connect/callback/route.ts
@@ -1,0 +1,328 @@
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { resolveOpenClawStateDir } from "@/lib/workspace";
+import {
+  getMcpServerConfig,
+  recordServerState,
+  setAuthorizationHeader,
+} from "@/lib/mcp-servers";
+import { probeMcpServer } from "@/lib/mcp-probe";
+import {
+  computeTokenExpiresAt,
+  discoverOAuthMetadata,
+  exchangeCodeForToken,
+  McpOAuthError,
+  type RegisteredClient,
+} from "@/lib/mcp-oauth";
+import {
+  clearTransientOAuthFields,
+  getMcpServerSecret,
+  setMcpServerSecret,
+  type McpServerSecret,
+} from "@/lib/mcp-secrets";
+import { resolveAppPublicOrigin } from "@/lib/public-origin";
+import { trackServer } from "@/lib/telemetry";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+type CallbackOutcome =
+  | { kind: "success"; serverKey: string }
+  | { kind: "error"; serverKey: string | null; reason: string; description: string };
+
+/**
+ * Linear scan of the secrets sidecar to find the server whose pending
+ * `oauthState` matches the `state` query param. The volume is small
+ * (handful of MCP servers per user), so a sorted index isn't worth the
+ * code.
+ */
+function findServerKeyByState(state: string): string | null {
+  const path = join(resolveOpenClawStateDir(), ".mcp-secrets.json");
+  if (!existsSync(path)) {
+    return null;
+  }
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  for (const [key, value] of Object.entries(parsed)) {
+    const entry = value as { oauthState?: unknown } | null;
+    if (entry && typeof entry.oauthState === "string" && entry.oauthState === state) {
+      return key;
+    }
+  }
+  return null;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function escapeJsonForScript(value: unknown): string {
+  // Embedding JSON in a <script> tag — escape `<` so a literal `</script>`
+  // inside a string can't break out of the tag.
+  return JSON.stringify(value).replace(/</g, "\\u003c");
+}
+
+function renderResultPage(
+  outcome: CallbackOutcome,
+  targetOrigin: string,
+): Response {
+  const message = outcome.kind === "success"
+    ? {
+        source: "denchclaw.mcp.connect",
+        type: "mcp-connected",
+        serverKey: outcome.serverKey,
+      }
+    : {
+        source: "denchclaw.mcp.connect",
+        type: "mcp-connect-failed",
+        serverKey: outcome.serverKey,
+        reason: outcome.reason,
+        description: outcome.description,
+      };
+
+  const heading = outcome.kind === "success"
+    ? `Connected ${escapeHtml(outcome.serverKey)}`
+    : "Connection failed";
+  const body = outcome.kind === "success"
+    ? "You can close this window."
+    : escapeHtml(outcome.description);
+  const accentColor = outcome.kind === "success" ? "#10b981" : "#ef4444";
+
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${heading}</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      background: #0b0d12;
+      color: #e7e9ee;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+    }
+    .card {
+      max-width: 360px;
+      padding: 32px;
+      border-radius: 16px;
+      background: #1a1d24;
+      border: 1px solid #2a2e38;
+      text-align: center;
+    }
+    .card h1 {
+      margin: 0 0 8px;
+      font-size: 18px;
+      color: ${accentColor};
+    }
+    .card p {
+      margin: 0;
+      font-size: 13px;
+      line-height: 1.6;
+      color: #9aa1ad;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>${heading}</h1>
+    <p>${body}</p>
+  </div>
+  <script>
+    (function () {
+      var msg = ${escapeJsonForScript(message)};
+      try {
+        if (window.opener) {
+          window.opener.postMessage(msg, ${escapeJsonForScript(targetOrigin)});
+        }
+      } catch (err) {
+        // ignore — opener might be cross-origin in unusual setups
+      }
+      setTimeout(function () { window.close(); }, 800);
+    }());
+  </script>
+</body>
+</html>`;
+
+  return new Response(html, {
+    status: 200,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store",
+    },
+  });
+}
+
+async function persistTokens(
+  serverKey: string,
+  cached: McpServerSecret,
+  tokenResponse: {
+    accessToken: string;
+    tokenType: string;
+    refreshToken: string | null;
+    expiresIn: number | null;
+    scope: string | null;
+  },
+): Promise<void> {
+  setAuthorizationHeader(serverKey, `${tokenResponse.tokenType} ${tokenResponse.accessToken}`);
+  setMcpServerSecret(serverKey, {
+    refreshToken: tokenResponse.refreshToken ?? cached.refreshToken,
+    tokenExpiresAt: computeTokenExpiresAt(tokenResponse.expiresIn),
+    scope: tokenResponse.scope ?? cached.scope,
+  });
+  clearTransientOAuthFields(serverKey);
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const targetOrigin = resolveAppPublicOrigin(request);
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  const oauthError = url.searchParams.get("error");
+  const oauthErrorDescription = url.searchParams.get("error_description");
+
+  // The AS reported an error — surface it to the opener and bail.
+  if (oauthError) {
+    const serverKey = state ? findServerKeyByState(state) : null;
+    if (serverKey) {
+      recordServerState(serverKey, {
+        state: "needs_auth",
+        detail: oauthErrorDescription ?? oauthError,
+      });
+      clearTransientOAuthFields(serverKey);
+      trackServer("mcp_connect_failed", {
+        key: serverKey,
+        reason: oauthError,
+      });
+    }
+    return renderResultPage(
+      {
+        kind: "error",
+        serverKey,
+        reason: oauthError,
+        description: oauthErrorDescription ?? oauthError,
+      },
+      targetOrigin,
+    );
+  }
+
+  if (!code || !state) {
+    return renderResultPage(
+      {
+        kind: "error",
+        serverKey: null,
+        reason: "missing_code_or_state",
+        description: "The authorization server did not return a code and state.",
+      },
+      targetOrigin,
+    );
+  }
+
+  const serverKey = findServerKeyByState(state);
+  if (!serverKey) {
+    return renderResultPage(
+      {
+        kind: "error",
+        serverKey: null,
+        reason: "unknown_state",
+        description: "Unknown state value. The Connect flow may have timed out — try again.",
+      },
+      targetOrigin,
+    );
+  }
+
+  const cached = getMcpServerSecret(serverKey);
+  if (!cached || !cached.codeVerifier || !cached.redirectUri) {
+    return renderResultPage(
+      {
+        kind: "error",
+        serverKey,
+        reason: "missing_pkce",
+        description: "Could not find the PKCE verifier saved at /connect/start time.",
+      },
+      targetOrigin,
+    );
+  }
+
+  // Re-discover the AS metadata from the cached metadata URL so we don't
+  // have to persist the entire AuthorizationServerMetadata document.
+  let discovered;
+  try {
+    discovered = await discoverOAuthMetadata(cached.asMetadataUrl);
+  } catch (err) {
+    const reason = err instanceof McpOAuthError ? err.reason : "discovery_failed";
+    const description = err instanceof Error ? err.message : "Discovery failed.";
+    recordServerState(serverKey, { state: "needs_auth", detail: description });
+    trackServer("mcp_connect_failed", { key: serverKey, reason });
+    return renderResultPage(
+      { kind: "error", serverKey, reason, description },
+      targetOrigin,
+    );
+  }
+
+  const client: RegisteredClient = {
+    clientId: cached.clientId,
+    clientSecret: cached.clientSecret,
+    registrationAccessToken: null,
+    registrationClientUri: null,
+  };
+
+  let tokenResponse;
+  try {
+    tokenResponse = await exchangeCodeForToken({
+      asMetadata: discovered.authServer,
+      client,
+      code,
+      codeVerifier: cached.codeVerifier,
+      redirectUri: cached.redirectUri,
+      resource: discovered.resource.resource,
+    });
+  } catch (err) {
+    const reason = err instanceof McpOAuthError ? err.reason : "token_exchange_failed";
+    const description = err instanceof Error ? err.message : "Token exchange failed.";
+    recordServerState(serverKey, { state: "needs_auth", detail: description });
+    clearTransientOAuthFields(serverKey);
+    trackServer("mcp_connect_failed", { key: serverKey, reason });
+    return renderResultPage(
+      { kind: "error", serverKey, reason, description },
+      targetOrigin,
+    );
+  }
+
+  await persistTokens(serverKey, cached, tokenResponse);
+
+  // Probe with the new token so the row's state lands as `connected`
+  // immediately — the user shouldn't have to refresh the page.
+  const serverConfig = getMcpServerConfig(serverKey);
+  if (serverConfig) {
+    const probe = await probeMcpServer({
+      url: serverConfig.url,
+      headers: serverConfig.headers,
+    });
+    recordServerState(serverKey, {
+      state: probe.status,
+      toolCount: probe.toolCount,
+      detail: probe.detail,
+      checkedAt: probe.checkedAt,
+    });
+  }
+
+  trackServer("mcp_connect_completed", { key: serverKey });
+
+  return renderResultPage(
+    { kind: "success", serverKey },
+    targetOrigin,
+  );
+}

--- a/apps/web/app/api/settings/mcp/connect/start/route.test.ts
+++ b/apps/web/app/api/settings/mcp/connect/start/route.test.ts
@@ -1,0 +1,333 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/mcp-servers", () => {
+  class MockMcpServerError extends Error {
+    status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = "McpServerError";
+      this.status = status;
+    }
+  }
+
+  return {
+    getMcpServer: vi.fn(),
+    getMcpServerConfig: vi.fn(),
+    recordServerState: vi.fn(),
+    McpServerError: MockMcpServerError,
+  };
+});
+
+vi.mock("@/lib/mcp-probe", () => ({
+  probeMcpServer: vi.fn(),
+}));
+
+vi.mock("@/lib/mcp-oauth", () => ({
+  buildAuthorizationUrl: vi.fn(),
+  discoverOAuthMetadata: vi.fn(),
+  McpOAuthError: class MockMcpOAuthError extends Error {
+    reason: string;
+
+    constructor(reason: string, message?: string) {
+      super(message ?? reason);
+      this.name = "McpOAuthError";
+      this.reason = reason;
+    }
+  },
+  registerOAuthClient: vi.fn(),
+}));
+
+vi.mock("@/lib/mcp-secrets", () => ({
+  getMcpServerSecret: vi.fn(),
+  setMcpServerSecret: vi.fn(),
+}));
+
+vi.mock("@/lib/public-origin", () => ({
+  resolveAppPublicOrigin: vi.fn(() => "http://localhost:3100"),
+}));
+
+vi.mock("@/lib/telemetry", () => ({
+  trackServer: vi.fn(),
+}));
+
+const {
+  getMcpServer,
+  getMcpServerConfig,
+  recordServerState,
+} = await import("@/lib/mcp-servers");
+const { probeMcpServer } = await import("@/lib/mcp-probe");
+const {
+  buildAuthorizationUrl,
+  discoverOAuthMetadata,
+  registerOAuthClient,
+} = await import("@/lib/mcp-oauth");
+const { getMcpServerSecret, setMcpServerSecret } = await import("@/lib/mcp-secrets");
+const { POST } = await import("./route");
+
+const mockedGetMcpServer = vi.mocked(getMcpServer);
+const mockedGetMcpServerConfig = vi.mocked(getMcpServerConfig);
+const mockedRecordServerState = vi.mocked(recordServerState);
+const mockedProbeMcpServer = vi.mocked(probeMcpServer);
+const mockedDiscoverOAuthMetadata = vi.mocked(discoverOAuthMetadata);
+const mockedRegisterOAuthClient = vi.mocked(registerOAuthClient);
+const mockedBuildAuthorizationUrl = vi.mocked(buildAuthorizationUrl);
+const mockedGetMcpServerSecret = vi.mocked(getMcpServerSecret);
+const mockedSetMcpServerSecret = vi.mocked(setMcpServerSecret);
+
+const serverEntry = {
+  key: "acme",
+  url: "https://mcp.example.com",
+  transport: "streamable-http",
+  hasAuth: false,
+  state: "needs_auth" as const,
+  toolCount: null,
+  lastCheckedAt: null,
+  lastDetail: null,
+};
+
+describe("POST /api/settings/mcp/connect/start", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedGetMcpServer.mockReturnValue(serverEntry);
+    mockedGetMcpServerConfig.mockReturnValue({
+      url: "https://mcp.example.com",
+      transport: "streamable-http",
+    });
+  });
+
+  it("validates key field", async () => {
+    const response = await POST(new Request("http://localhost/api/settings/mcp/connect/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: 123 }),
+    }));
+
+    expect(response.status).toBe(400);
+  });
+
+  it("falls back when the server doesn't advertise resource_metadata", async () => {
+    mockedProbeMcpServer.mockResolvedValue({
+      status: "needs_auth",
+      toolCount: null,
+      authChallenge: null,
+      detail: "HTTP 401 from MCP server.",
+      checkedAt: "2026-04-29T00:00:00.000Z",
+      httpStatus: 401,
+    });
+
+    const response = await POST(new Request("http://localhost/api/settings/mcp/connect/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "acme" }),
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.supportsOAuth).toBe(false);
+    expect(body.reason).toMatch(/did not advertise/);
+    expect(mockedRecordServerState).toHaveBeenCalledWith("acme", expect.objectContaining({
+      state: "needs_auth",
+    }));
+  });
+
+  it("returns authorizationUrl and persists transient OAuth state on happy path", async () => {
+    mockedProbeMcpServer.mockResolvedValue({
+      status: "needs_auth",
+      toolCount: null,
+      authChallenge: {
+        scheme: "Bearer",
+        realm: null,
+        resourceMetadataUrl: "https://mcp.example.com/.well-known/oauth-protected-resource",
+        scope: null,
+        errorCode: null,
+        errorDescription: null,
+      },
+      detail: "HTTP 401 from MCP server.",
+      checkedAt: "2026-04-29T00:00:00.000Z",
+      httpStatus: 401,
+    });
+    mockedDiscoverOAuthMetadata.mockResolvedValue({
+      resource: {
+        resource: "https://mcp.example.com",
+        authorizationServers: ["https://auth.example.com"],
+        scopesSupported: ["mcp:read"],
+        bearerMethodsSupported: ["header"],
+      },
+      authServer: {
+        issuer: "https://auth.example.com",
+        authorizationEndpoint: "https://auth.example.com/authorize",
+        tokenEndpoint: "https://auth.example.com/token",
+        registrationEndpoint: "https://auth.example.com/register",
+        scopesSupported: ["mcp:read"],
+        responseTypesSupported: ["code"],
+        grantTypesSupported: ["authorization_code"],
+        codeChallengeMethodsSupported: ["S256"],
+        tokenEndpointAuthMethodsSupported: ["none"],
+      },
+    });
+    mockedGetMcpServerSecret.mockReturnValue(null);
+    mockedRegisterOAuthClient.mockResolvedValue({
+      clientId: "client-123",
+      clientSecret: null,
+      registrationAccessToken: null,
+      registrationClientUri: null,
+    });
+    mockedBuildAuthorizationUrl.mockReturnValue({
+      authorizationUrl: "https://auth.example.com/authorize?client_id=client-123",
+      state: "state-123",
+      codeVerifier: "verifier-123",
+      redirectUri: "http://localhost:3100/api/settings/mcp/connect/callback",
+      scope: "mcp:read",
+    });
+
+    const response = await POST(new Request("http://localhost/api/settings/mcp/connect/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "acme" }),
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      supportsOAuth: true,
+      authorizationUrl: "https://auth.example.com/authorize?client_id=client-123",
+      redirectUri: "http://localhost:3100/api/settings/mcp/connect/callback",
+      issuer: "https://auth.example.com",
+    });
+    expect(mockedSetMcpServerSecret).toHaveBeenCalledWith("acme", expect.objectContaining({
+      clientId: "client-123",
+      codeVerifier: "verifier-123",
+      oauthState: "state-123",
+      registeredRedirectUri: "http://localhost:3100/api/settings/mcp/connect/callback",
+      scope: "mcp:read",
+    }));
+  });
+
+  it("registers a fresh client when the cached redirect URI differs", async () => {
+    mockedProbeMcpServer.mockResolvedValue({
+      status: "needs_auth",
+      toolCount: null,
+      authChallenge: {
+        scheme: "Bearer",
+        realm: null,
+        resourceMetadataUrl: "https://mcp.example.com/.well-known/oauth-protected-resource",
+        scope: null,
+        errorCode: null,
+        errorDescription: null,
+      },
+      detail: "HTTP 401 from MCP server.",
+      checkedAt: "2026-04-29T00:00:00.000Z",
+      httpStatus: 401,
+    });
+    mockedDiscoverOAuthMetadata.mockResolvedValue({
+      resource: {
+        resource: "https://mcp.example.com",
+        authorizationServers: ["https://auth.example.com"],
+        scopesSupported: ["mcp:read"],
+        bearerMethodsSupported: ["header"],
+      },
+      authServer: {
+        issuer: "https://auth.example.com",
+        authorizationEndpoint: "https://auth.example.com/authorize",
+        tokenEndpoint: "https://auth.example.com/token",
+        registrationEndpoint: "https://auth.example.com/register",
+        scopesSupported: ["mcp:read"],
+        responseTypesSupported: ["code"],
+        grantTypesSupported: ["authorization_code"],
+        codeChallengeMethodsSupported: ["S256"],
+        tokenEndpointAuthMethodsSupported: ["none"],
+      },
+    });
+    mockedGetMcpServerSecret.mockReturnValue({
+      clientId: "old-client",
+      clientSecret: null,
+      refreshToken: null,
+      tokenExpiresAt: null,
+      asMetadataUrl: "https://mcp.example.com/.well-known/oauth-protected-resource",
+      authServerIssuer: "https://auth.example.com",
+      registeredRedirectUri: "http://old.example/api/settings/mcp/connect/callback",
+      codeVerifier: null,
+      oauthState: null,
+      redirectUri: null,
+      scope: "mcp:read",
+    });
+    mockedRegisterOAuthClient.mockResolvedValue({
+      clientId: "new-client",
+      clientSecret: null,
+      registrationAccessToken: null,
+      registrationClientUri: null,
+    });
+    mockedBuildAuthorizationUrl.mockReturnValue({
+      authorizationUrl: "https://auth.example.com/authorize?client_id=new-client",
+      state: "state-123",
+      codeVerifier: "verifier-123",
+      redirectUri: "http://localhost:3100/api/settings/mcp/connect/callback",
+      scope: "mcp:read",
+    });
+
+    const response = await POST(new Request("http://localhost/api/settings/mcp/connect/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "acme" }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(mockedRegisterOAuthClient).toHaveBeenCalledWith(expect.objectContaining({
+      redirectUri: "http://localhost:3100/api/settings/mcp/connect/callback",
+    }));
+    expect(mockedSetMcpServerSecret).toHaveBeenCalledWith("acme", expect.objectContaining({
+      clientId: "new-client",
+      registeredRedirectUri: "http://localhost:3100/api/settings/mcp/connect/callback",
+    }));
+  });
+
+  it("falls back when the authorization server does not support dynamic registration", async () => {
+    mockedProbeMcpServer.mockResolvedValue({
+      status: "needs_auth",
+      toolCount: null,
+      authChallenge: {
+        scheme: "Bearer",
+        realm: null,
+        resourceMetadataUrl: "https://mcp.example.com/.well-known/oauth-protected-resource",
+        scope: null,
+        errorCode: null,
+        errorDescription: null,
+      },
+      detail: "HTTP 401 from MCP server.",
+      checkedAt: "2026-04-29T00:00:00.000Z",
+      httpStatus: 401,
+    });
+    mockedDiscoverOAuthMetadata.mockResolvedValue({
+      resource: {
+        resource: "https://mcp.example.com",
+        authorizationServers: ["https://auth.example.com"],
+        scopesSupported: [],
+        bearerMethodsSupported: [],
+      },
+      authServer: {
+        issuer: "https://auth.example.com",
+        authorizationEndpoint: "https://auth.example.com/authorize",
+        tokenEndpoint: "https://auth.example.com/token",
+        registrationEndpoint: null,
+        scopesSupported: [],
+        responseTypesSupported: ["code"],
+        grantTypesSupported: ["authorization_code"],
+        codeChallengeMethodsSupported: ["S256"],
+        tokenEndpointAuthMethodsSupported: ["none"],
+      },
+    });
+    mockedRegisterOAuthClient.mockRejectedValue(new Error("no registration_endpoint"));
+
+    const response = await POST(new Request("http://localhost/api/settings/mcp/connect/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "acme" }),
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.supportsOAuth).toBe(false);
+    expect(body.reason).toMatch(/Dynamic client registration failed/);
+  });
+});

--- a/apps/web/app/api/settings/mcp/connect/start/route.ts
+++ b/apps/web/app/api/settings/mcp/connect/start/route.ts
@@ -1,0 +1,244 @@
+import {
+  getMcpServer,
+  getMcpServerConfig,
+  McpServerError,
+  recordServerState,
+} from "@/lib/mcp-servers";
+import { probeMcpServer } from "@/lib/mcp-probe";
+import {
+  buildAuthorizationUrl,
+  discoverOAuthMetadata,
+  McpOAuthError,
+  registerOAuthClient,
+  type AuthorizationServerMetadata,
+  type RegisteredClient,
+} from "@/lib/mcp-oauth";
+import { getMcpServerSecret, setMcpServerSecret } from "@/lib/mcp-secrets";
+import { resolveAppPublicOrigin } from "@/lib/public-origin";
+import { trackServer } from "@/lib/telemetry";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+type StartBody = {
+  key?: unknown;
+};
+
+function jsonError(message: string, status: number): Response {
+  return Response.json({ error: message }, { status });
+}
+
+function notSupported(reason: string): Response {
+  return Response.json({ supportsOAuth: false, reason });
+}
+
+function buildRedirectUri(request: Request): string {
+  const origin = resolveAppPublicOrigin(request);
+  return `${origin}/api/settings/mcp/connect/callback`;
+}
+
+/**
+ * Reuse a previously cached client_id only when it still matches the same
+ * authorization server and redirect URI. DCR clients are registered with a
+ * fixed callback URL, so reusing one across localhost/tunnel/origin changes
+ * can produce "redirect URL is invalid" during authorization.
+ */
+function maybeRehydrateClient(
+  key: string,
+  asMetadata: AuthorizationServerMetadata,
+  asMetadataUrl: string,
+  redirectUri: string,
+): RegisteredClient | null {
+  const cached = getMcpServerSecret(key);
+  if (!cached || !cached.clientId) {
+    return null;
+  }
+  if (cached.asMetadataUrl !== asMetadataUrl) {
+    return null;
+  }
+  if (cached.authServerIssuer && cached.authServerIssuer !== asMetadata.issuer) {
+    return null;
+  }
+  if (cached.registeredRedirectUri !== redirectUri) {
+    return null;
+  }
+  return {
+    clientId: cached.clientId,
+    clientSecret: cached.clientSecret,
+    registrationAccessToken: null,
+    registrationClientUri: null,
+  };
+}
+
+export async function POST(request: Request): Promise<Response> {
+  let body: StartBody;
+  try {
+    body = (await request.json()) as StartBody;
+  } catch {
+    return jsonError("Invalid JSON body.", 400);
+  }
+  if (typeof body.key !== "string") {
+    return jsonError("Field 'key' must be a string.", 400);
+  }
+  const key = body.key;
+
+  let serverEntry;
+  try {
+    serverEntry = getMcpServer(key);
+  } catch (err) {
+    if (err instanceof McpServerError) {
+      return jsonError(err.message, err.status);
+    }
+    return jsonError(
+      err instanceof Error ? err.message : "Failed to load MCP server.",
+      500,
+    );
+  }
+  if (!serverEntry) {
+    return jsonError(`MCP server '${key}' was not found.`, 404);
+  }
+
+  trackServer("mcp_connect_started", {
+    key,
+    method: "oauth",
+  });
+
+  const serverConfig = getMcpServerConfig(key);
+  if (!serverConfig) {
+    return jsonError(`MCP server '${key}' is missing wire config.`, 500);
+  }
+
+  // Step 1: probe the MCP server. We need the live WWW-Authenticate header
+  // because the user might have rotated auth servers since the last probe.
+  const probe = await probeMcpServer({
+    url: serverConfig.url,
+    headers: serverConfig.headers,
+  });
+
+  if (probe.status === "connected") {
+    // Already connected — record fresh state and tell the UI nothing to do.
+    recordServerState(key, {
+      state: "connected",
+      toolCount: probe.toolCount,
+      detail: probe.detail,
+      checkedAt: probe.checkedAt,
+    });
+    return Response.json({
+      alreadyConnected: true,
+      server: getMcpServer(key),
+    });
+  }
+
+  if (probe.status === "error") {
+    recordServerState(key, {
+      state: "error",
+      detail: probe.detail,
+      checkedAt: probe.checkedAt,
+    });
+    trackServer("mcp_connect_failed", {
+      key,
+      reason: "probe_error",
+    });
+    return notSupported(`The server is not reachable: ${probe.detail}`);
+  }
+
+  const challenge = probe.authChallenge;
+  const resourceMetadataUrl = challenge?.resourceMetadataUrl ?? null;
+  if (!resourceMetadataUrl) {
+    recordServerState(key, {
+      state: "needs_auth",
+      detail: probe.detail,
+      checkedAt: probe.checkedAt,
+    });
+    trackServer("mcp_connect_failed", {
+      key,
+      reason: "no_oauth_metadata",
+    });
+    return notSupported(
+      "The server did not advertise an OAuth resource metadata URL. Use a manual access token instead.",
+    );
+  }
+
+  // Step 2: walk RFC 9728 + RFC 8414 discovery.
+  let discovered;
+  try {
+    discovered = await discoverOAuthMetadata(resourceMetadataUrl);
+  } catch (err) {
+    const reason = err instanceof McpOAuthError
+      ? err.reason
+      : "discovery_failed";
+    const detail = err instanceof Error ? err.message : "Discovery failed.";
+    recordServerState(key, {
+      state: "needs_auth",
+      detail,
+      checkedAt: new Date().toISOString(),
+    });
+    trackServer("mcp_connect_failed", {
+      key,
+      reason,
+    });
+    return notSupported(`OAuth discovery failed (${reason}): ${detail}`);
+  }
+
+  const redirectUri = buildRedirectUri(request);
+  const scope = discovered.resource.scopesSupported.length > 0
+    ? discovered.resource.scopesSupported.join(" ")
+    : (challenge?.scope ?? null);
+
+  // Step 3: register (or reuse) an OAuth client.
+  let client = maybeRehydrateClient(
+    key,
+    discovered.authServer,
+    resourceMetadataUrl,
+    redirectUri,
+  );
+  if (!client) {
+    try {
+      client = await registerOAuthClient({
+        asMetadata: discovered.authServer,
+        redirectUri,
+        clientName: `DenchClaw (${key})`,
+        scope,
+      });
+    } catch (err) {
+      const reason = err instanceof McpOAuthError
+        ? err.reason
+        : "registration_failed";
+      const detail = err instanceof Error ? err.message : "Registration failed.";
+      trackServer("mcp_connect_failed", {
+        key,
+        reason,
+      });
+      return notSupported(`Dynamic client registration failed (${reason}): ${detail}`);
+    }
+  }
+
+  // Step 4: build the authorization URL with PKCE + state.
+  const authParams = buildAuthorizationUrl({
+    asMetadata: discovered.authServer,
+    client,
+    redirectUri,
+    scope,
+    resource: discovered.resource.resource,
+  });
+
+  // Step 5: persist everything we'll need at the callback step.
+  setMcpServerSecret(key, {
+    clientId: client.clientId,
+    clientSecret: client.clientSecret,
+    asMetadataUrl: resourceMetadataUrl,
+    authServerIssuer: discovered.authServer.issuer,
+    registeredRedirectUri: redirectUri,
+    codeVerifier: authParams.codeVerifier,
+    oauthState: authParams.state,
+    redirectUri: authParams.redirectUri,
+    scope: authParams.scope,
+  });
+
+  return Response.json({
+    supportsOAuth: true,
+    authorizationUrl: authParams.authorizationUrl,
+    redirectUri,
+    issuer: discovered.authServer.issuer,
+  });
+}

--- a/apps/web/app/api/settings/mcp/connect/token/route.test.ts
+++ b/apps/web/app/api/settings/mcp/connect/token/route.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/mcp-servers", () => {
+  class MockMcpServerError extends Error {
+    status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = "McpServerError";
+      this.status = status;
+    }
+  }
+
+  return {
+    getMcpServerConfig: vi.fn(),
+    setAuthorizationHeader: vi.fn(),
+    recordServerState: vi.fn(),
+    McpServerError: MockMcpServerError,
+  };
+});
+
+vi.mock("@/lib/mcp-probe", () => ({
+  probeMcpServer: vi.fn(),
+}));
+
+vi.mock("@/lib/telemetry", () => ({
+  trackServer: vi.fn(),
+}));
+
+const {
+  getMcpServerConfig,
+  McpServerError,
+  recordServerState,
+  setAuthorizationHeader,
+} = await import("@/lib/mcp-servers");
+const { probeMcpServer } = await import("@/lib/mcp-probe");
+const { trackServer } = await import("@/lib/telemetry");
+const { POST } = await import("./route");
+
+const mockedGetMcpServerConfig = vi.mocked(getMcpServerConfig);
+const mockedProbeMcpServer = vi.mocked(probeMcpServer);
+const mockedRecordServerState = vi.mocked(recordServerState);
+const mockedSetAuthorizationHeader = vi.mocked(setAuthorizationHeader);
+const mockedTrackServer = vi.mocked(trackServer);
+
+const baseEntry = {
+  key: "acme",
+  url: "https://mcp.example.com",
+  transport: "streamable-http",
+  hasAuth: true,
+  state: "connected" as const,
+  toolCount: 2,
+  lastCheckedAt: "2026-04-29T00:00:00.000Z",
+  lastDetail: "Connected. 2 tools available.",
+};
+
+describe("POST /api/settings/mcp/connect/token", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects missing key", async () => {
+    const response = await POST(new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ authToken: "abc" }),
+    }));
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects empty authToken", async () => {
+    const response = await POST(new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "acme", authToken: "  " }),
+    }));
+    expect(response.status).toBe(400);
+  });
+
+  it("strips a leading 'Bearer ' prefix from the supplied token", async () => {
+    mockedSetAuthorizationHeader.mockReturnValue(baseEntry);
+    mockedGetMcpServerConfig.mockReturnValue({
+      url: "https://mcp.example.com",
+      transport: "streamable-http",
+      headers: { Authorization: "Bearer abc" },
+    });
+    mockedProbeMcpServer.mockResolvedValue({
+      status: "connected",
+      toolCount: 2,
+      authChallenge: null,
+      detail: "Connected. 2 tools available.",
+      checkedAt: "2026-04-29T00:00:00.000Z",
+      httpStatus: 200,
+    });
+    mockedRecordServerState.mockReturnValue(baseEntry);
+
+    const response = await POST(new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "acme", authToken: "Bearer abc" }),
+    }));
+
+    expect(mockedSetAuthorizationHeader).toHaveBeenCalledWith("acme", "Bearer abc");
+    expect(response.status).toBe(200);
+    expect(mockedTrackServer).toHaveBeenCalledWith("mcp_server_token_set", {
+      key: "acme",
+      probe_status: "connected",
+    });
+  });
+
+  it("propagates McpServerError when the server doesn't exist", async () => {
+    mockedSetAuthorizationHeader.mockImplementation(() => {
+      throw new McpServerError(404, "MCP server 'missing' was not found.");
+    });
+
+    const response = await POST(new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "missing", authToken: "abc" }),
+    }));
+    expect(response.status).toBe(404);
+  });
+});

--- a/apps/web/app/api/settings/mcp/connect/token/route.ts
+++ b/apps/web/app/api/settings/mcp/connect/token/route.ts
@@ -1,0 +1,114 @@
+import {
+  getMcpServerConfig,
+  McpServerError,
+  recordServerState,
+  setAuthorizationHeader,
+} from "@/lib/mcp-servers";
+import { probeMcpServer } from "@/lib/mcp-probe";
+import { trackServer } from "@/lib/telemetry";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+type ConnectTokenBody = {
+  key?: unknown;
+  authToken?: unknown;
+};
+
+function jsonError(message: string, status: number): Response {
+  return Response.json({ error: message }, { status });
+}
+
+function formatBearerHeader(rawToken: string): string {
+  const tokenWithoutPrefix = rawToken.replace(/^Bearer\s+/iu, "").trim();
+  return `Bearer ${tokenWithoutPrefix}`;
+}
+
+export async function POST(req: Request): Promise<Response> {
+  let body: ConnectTokenBody;
+  try {
+    body = (await req.json()) as ConnectTokenBody;
+  } catch {
+    return jsonError("Invalid JSON body.", 400);
+  }
+
+  if (typeof body.key !== "string") {
+    return jsonError("Field 'key' must be a string.", 400);
+  }
+  if (typeof body.authToken !== "string" || !body.authToken.trim()) {
+    return jsonError("Field 'authToken' must be a non-empty string.", 400);
+  }
+
+  const tokenHeader = formatBearerHeader(body.authToken);
+  trackServer("mcp_connect_started", {
+    key: body.key,
+    method: "token",
+  });
+
+  try {
+    setAuthorizationHeader(body.key, tokenHeader);
+  } catch (err) {
+    if (err instanceof McpServerError) {
+      return jsonError(err.message, err.status);
+    }
+    return jsonError(
+      err instanceof Error ? err.message : "Failed to update MCP server auth.",
+      500,
+    );
+  }
+
+  const serverConfig = getMcpServerConfig(body.key);
+  if (!serverConfig) {
+    return jsonError(`MCP server '${body.key}' was not found.`, 404);
+  }
+
+  // Re-probe with the new token so the row's state reflects reality. If the
+  // token is wrong the row will land in `needs_auth` again and the UI can
+  // surface the error message from the server.
+  const result = await probeMcpServer({
+    url: serverConfig.url,
+    headers: serverConfig.headers,
+  });
+
+  let entry;
+  try {
+    entry = recordServerState(body.key, {
+      state: result.status,
+      toolCount: result.toolCount,
+      detail: result.detail,
+      checkedAt: result.checkedAt,
+    });
+  } catch (err) {
+    if (err instanceof McpServerError) {
+      return jsonError(err.message, err.status);
+    }
+    return jsonError(
+      err instanceof Error ? err.message : "Failed to record probe result.",
+      500,
+    );
+  }
+
+  trackServer("mcp_server_token_set", {
+    key: body.key,
+    probe_status: result.status,
+  });
+  trackServer(
+    result.status === "connected" ? "mcp_connect_completed" : "mcp_connect_failed",
+    {
+      key: body.key,
+      method: "token",
+      ...(result.status === "connected" ? {} : { reason: result.status }),
+    },
+  );
+
+  return Response.json({
+    server: entry,
+    probe: {
+      status: result.status,
+      toolCount: result.toolCount,
+      detail: result.detail,
+      checkedAt: result.checkedAt,
+      httpStatus: result.httpStatus,
+    },
+  });
+}

--- a/apps/web/app/api/settings/mcp/probe/route.test.ts
+++ b/apps/web/app/api/settings/mcp/probe/route.test.ts
@@ -1,0 +1,319 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/mcp-servers", () => {
+  class MockMcpServerError extends Error {
+    status: number;
+
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = "McpServerError";
+      this.status = status;
+    }
+  }
+
+  return {
+    getMcpServerConfig: vi.fn(),
+    recordServerState: vi.fn(),
+    setAuthorizationHeader: vi.fn(),
+    McpServerError: MockMcpServerError,
+  };
+});
+
+vi.mock("@/lib/mcp-probe", () => ({
+  probeMcpServer: vi.fn(),
+}));
+
+vi.mock("@/lib/mcp-oauth", () => ({
+  computeTokenExpiresAt: vi.fn(() => "2026-04-29T01:00:00.000Z"),
+  discoverOAuthMetadata: vi.fn(),
+  refreshAccessToken: vi.fn(),
+}));
+
+vi.mock("@/lib/mcp-secrets", () => ({
+  getMcpServerSecret: vi.fn(),
+  setMcpServerSecret: vi.fn(),
+}));
+
+vi.mock("@/lib/telemetry", () => ({
+  trackServer: vi.fn(),
+}));
+
+const {
+  getMcpServerConfig,
+  McpServerError,
+  recordServerState,
+  setAuthorizationHeader,
+} = await import("@/lib/mcp-servers");
+const { probeMcpServer } = await import("@/lib/mcp-probe");
+const {
+  discoverOAuthMetadata,
+  refreshAccessToken,
+} = await import("@/lib/mcp-oauth");
+const { getMcpServerSecret, setMcpServerSecret } = await import("@/lib/mcp-secrets");
+const { trackServer } = await import("@/lib/telemetry");
+const { POST } = await import("./route");
+
+const mockedGetMcpServerConfig = vi.mocked(getMcpServerConfig);
+const mockedProbeMcpServer = vi.mocked(probeMcpServer);
+const mockedRecordServerState = vi.mocked(recordServerState);
+const mockedSetAuthorizationHeader = vi.mocked(setAuthorizationHeader);
+const mockedDiscoverOAuthMetadata = vi.mocked(discoverOAuthMetadata);
+const mockedRefreshAccessToken = vi.mocked(refreshAccessToken);
+const mockedGetMcpServerSecret = vi.mocked(getMcpServerSecret);
+const mockedSetMcpServerSecret = vi.mocked(setMcpServerSecret);
+const mockedTrackServer = vi.mocked(trackServer);
+
+describe("POST /api/settings/mcp/probe", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("validates key field", async () => {
+    const response = await POST(new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: 123 }),
+    }));
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 404 when the server doesn't exist", async () => {
+    mockedGetMcpServerConfig.mockReturnValue(null);
+    const response = await POST(new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "missing" }),
+    }));
+    expect(response.status).toBe(404);
+  });
+
+  it("propagates McpServerError status from getMcpServerConfig", async () => {
+    mockedGetMcpServerConfig.mockImplementation(() => {
+      throw new McpServerError(400, "Field 'key' must use only letters, numbers, hyphens, or underscores.");
+    });
+    const response = await POST(new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "bad key" }),
+    }));
+    expect(response.status).toBe(400);
+  });
+
+  it("probes and records state on success", async () => {
+    mockedGetMcpServerConfig.mockReturnValue({
+      url: "https://mcp.example.com",
+      transport: "streamable-http",
+      headers: { Authorization: "Bearer abc" },
+    });
+    mockedProbeMcpServer.mockResolvedValue({
+      status: "connected",
+      toolCount: 4,
+      authChallenge: null,
+      detail: "Connected. 4 tools available.",
+      checkedAt: "2026-04-29T00:00:00.000Z",
+      httpStatus: 200,
+    });
+    mockedRecordServerState.mockReturnValue({
+      key: "acme",
+      url: "https://mcp.example.com",
+      transport: "streamable-http",
+      hasAuth: true,
+      state: "connected",
+      toolCount: 4,
+      lastCheckedAt: "2026-04-29T00:00:00.000Z",
+      lastDetail: "Connected. 4 tools available.",
+    });
+
+    const response = await POST(new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "acme" }),
+    }));
+    const body = await response.json();
+
+    expect(mockedProbeMcpServer).toHaveBeenCalledWith({
+      url: "https://mcp.example.com",
+      headers: { Authorization: "Bearer abc" },
+    });
+    expect(mockedRecordServerState).toHaveBeenCalledWith("acme", {
+      state: "connected",
+      toolCount: 4,
+      detail: "Connected. 4 tools available.",
+      checkedAt: "2026-04-29T00:00:00.000Z",
+    });
+    expect(response.status).toBe(200);
+    expect(body.server).toMatchObject({ state: "connected", toolCount: 4 });
+    expect(body.probe.status).toBe("connected");
+  });
+
+  it("refreshes the OAuth token after invalid_token and re-probes", async () => {
+    mockedGetMcpServerConfig
+      .mockReturnValueOnce({
+        url: "https://mcp.example.com",
+        transport: "streamable-http",
+        headers: { Authorization: "Bearer expired" },
+      })
+      .mockReturnValueOnce({
+        url: "https://mcp.example.com",
+        transport: "streamable-http",
+        headers: { Authorization: "Bearer fresh" },
+      });
+    mockedProbeMcpServer
+      .mockResolvedValueOnce({
+        status: "needs_auth",
+        toolCount: null,
+        authChallenge: {
+          scheme: "Bearer",
+          realm: null,
+          resourceMetadataUrl: "https://mcp.example.com/.well-known/oauth-protected-resource",
+          scope: null,
+          errorCode: "invalid_token",
+          errorDescription: "expired",
+        },
+        detail: "expired",
+        checkedAt: "2026-04-29T00:00:00.000Z",
+        httpStatus: 401,
+      })
+      .mockResolvedValueOnce({
+        status: "connected",
+        toolCount: 8,
+        authChallenge: null,
+        detail: "Connected. 8 tools available.",
+        checkedAt: "2026-04-29T00:00:01.000Z",
+        httpStatus: 200,
+      });
+    mockedGetMcpServerSecret.mockReturnValue({
+      clientId: "client-123",
+      clientSecret: null,
+      refreshToken: "refresh-123",
+      tokenExpiresAt: null,
+      asMetadataUrl: "https://mcp.example.com/.well-known/oauth-protected-resource",
+      authServerIssuer: "https://auth.example.com",
+      registeredRedirectUri: "http://localhost:3100/api/settings/mcp/connect/callback",
+      codeVerifier: null,
+      oauthState: null,
+      redirectUri: null,
+      scope: "mcp:read",
+    });
+    mockedDiscoverOAuthMetadata.mockResolvedValue({
+      resource: {
+        resource: "https://mcp.example.com",
+        authorizationServers: ["https://auth.example.com"],
+        scopesSupported: ["mcp:read"],
+        bearerMethodsSupported: ["header"],
+      },
+      authServer: {
+        issuer: "https://auth.example.com",
+        authorizationEndpoint: "https://auth.example.com/authorize",
+        tokenEndpoint: "https://auth.example.com/token",
+        registrationEndpoint: "https://auth.example.com/register",
+        scopesSupported: ["mcp:read"],
+        responseTypesSupported: ["code"],
+        grantTypesSupported: ["authorization_code"],
+        codeChallengeMethodsSupported: ["S256"],
+        tokenEndpointAuthMethodsSupported: ["none"],
+      },
+    });
+    mockedRefreshAccessToken.mockResolvedValue({
+      accessToken: "fresh",
+      tokenType: "Bearer",
+      refreshToken: "refresh-456",
+      expiresIn: 3600,
+      scope: "mcp:read",
+    });
+    mockedRecordServerState.mockReturnValue({
+      key: "acme",
+      url: "https://mcp.example.com",
+      transport: "streamable-http",
+      hasAuth: true,
+      state: "connected",
+      toolCount: 8,
+      lastCheckedAt: "2026-04-29T00:00:01.000Z",
+      lastDetail: "Connected. 8 tools available.",
+    });
+
+    const response = await POST(new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "acme" }),
+    }));
+    const body = await response.json();
+
+    expect(mockedSetAuthorizationHeader).toHaveBeenCalledWith("acme", "Bearer fresh");
+    expect(mockedSetMcpServerSecret).toHaveBeenCalledWith("acme", expect.objectContaining({
+      refreshToken: "refresh-456",
+      tokenExpiresAt: "2026-04-29T01:00:00.000Z",
+    }));
+    expect(mockedProbeMcpServer).toHaveBeenCalledTimes(2);
+    expect(body.probe.status).toBe("connected");
+    expect(body.probe.toolCount).toBe(8);
+    expect(mockedTrackServer).toHaveBeenCalledWith("mcp_probe_refreshed", {
+      key: "acme",
+      success: true,
+    });
+  });
+
+  it("clears the refresh token and keeps needs_auth when refresh fails", async () => {
+    mockedGetMcpServerConfig.mockReturnValue({
+      url: "https://mcp.example.com",
+      transport: "streamable-http",
+      headers: { Authorization: "Bearer expired" },
+    });
+    mockedProbeMcpServer.mockResolvedValue({
+      status: "needs_auth",
+      toolCount: null,
+      authChallenge: {
+        scheme: "Bearer",
+        realm: null,
+        resourceMetadataUrl: "https://mcp.example.com/.well-known/oauth-protected-resource",
+        scope: null,
+        errorCode: "invalid_token",
+        errorDescription: "expired",
+      },
+      detail: "expired",
+      checkedAt: "2026-04-29T00:00:00.000Z",
+      httpStatus: 401,
+    });
+    mockedGetMcpServerSecret.mockReturnValue({
+      clientId: "client-123",
+      clientSecret: null,
+      refreshToken: "refresh-123",
+      tokenExpiresAt: null,
+      asMetadataUrl: "https://mcp.example.com/.well-known/oauth-protected-resource",
+      authServerIssuer: "https://auth.example.com",
+      registeredRedirectUri: "http://localhost:3100/api/settings/mcp/connect/callback",
+      codeVerifier: null,
+      oauthState: null,
+      redirectUri: null,
+      scope: "mcp:read",
+    });
+    mockedDiscoverOAuthMetadata.mockRejectedValue(new Error("refresh metadata failed"));
+    mockedRecordServerState.mockReturnValue({
+      key: "acme",
+      url: "https://mcp.example.com",
+      transport: "streamable-http",
+      hasAuth: true,
+      state: "needs_auth",
+      toolCount: null,
+      lastCheckedAt: "2026-04-29T00:00:00.000Z",
+      lastDetail: "refresh metadata failed",
+    });
+
+    const response = await POST(new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "acme" }),
+    }));
+    const body = await response.json();
+
+    expect(mockedSetMcpServerSecret).toHaveBeenCalledWith("acme", {
+      refreshToken: null,
+      tokenExpiresAt: null,
+    });
+    expect(mockedRecordServerState).toHaveBeenCalledWith("acme", expect.objectContaining({
+      state: "needs_auth",
+      detail: "refresh metadata failed",
+    }));
+    expect(body.probe.status).toBe("needs_auth");
+  });
+});

--- a/apps/web/app/api/settings/mcp/probe/route.ts
+++ b/apps/web/app/api/settings/mcp/probe/route.ts
@@ -1,0 +1,158 @@
+import {
+  getMcpServerConfig,
+  McpServerError,
+  recordServerState,
+  setAuthorizationHeader,
+} from "@/lib/mcp-servers";
+import {
+  computeTokenExpiresAt,
+  discoverOAuthMetadata,
+  refreshAccessToken,
+  type RegisteredClient,
+} from "@/lib/mcp-oauth";
+import { probeMcpServer } from "@/lib/mcp-probe";
+import { getMcpServerSecret, setMcpServerSecret } from "@/lib/mcp-secrets";
+import { trackServer } from "@/lib/telemetry";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+type ProbeBody = {
+  key?: unknown;
+};
+
+function jsonError(message: string, status: number): Response {
+  return Response.json({ error: message }, { status });
+}
+
+async function tryRefreshAfterInvalidToken(key: string): Promise<{
+  refreshed: boolean;
+  detail: string | null;
+}> {
+  const cached = getMcpServerSecret(key);
+  if (!cached?.refreshToken || !cached.clientId || !cached.asMetadataUrl) {
+    return { refreshed: false, detail: "No refresh token is available." };
+  }
+
+  try {
+    const discovered = await discoverOAuthMetadata(cached.asMetadataUrl);
+    const client: RegisteredClient = {
+      clientId: cached.clientId,
+      clientSecret: cached.clientSecret,
+      registrationAccessToken: null,
+      registrationClientUri: null,
+    };
+    const token = await refreshAccessToken({
+      asMetadata: discovered.authServer,
+      client,
+      refreshToken: cached.refreshToken,
+      scope: cached.scope,
+      resource: discovered.resource.resource,
+    });
+
+    setAuthorizationHeader(key, `${token.tokenType} ${token.accessToken}`);
+    setMcpServerSecret(key, {
+      refreshToken: token.refreshToken ?? cached.refreshToken,
+      tokenExpiresAt: computeTokenExpiresAt(token.expiresIn),
+      scope: token.scope ?? cached.scope,
+    });
+    trackServer("mcp_probe_refreshed", { key, success: true });
+    return { refreshed: true, detail: null };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : "Token refresh failed.";
+    setMcpServerSecret(key, {
+      refreshToken: null,
+      tokenExpiresAt: null,
+    });
+    trackServer("mcp_probe_refreshed", {
+      key,
+      success: false,
+      reason: detail,
+    });
+    return { refreshed: false, detail };
+  }
+}
+
+export async function POST(req: Request): Promise<Response> {
+  let body: ProbeBody;
+  try {
+    body = (await req.json()) as ProbeBody;
+  } catch {
+    return jsonError("Invalid JSON body.", 400);
+  }
+
+  if (typeof body.key !== "string") {
+    return jsonError("Field 'key' must be a string.", 400);
+  }
+
+  let serverConfig;
+  try {
+    serverConfig = getMcpServerConfig(body.key);
+  } catch (err) {
+    if (err instanceof McpServerError) {
+      return jsonError(err.message, err.status);
+    }
+    return jsonError(
+      err instanceof Error ? err.message : "Failed to load MCP server.",
+      500,
+    );
+  }
+
+  if (!serverConfig) {
+    return jsonError(`MCP server '${body.key}' was not found.`, 404);
+  }
+
+  let result = await probeMcpServer({
+    url: serverConfig.url,
+    headers: serverConfig.headers,
+  });
+
+  const invalidToken = result.status === "needs_auth"
+    && result.authChallenge?.errorCode === "invalid_token";
+
+  if (invalidToken) {
+    const refresh = await tryRefreshAfterInvalidToken(body.key);
+    if (refresh.refreshed) {
+      const refreshedConfig = getMcpServerConfig(body.key);
+      if (refreshedConfig) {
+        result = await probeMcpServer({
+          url: refreshedConfig.url,
+          headers: refreshedConfig.headers,
+        });
+      }
+    } else {
+      result = {
+        ...result,
+        detail: refresh.detail ?? result.detail,
+      };
+    }
+  }
+
+  try {
+    const entry = recordServerState(body.key, {
+      state: result.status,
+      toolCount: result.toolCount,
+      detail: result.detail,
+      checkedAt: result.checkedAt,
+    });
+    return Response.json({
+      server: entry,
+      probe: {
+        status: result.status,
+        toolCount: result.toolCount,
+        detail: result.detail,
+        checkedAt: result.checkedAt,
+        httpStatus: result.httpStatus,
+        authChallenge: result.authChallenge,
+      },
+    });
+  } catch (err) {
+    if (err instanceof McpServerError) {
+      return jsonError(err.message, err.status);
+    }
+    return jsonError(
+      err instanceof Error ? err.message : "Failed to record probe result.",
+      500,
+    );
+  }
+}

--- a/apps/web/app/api/settings/mcp/route.test.ts
+++ b/apps/web/app/api/settings/mcp/route.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { DELETE, GET, POST } from "./route";
 
 vi.mock("@/lib/mcp-servers", () => {
   class MockMcpServerError extends Error {
@@ -16,9 +15,15 @@ vi.mock("@/lib/mcp-servers", () => {
     listMcpServers: vi.fn(),
     addMcpServer: vi.fn(),
     removeMcpServer: vi.fn(),
+    getMcpServerConfig: vi.fn(),
+    recordServerState: vi.fn(),
     McpServerError: MockMcpServerError,
   };
 });
+
+vi.mock("@/lib/mcp-probe", () => ({
+  probeMcpServer: vi.fn(),
+}));
 
 vi.mock("@/lib/telemetry", () => ({
   trackServer: vi.fn(),
@@ -26,16 +31,34 @@ vi.mock("@/lib/telemetry", () => ({
 
 const {
   addMcpServer,
+  getMcpServerConfig,
   listMcpServers,
   McpServerError,
+  recordServerState,
   removeMcpServer,
 } = await import("@/lib/mcp-servers");
+const { probeMcpServer } = await import("@/lib/mcp-probe");
 const { trackServer } = await import("@/lib/telemetry");
+const { DELETE, GET, POST } = await import("./route");
 
 const mockedAddMcpServer = vi.mocked(addMcpServer);
+const mockedGetMcpServerConfig = vi.mocked(getMcpServerConfig);
 const mockedListMcpServers = vi.mocked(listMcpServers);
 const mockedRemoveMcpServer = vi.mocked(removeMcpServer);
+const mockedRecordServerState = vi.mocked(recordServerState);
+const mockedProbeMcpServer = vi.mocked(probeMcpServer);
 const mockedTrackServer = vi.mocked(trackServer);
+
+const baseEntry = {
+  key: "acme",
+  url: "https://mcp.example.com",
+  transport: "streamable-http",
+  hasAuth: false,
+  state: "untested" as const,
+  toolCount: null,
+  lastCheckedAt: null,
+  lastDetail: null,
+};
 
 describe("MCP settings API", () => {
   beforeEach(() => {
@@ -44,12 +67,7 @@ describe("MCP settings API", () => {
 
   it("GET returns configured MCP servers", async () => {
     mockedListMcpServers.mockReturnValue([
-      {
-        key: "acme",
-        url: "https://mcp.example.com",
-        transport: "streamable-http",
-        hasAuth: true,
-      },
+      { ...baseEntry, hasAuth: true, state: "connected", toolCount: 5 },
     ]);
 
     const response = await GET();
@@ -58,10 +76,10 @@ describe("MCP settings API", () => {
     expect(response.status).toBe(200);
     expect(body.servers).toEqual([
       {
-        key: "acme",
-        url: "https://mcp.example.com",
-        transport: "streamable-http",
+        ...baseEntry,
         hasAuth: true,
+        state: "connected",
+        toolCount: 5,
       },
     ]);
   });
@@ -94,12 +112,25 @@ describe("MCP settings API", () => {
     });
   });
 
-  it("POST creates a server and returns it", async () => {
-    mockedAddMcpServer.mockReturnValue({
-      key: "acme",
+  it("POST creates a server, runs an immediate probe, and returns the post-probe entry", async () => {
+    mockedAddMcpServer.mockReturnValue({ ...baseEntry });
+    mockedGetMcpServerConfig.mockReturnValue({
       url: "https://mcp.example.com",
       transport: "streamable-http",
-      hasAuth: true,
+    });
+    mockedProbeMcpServer.mockResolvedValue({
+      status: "needs_auth",
+      toolCount: null,
+      authChallenge: null,
+      detail: "HTTP 401 from MCP server.",
+      checkedAt: "2026-04-29T00:00:00.000Z",
+      httpStatus: 401,
+    });
+    mockedRecordServerState.mockReturnValue({
+      ...baseEntry,
+      state: "needs_auth",
+      lastDetail: "HTTP 401 from MCP server.",
+      lastCheckedAt: "2026-04-29T00:00:00.000Z",
     });
 
     const response = await POST(new Request("http://localhost/api/settings/mcp", {
@@ -108,7 +139,6 @@ describe("MCP settings API", () => {
       body: JSON.stringify({
         key: "acme",
         url: "https://mcp.example.com",
-        authToken: "secret-token",
       }),
     }));
     const body = await response.json();
@@ -118,19 +148,46 @@ describe("MCP settings API", () => {
       key: "acme",
       url: "https://mcp.example.com",
       transport: undefined,
-      authToken: "secret-token",
     });
-    expect(body.server).toEqual({
-      key: "acme",
+    expect(mockedProbeMcpServer).toHaveBeenCalledWith({
       url: "https://mcp.example.com",
-      transport: "streamable-http",
-      hasAuth: true,
+      headers: undefined,
+    });
+    expect(mockedRecordServerState).toHaveBeenCalledWith("acme", {
+      state: "needs_auth",
+      toolCount: null,
+      detail: "HTTP 401 from MCP server.",
+      checkedAt: "2026-04-29T00:00:00.000Z",
+    });
+    expect(body.server).toMatchObject({
+      key: "acme",
+      state: "needs_auth",
+      lastDetail: "HTTP 401 from MCP server.",
     });
     expect(mockedTrackServer).toHaveBeenCalledWith("mcp_server_added", {
       key: "acme",
       transport: "streamable-http",
-      has_auth: true,
+      has_auth: false,
     });
+  });
+
+  it("POST still returns 201 when the post-create probe blows up", async () => {
+    mockedAddMcpServer.mockReturnValue({ ...baseEntry });
+    mockedGetMcpServerConfig.mockReturnValue(null);
+
+    const response = await POST(new Request("http://localhost/api/settings/mcp", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        key: "acme",
+        url: "https://mcp.example.com",
+      }),
+    }));
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.server).toMatchObject({ key: "acme", state: "untested" });
+    expect(mockedProbeMcpServer).not.toHaveBeenCalled();
   });
 
   it("POST returns helper validation errors", async () => {

--- a/apps/web/app/api/settings/mcp/route.ts
+++ b/apps/web/app/api/settings/mcp/route.ts
@@ -1,9 +1,12 @@
 import {
   addMcpServer,
+  getMcpServerConfig,
   listMcpServers,
   McpServerError,
+  recordServerState,
   removeMcpServer,
 } from "@/lib/mcp-servers";
+import { probeMcpServer } from "@/lib/mcp-probe";
 import { trackServer } from "@/lib/telemetry";
 
 export const dynamic = "force-dynamic";
@@ -13,7 +16,6 @@ type PostBody = {
   key?: unknown;
   url?: unknown;
   transport?: unknown;
-  authToken?: unknown;
 };
 
 type DeleteBody = {
@@ -24,7 +26,7 @@ function jsonError(message: string, status: number): Response {
   return Response.json({ error: message }, { status });
 }
 
-export async function GET() {
+export async function GET(): Promise<Response> {
   try {
     return Response.json({
       servers: listMcpServers(),
@@ -37,7 +39,7 @@ export async function GET() {
   }
 }
 
-export async function POST(req: Request) {
+export async function POST(req: Request): Promise<Response> {
   let body: PostBody;
   try {
     body = (await req.json()) as PostBody;
@@ -54,27 +56,23 @@ export async function POST(req: Request) {
   if (body.transport !== undefined && typeof body.transport !== "string") {
     return jsonError("Field 'transport' must be a string.", 400);
   }
-  if (
-    body.authToken !== undefined
-    && body.authToken !== null
-    && typeof body.authToken !== "string"
-  ) {
-    return jsonError("Field 'authToken' must be a string or null.", 400);
-  }
 
+  let server;
   try {
-    const server = addMcpServer({
+    server = addMcpServer({
       key: body.key,
       url: body.url,
       transport: body.transport,
-      authToken: body.authToken,
+      // No authToken at creation time — Connect happens after the row appears,
+      // either via the OAuth flow (Phase 2) or a paste-a-token dialog (Phase 1
+      // fallback). This matches the Cursor UX where the Add dialog only takes
+      // a name + URL.
     });
     trackServer("mcp_server_added", {
       key: server.key,
       transport: server.transport,
       has_auth: server.hasAuth,
     });
-    return Response.json({ server }, { status: 201 });
   } catch (err) {
     if (err instanceof McpServerError) {
       return jsonError(err.message, err.status);
@@ -84,9 +82,36 @@ export async function POST(req: Request) {
       500,
     );
   }
+
+  // Run an immediate probe so the new row lands with the right state. We
+  // intentionally don't fail the POST when the probe fails — the row exists,
+  // the user can click Connect to fix it. The probe just decides whether the
+  // initial label says "Connect", "Needs authentication", or shows a tool
+  // count.
+  const serverConfig = getMcpServerConfig(server.key);
+  if (serverConfig) {
+    const probe = await probeMcpServer({
+      url: serverConfig.url,
+      headers: serverConfig.headers,
+    });
+    try {
+      const updated = recordServerState(server.key, {
+        state: probe.status,
+        toolCount: probe.toolCount,
+        detail: probe.detail,
+        checkedAt: probe.checkedAt,
+      });
+      return Response.json({ server: updated }, { status: 201 });
+    } catch {
+      // If state recording fails for some reason, fall through to returning
+      // the untested entry. The UI can re-probe.
+    }
+  }
+
+  return Response.json({ server }, { status: 201 });
 }
 
-export async function DELETE(req: Request) {
+export async function DELETE(req: Request): Promise<Response> {
   let body: DeleteBody;
   try {
     body = (await req.json()) as DeleteBody;

--- a/apps/web/app/components/settings/connect-mcp-fallback-dialog.tsx
+++ b/apps/web/app/components/settings/connect-mcp-fallback-dialog.tsx
@@ -12,25 +12,39 @@ import {
   DialogTitle,
 } from "../ui/dialog";
 
-export type AddMcpServerInput = {
-  key: string;
-  url: string;
+export type ConnectMcpFallbackInput = {
+  authToken: string;
 };
 
-type AddMcpServerDialogProps = {
+type ConnectMcpFallbackDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onSubmit: (input: AddMcpServerInput) => Promise<string | null>;
+  serverKey: string;
+  serverUrl: string;
+  /**
+   * Called when the user submits a token. Returns an error message string to
+   * display in the dialog, or null on success (which causes the dialog to
+   * close).
+   */
+  onSubmit: (input: ConnectMcpFallbackInput) => Promise<string | null>;
+  /**
+   * If provided, surfaced above the input as context (e.g. the
+   * `WWW-Authenticate` `error_description` from the server). Helps the user
+   * understand why they're being asked for a token.
+   */
+  hint?: string | null;
 };
 
-export function AddMcpServerDialog({
+export function ConnectMcpFallbackDialog({
   open,
   onOpenChange,
+  serverKey,
+  serverUrl,
   onSubmit,
-}: AddMcpServerDialogProps) {
-  const keyInputRef = useRef<HTMLInputElement>(null);
-  const [key, setKey] = useState("");
-  const [url, setUrl] = useState("");
+  hint,
+}: ConnectMcpFallbackDialogProps) {
+  const tokenInputRef = useRef<HTMLInputElement>(null);
+  const [token, setToken] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
@@ -38,20 +52,15 @@ export function AddMcpServerDialog({
     if (!open) {
       return;
     }
-    setKey("");
-    setUrl("");
+    setToken("");
     setError(null);
     setSubmitting(false);
-    setTimeout(() => keyInputRef.current?.focus(), 100);
+    setTimeout(() => tokenInputRef.current?.focus(), 100);
   }, [open]);
 
   const handleSubmit = async () => {
-    if (!key.trim()) {
-      setError("Please enter a server name.");
-      return;
-    }
-    if (!url.trim()) {
-      setError("Please enter a server URL.");
+    if (!token.trim()) {
+      setError("Please enter an access token.");
       return;
     }
 
@@ -59,16 +68,11 @@ export function AddMcpServerDialog({
     setError(null);
 
     try {
-      const submitError = await onSubmit({
-        key: key.trim(),
-        url: url.trim(),
-      });
-
+      const submitError = await onSubmit({ authToken: token.trim() });
       if (submitError) {
         setError(submitError);
         return;
       }
-
       onOpenChange(false);
     } finally {
       setSubmitting(false);
@@ -79,27 +83,54 @@ export function AddMcpServerDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>Add MCP Server</DialogTitle>
+          <DialogTitle>Connect to {serverKey}</DialogTitle>
           <DialogDescription>
-            Connect a remote MCP server over streamable HTTP. After adding it, click
-            Connect on the row to authenticate.
+            Paste an access token for this MCP server. It will be sent as an
+            <code className="mx-1">Authorization: Bearer ...</code>
+            header on every request.
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">
+          <div
+            className="rounded-xl border px-3 py-2 text-xs leading-5"
+            style={{
+              borderColor: "var(--color-border)",
+              background: "var(--color-surface)",
+              color: "var(--color-text-muted)",
+            }}
+          >
+            <div className="text-[11px] uppercase tracking-wide">Endpoint</div>
+            <div className="mt-1 truncate" style={{ color: "var(--color-text)" }} title={serverUrl}>
+              {serverUrl}
+            </div>
+          </div>
+
+          {hint ? (
+            <p
+              className="rounded-lg px-3 py-2 text-xs leading-5"
+              style={{
+                background: "rgba(234, 179, 8, 0.08)",
+                color: "var(--color-text-muted)",
+              }}
+            >
+              Server says: {hint}
+            </p>
+          ) : null}
+
           <div>
             <label
               className="mb-1.5 block text-sm font-medium"
               style={{ color: "var(--color-text-secondary)" }}
             >
-              Server name
+              Access token
             </label>
             <input
-              ref={keyInputRef}
-              type="text"
-              value={key}
+              ref={tokenInputRef}
+              type="password"
+              value={token}
               onChange={(event) => {
-                setKey(event.target.value);
+                setToken(event.target.value);
                 setError(null);
               }}
               onKeyDown={(event) => {
@@ -107,7 +138,7 @@ export function AddMcpServerDialog({
                   void handleSubmit();
                 }
               }}
-              placeholder="e.g. acme-mcp"
+              placeholder="sk-..."
               className="w-full rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]"
               style={{
                 background: "var(--color-bg)",
@@ -116,48 +147,8 @@ export function AddMcpServerDialog({
               }}
             />
             <p className="mt-1 text-xs" style={{ color: "var(--color-text-muted)" }}>
-              Use only letters, numbers, hyphens, or underscores.
+              The <code>Bearer</code> prefix is added automatically.
             </p>
-          </div>
-
-          <div>
-            <label
-              className="mb-1.5 block text-sm font-medium"
-              style={{ color: "var(--color-text-secondary)" }}
-            >
-              Server URL
-            </label>
-            <input
-              type="url"
-              value={url}
-              onChange={(event) => {
-                setUrl(event.target.value);
-                setError(null);
-              }}
-              onKeyDown={(event) => {
-                if (event.key === "Enter" && !submitting) {
-                  void handleSubmit();
-                }
-              }}
-              placeholder="https://mcp.example.com"
-              className="w-full rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]"
-              style={{
-                background: "var(--color-bg)",
-                border: "1px solid var(--color-border)",
-                color: "var(--color-text)",
-              }}
-            />
-          </div>
-
-          <div
-            className="rounded-xl border px-3 py-2 text-xs"
-            style={{
-              borderColor: "var(--color-border)",
-              background: "var(--color-surface)",
-              color: "var(--color-text-muted)",
-            }}
-          >
-            Transport: <span style={{ color: "var(--color-text)" }}>streamable-http</span>
           </div>
 
           {error && (
@@ -184,13 +175,13 @@ export function AddMcpServerDialog({
           <Button
             type="button"
             onClick={() => void handleSubmit()}
-            disabled={submitting || !key.trim() || !url.trim()}
+            disabled={submitting || !token.trim()}
             className="rounded-lg px-5"
             style={{ background: "var(--color-accent)", color: "var(--color-bg)" }}
           >
             <span className="inline-flex items-center gap-2">
               {submitting ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> : null}
-              <span>{submitting ? "Adding..." : "Add Server"}</span>
+              <span>{submitting ? "Connecting..." : "Connect"}</span>
             </span>
           </Button>
         </DialogFooter>

--- a/apps/web/app/components/settings/mcp-servers-section.test.tsx
+++ b/apps/web/app/components/settings/mcp-servers-section.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { McpServersSection } from "./mcp-servers-section";
+
+type MockServer = {
+  key: string;
+  url: string;
+  transport: string;
+  hasAuth: boolean;
+  state: "untested" | "connected" | "needs_auth" | "error";
+  toolCount: number | null;
+  lastCheckedAt: string | null;
+  lastDetail: string | null;
+};
+
+function server(state: MockServer["state"] = "untested"): MockServer {
+  return {
+    key: "acme",
+    url: "https://mcp.example.com",
+    transport: "streamable-http",
+    hasAuth: state === "connected",
+    state,
+    toolCount: state === "connected" ? 2 : null,
+    lastCheckedAt: state === "connected" ? "2026-04-29T00:00:00.000Z" : null,
+    lastDetail: state === "connected" ? "Connected. 2 tools available." : null,
+  };
+}
+
+describe("McpServersSection", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+  });
+
+  it("auto-probes again when a deleted server key is re-added", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const method = init?.method ?? "GET";
+
+      if (url === "/api/settings/mcp" && method === "GET") {
+        return Response.json({ servers: [server()] });
+      }
+      if (url === "/api/settings/mcp/probe" && method === "POST") {
+        return Response.json({
+          server: server("connected"),
+          probe: {
+            status: "connected",
+            toolCount: 2,
+            detail: "Connected. 2 tools available.",
+            checkedAt: "2026-04-29T00:00:00.000Z",
+            httpStatus: 200,
+          },
+        });
+      }
+      if (url === "/api/settings/mcp" && method === "DELETE") {
+        return Response.json({ key: "acme" });
+      }
+      if (url === "/api/settings/mcp" && method === "POST") {
+        return Response.json({ server: server() }, { status: 201 });
+      }
+
+      throw new Error(`Unexpected fetch: ${method} ${url}`);
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    const user = userEvent.setup();
+    render(<McpServersSection />);
+
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.filter(([, init]) => init?.method === "POST").length).toBe(1);
+    });
+
+    await user.click(await screen.findByRole("button", { name: "Remove acme" }));
+    await screen.findByText("No MCP servers yet");
+
+    await user.click(screen.getByRole("button", { name: "Add MCP Server" }));
+    await user.type(screen.getByPlaceholderText("e.g. acme-mcp"), "acme");
+    await user.type(screen.getByPlaceholderText("https://mcp.example.com"), "https://mcp.example.com");
+    await user.click(screen.getByRole("button", { name: "Add Server" }));
+
+    await waitFor(() => {
+      const probeCalls = fetchMock.mock.calls.filter(([input, init]) => {
+        const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        return url === "/api/settings/mcp/probe" && init?.method === "POST";
+      });
+      expect(probeCalls).toHaveLength(2);
+    });
+  });
+});

--- a/apps/web/app/components/settings/mcp-servers-section.tsx
+++ b/apps/web/app/components/settings/mcp-servers-section.tsx
@@ -191,6 +191,7 @@ export function McpServersSection() {
 
       const payload = await response.json() as { server?: McpServerEntry };
       if (payload.server) {
+        hydratedProbeKeysRef.current.delete(payload.server.key);
         setServers((current) => upsertServer(current, payload.server as McpServerEntry));
       } else {
         await fetchServers();

--- a/apps/web/app/components/settings/mcp-servers-section.tsx
+++ b/apps/web/app/components/settings/mcp-servers-section.tsx
@@ -1,15 +1,35 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import { Loader2, Plus, Server, ShieldCheck, ShieldOff, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Loader2,
+  Plus,
+  RotateCcw,
+  Server,
+  ShieldCheck,
+  ShieldOff,
+  Trash2,
+} from "lucide-react";
 import { Button } from "../ui/button";
 import { AddMcpServerDialog, type AddMcpServerInput } from "./add-mcp-server-dialog";
+import {
+  ConnectMcpFallbackDialog,
+  type ConnectMcpFallbackInput,
+} from "./connect-mcp-fallback-dialog";
+
+type McpServerState = "untested" | "connected" | "needs_auth" | "error";
 
 type McpServerEntry = {
   key: string;
   url: string;
   transport: string;
   hasAuth: boolean;
+  state: McpServerState;
+  toolCount: number | null;
+  lastCheckedAt: string | null;
+  lastDetail: string | null;
 };
 
 type ActionNotice = {
@@ -41,7 +61,87 @@ async function readErrorMessage(response: Response, fallback: string): Promise<s
 }
 
 function sortServers(servers: McpServerEntry[]): McpServerEntry[] {
-  return [...servers].sort((a, b) => a.key.localeCompare(b.key));
+  return [...servers].toSorted((a, b) => a.key.localeCompare(b.key));
+}
+
+function upsertServer(
+  servers: McpServerEntry[],
+  next: McpServerEntry,
+): McpServerEntry[] {
+  const without = servers.filter((entry) => entry.key !== next.key);
+  return sortServers([...without, next]);
+}
+
+type ConnectTarget = {
+  serverKey: string;
+  serverUrl: string;
+  hint: string | null;
+};
+
+type OAuthCallbackMessage = {
+  source?: unknown;
+  type?: unknown;
+  serverKey?: unknown;
+  reason?: unknown;
+  description?: unknown;
+};
+
+const OAUTH_POPUP_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Wait for the OAuth callback page to postMessage back, the popup to close
+ * (user dismissed without completing), or a timeout. Resolves either way —
+ * the caller probes the server afterward to figure out what actually
+ * happened.
+ */
+async function waitForOAuthOutcome(serverKey: string, popup: Window): Promise<void> {
+  return await new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      window.removeEventListener("message", handleMessage);
+      clearInterval(closedPoll);
+      clearTimeout(timeout);
+      resolve();
+    };
+
+    const handleMessage = (event: MessageEvent) => {
+      if (event.source !== popup) {
+        return;
+      }
+      const data = event.data as OAuthCallbackMessage | null;
+      if (!data || data.source !== "denchclaw.mcp.connect") {
+        return;
+      }
+      if (typeof data.serverKey !== "string" || data.serverKey !== serverKey) {
+        return;
+      }
+      try {
+        popup.close();
+      } catch {
+        // ignore
+      }
+      finish();
+    };
+
+    window.addEventListener("message", handleMessage);
+    const closedPoll = window.setInterval(() => {
+      if (popup.closed) {
+        finish();
+      }
+    }, 500);
+    const timeout = window.setTimeout(() => {
+      try {
+        popup.close();
+      } catch {
+        // ignore
+      }
+      finish();
+    }, OAUTH_POPUP_TIMEOUT_MS);
+  });
 }
 
 export function McpServersSection() {
@@ -50,7 +150,10 @@ export function McpServersSection() {
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<ActionNotice | null>(null);
   const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const [connectTarget, setConnectTarget] = useState<ConnectTarget | null>(null);
   const [deletingKey, setDeletingKey] = useState<string | null>(null);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const hydratedProbeKeysRef = useRef<Set<string>>(new Set());
 
   const fetchServers = useCallback(async () => {
     setLoading(true);
@@ -88,16 +191,219 @@ export function McpServersSection() {
 
       const payload = await response.json() as { server?: McpServerEntry };
       if (payload.server) {
-        setServers((current) => sortServers([...current, payload.server as McpServerEntry]));
+        setServers((current) => upsertServer(current, payload.server as McpServerEntry));
       } else {
         await fetchServers();
       }
-      setNotice({ tone: "success", message: `Added MCP server '${input.key}'.` });
+      setNotice({
+        tone: "success",
+        message: `Added MCP server '${input.key}'. Click Connect to authenticate.`,
+      });
       return null;
     } catch (err) {
       return err instanceof Error ? err.message : "Failed to add MCP server.";
     }
   }, [fetchServers]);
+
+  const handleProbeServer = useCallback(async (server: McpServerEntry) => {
+    setBusyKey(server.key);
+    setNotice(null);
+    try {
+      const response = await fetch("/api/settings/mcp/probe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ key: server.key }),
+      });
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response, "Probe failed."));
+      }
+      const payload = await response.json() as { server?: McpServerEntry };
+      if (payload.server) {
+        setServers((current) => upsertServer(current, payload.server as McpServerEntry));
+      }
+    } catch (err) {
+      setNotice({
+        tone: "error",
+        message: err instanceof Error ? err.message : "Probe failed.",
+      });
+    } finally {
+      setBusyKey(null);
+    }
+  }, []);
+
+  const openFallbackDialog = useCallback((server: McpServerEntry, hint: string | null) => {
+    setConnectTarget({
+      serverKey: server.key,
+      serverUrl: server.url,
+      hint,
+    });
+  }, []);
+
+  const refreshServer = useCallback(async (
+    serverKey: string,
+    options?: { showSuccessNotice?: boolean },
+  ) => {
+    try {
+      const response = await fetch("/api/settings/mcp/probe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ key: serverKey }),
+      });
+      if (!response.ok) {
+        return;
+      }
+      const payload = await response.json() as { server?: McpServerEntry };
+      if (payload.server) {
+        setServers((current) => upsertServer(current, payload.server as McpServerEntry));
+        if (options?.showSuccessNotice !== false && payload.server.state === "connected") {
+          setNotice({
+            tone: "success",
+            message: `Connected '${serverKey}'.`,
+          });
+        }
+      }
+    } catch {
+      // ignore — the row state will surface the error on the next probe
+    }
+  }, []);
+
+  useEffect(() => {
+    const currentKeys = new Set(servers.map((server) => server.key));
+    for (const hydratedKey of hydratedProbeKeysRef.current) {
+      if (!currentKeys.has(hydratedKey)) {
+        hydratedProbeKeysRef.current.delete(hydratedKey);
+      }
+    }
+
+    if (loading || servers.length === 0) {
+      return;
+    }
+
+    for (const server of servers) {
+      if (hydratedProbeKeysRef.current.has(server.key)) {
+        continue;
+      }
+      hydratedProbeKeysRef.current.add(server.key);
+      void refreshServer(server.key, { showSuccessNotice: false });
+    }
+  }, [loading, refreshServer, servers]);
+
+  const handleConnectClick = useCallback(
+    async (server: McpServerEntry): Promise<void> => {
+      setBusyKey(server.key);
+      setNotice(null);
+
+      try {
+        const response = await fetch("/api/settings/mcp/connect/start", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ key: server.key }),
+        });
+        if (!response.ok) {
+          const message = await readErrorMessage(response, "Failed to start Connect.");
+          openFallbackDialog(server, message);
+          return;
+        }
+        const payload = await response.json() as {
+          supportsOAuth?: boolean;
+          alreadyConnected?: boolean;
+          authorizationUrl?: string;
+          reason?: string;
+          server?: McpServerEntry;
+        };
+
+        if (payload.alreadyConnected && payload.server) {
+          setServers((current) => upsertServer(current, payload.server as McpServerEntry));
+          setNotice({
+            tone: "success",
+            message: `'${server.key}' is already connected.`,
+          });
+          return;
+        }
+
+        if (payload.supportsOAuth === false) {
+          openFallbackDialog(server, payload.reason ?? server.lastDetail);
+          return;
+        }
+
+        if (!payload.authorizationUrl) {
+          openFallbackDialog(server, "OAuth start did not return an authorization URL.");
+          return;
+        }
+
+        // Open the AS authorization URL in a popup. The callback page will
+        // postMessage back to us when it's done.
+        const popup = window.open(
+          payload.authorizationUrl,
+          `mcp-connect-${server.key}`,
+          "popup=yes,width=520,height=720,noopener=no",
+        );
+        if (!popup) {
+          openFallbackDialog(
+            server,
+            "The browser blocked the OAuth popup. Allow popups and try again, or paste a token instead.",
+          );
+          return;
+        }
+
+        await waitForOAuthOutcome(server.key, popup);
+        await refreshServer(server.key);
+      } catch (err) {
+        openFallbackDialog(
+          server,
+          err instanceof Error ? err.message : "Connect failed.",
+        );
+      } finally {
+        setBusyKey(null);
+      }
+    },
+    [openFallbackDialog, refreshServer],
+  );
+
+  const handleConnectSubmit = useCallback(
+    async (input: ConnectMcpFallbackInput) => {
+      if (!connectTarget) {
+        return "No server selected.";
+      }
+      try {
+        const response = await fetch("/api/settings/mcp/connect/token", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            key: connectTarget.serverKey,
+            authToken: input.authToken,
+          }),
+        });
+        if (!response.ok) {
+          return await readErrorMessage(response, "Failed to connect.");
+        }
+        const payload = await response.json() as {
+          server?: McpServerEntry;
+          probe?: { status?: McpServerState; detail?: string };
+        };
+        if (payload.server) {
+          setServers((current) => upsertServer(current, payload.server as McpServerEntry));
+        }
+
+        const probeStatus = payload.probe?.status;
+        if (probeStatus === "connected") {
+          setNotice({
+            tone: "success",
+            message: `Connected to '${connectTarget.serverKey}'.`,
+          });
+          return null;
+        }
+
+        // The token was saved but the probe said it didn't grant access.
+        // Show the server's hint inline instead of closing the dialog.
+        return payload.probe?.detail
+          ?? "The token was saved but the server still rejected the connection.";
+      } catch (err) {
+        return err instanceof Error ? err.message : "Failed to connect.";
+      }
+    },
+    [connectTarget],
+  );
 
   const handleDeleteServer = useCallback(async (server: McpServerEntry) => {
     const confirmed = window.confirm(`Remove MCP server '${server.key}'?`);
@@ -205,87 +511,17 @@ export function McpServersSection() {
         </div>
       ) : (
         <div className="space-y-3">
-          {servers.map((server) => {
-            const isDeleting = deletingKey === server.key;
-            return (
-              <div
-                key={server.key}
-                className="rounded-xl border px-4 py-4"
-                style={{
-                  borderColor: "var(--color-border)",
-                  background: "var(--color-surface)",
-                }}
-              >
-                <div className="flex items-start justify-between gap-4">
-                  <div className="flex min-w-0 gap-3">
-                    <div
-                      className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg"
-                      style={{ background: "var(--color-surface-hover)", color: "var(--color-text)" }}
-                    >
-                      <Server className="h-5 w-5" aria-hidden />
-                    </div>
-                    <div className="min-w-0">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <div className="truncate text-sm font-medium" style={{ color: "var(--color-text)" }}>
-                          {server.key}
-                        </div>
-                        <span
-                          className="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium"
-                          style={{
-                            background: "var(--color-surface-hover)",
-                            color: "var(--color-text)",
-                          }}
-                        >
-                          {server.transport}
-                        </span>
-                        <span
-                          className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium"
-                          style={{
-                            background: "var(--color-surface-hover)",
-                            color: "var(--color-text)",
-                          }}
-                        >
-                          {server.hasAuth ? (
-                            <ShieldCheck className="h-3 w-3" aria-hidden />
-                          ) : (
-                            <ShieldOff className="h-3 w-3" aria-hidden />
-                          )}
-                          <span>{server.hasAuth ? "Authenticated" : "No auth"}</span>
-                        </span>
-                      </div>
-                      <p className="mt-2 text-[11px] uppercase tracking-wide" style={{ color: "var(--color-text-muted)" }}>
-                        Remote endpoint
-                      </p>
-                      <div
-                        className="mt-1 truncate text-xs leading-5"
-                        style={{ color: "var(--color-text-muted)" }}
-                        title={server.url}
-                      >
-                        {server.url}
-                      </div>
-                    </div>
-                  </div>
-
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="shrink-0 rounded-lg"
-                    onClick={() => void handleDeleteServer(server)}
-                    disabled={isDeleting}
-                    aria-label={`Remove ${server.key}`}
-                    style={{ color: "var(--color-text-muted)" }}
-                  >
-                    {isDeleting ? (
-                      <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-                    ) : (
-                      <Trash2 className="h-4 w-4" aria-hidden />
-                    )}
-                  </Button>
-                </div>
-              </div>
-            );
-          })}
+          {servers.map((server) => (
+            <McpServerRow
+              key={server.key}
+              server={server}
+              busy={busyKey === server.key}
+              deleting={deletingKey === server.key}
+              onConnect={() => handleConnectClick(server)}
+              onRetry={() => void handleProbeServer(server)}
+              onDelete={() => void handleDeleteServer(server)}
+            />
+          ))}
         </div>
       )}
 
@@ -294,6 +530,255 @@ export function McpServersSection() {
         onOpenChange={setAddDialogOpen}
         onSubmit={handleAddServer}
       />
+
+      {connectTarget ? (
+        <ConnectMcpFallbackDialog
+          open={Boolean(connectTarget)}
+          onOpenChange={(open) => {
+            if (!open) {
+              setConnectTarget(null);
+            }
+          }}
+          serverKey={connectTarget.serverKey}
+          serverUrl={connectTarget.serverUrl}
+          hint={connectTarget.hint}
+          onSubmit={handleConnectSubmit}
+        />
+      ) : null}
     </div>
+  );
+}
+
+type McpServerRowProps = {
+  server: McpServerEntry;
+  busy: boolean;
+  deleting: boolean;
+  onConnect: () => void;
+  onRetry: () => void;
+  onDelete: () => void;
+};
+
+function McpServerRow({
+  server,
+  busy,
+  deleting,
+  onConnect,
+  onRetry,
+  onDelete,
+}: McpServerRowProps) {
+  return (
+    <div
+      className="rounded-xl border px-4 py-4"
+      style={{
+        borderColor: "var(--color-border)",
+        background: "var(--color-surface)",
+      }}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex min-w-0 gap-3">
+          <div
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg"
+            style={{ background: "var(--color-surface-hover)", color: "var(--color-text)" }}
+          >
+            <Server className="h-5 w-5" aria-hidden />
+          </div>
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="truncate text-sm font-medium" style={{ color: "var(--color-text)" }}>
+                {server.key}
+              </div>
+              <ServerStateBadge server={server} />
+              <span
+                className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium"
+                style={{
+                  background: "var(--color-surface-hover)",
+                  color: "var(--color-text)",
+                }}
+              >
+                {server.hasAuth ? (
+                  <ShieldCheck className="h-3 w-3" aria-hidden />
+                ) : (
+                  <ShieldOff className="h-3 w-3" aria-hidden />
+                )}
+                <span>{server.hasAuth ? "Authenticated" : "No auth"}</span>
+              </span>
+            </div>
+            <p className="mt-2 text-[11px] uppercase tracking-wide" style={{ color: "var(--color-text-muted)" }}>
+              Remote endpoint
+            </p>
+            <div
+              className="mt-1 truncate text-xs leading-5"
+              style={{ color: "var(--color-text-muted)" }}
+              title={server.url}
+            >
+              {server.url}
+            </div>
+            {server.lastDetail && server.state !== "connected" ? (
+              <div
+                className="mt-2 text-xs leading-5"
+                style={{ color: "var(--color-text-muted)" }}
+                title={server.lastDetail}
+              >
+                {server.lastDetail}
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-2">
+          <ServerActionButton
+            server={server}
+            busy={busy}
+            onConnect={onConnect}
+            onRetry={onRetry}
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="rounded-lg"
+            onClick={onDelete}
+            disabled={deleting}
+            aria-label={`Remove ${server.key}`}
+            style={{ color: "var(--color-text-muted)" }}
+          >
+            {deleting ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+            ) : (
+              <Trash2 className="h-4 w-4" aria-hidden />
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ServerStateBadge({ server }: { server: McpServerEntry }) {
+  const baseClass = "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium";
+
+  if (server.state === "connected") {
+    const count = server.toolCount ?? 0;
+    return (
+      <span
+        className={baseClass}
+        style={{
+          background: "rgba(16, 185, 129, 0.12)",
+          color: "rgb(110, 231, 183)",
+        }}
+      >
+        <CheckCircle2 className="h-3 w-3" aria-hidden />
+        <span>
+          {count} tool{count === 1 ? "" : "s"} enabled
+        </span>
+      </span>
+    );
+  }
+
+  if (server.state === "needs_auth") {
+    return (
+      <span
+        className={baseClass}
+        style={{
+          background: "rgba(234, 179, 8, 0.12)",
+          color: "rgb(252, 211, 77)",
+        }}
+      >
+        <ShieldOff className="h-3 w-3" aria-hidden />
+        <span>Needs authentication</span>
+      </span>
+    );
+  }
+
+  if (server.state === "error") {
+    return (
+      <span
+        className={baseClass}
+        style={{
+          background: "rgba(239, 68, 68, 0.12)",
+          color: "rgb(252, 165, 165)",
+        }}
+      >
+        <AlertTriangle className="h-3 w-3" aria-hidden />
+        <span>Error</span>
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={baseClass}
+      style={{
+        background: "var(--color-surface-hover)",
+        color: "var(--color-text-muted)",
+      }}
+    >
+      {server.transport}
+    </span>
+  );
+}
+
+type ServerActionButtonProps = {
+  server: McpServerEntry;
+  busy: boolean;
+  onConnect: () => void;
+  onRetry: () => void;
+};
+
+function ServerActionButton({ server, busy, onConnect, onRetry }: ServerActionButtonProps) {
+  if (server.state === "connected") {
+    return (
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="rounded-lg"
+        onClick={onRetry}
+        disabled={busy}
+        aria-label={`Re-check ${server.key}`}
+        style={{ color: "var(--color-text-muted)" }}
+      >
+        {busy ? (
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+        ) : (
+          <RotateCcw className="h-4 w-4" aria-hidden />
+        )}
+      </Button>
+    );
+  }
+
+  if (server.state === "error") {
+    return (
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="rounded-lg"
+        onClick={onRetry}
+        disabled={busy}
+      >
+        {busy ? (
+          <Loader2 className="mr-1 h-4 w-4 animate-spin" aria-hidden />
+        ) : null}
+        Retry
+      </Button>
+    );
+  }
+
+  // needs_auth or untested → Connect
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="rounded-lg"
+      onClick={onConnect}
+      disabled={busy}
+    >
+      {busy ? (
+        <Loader2 className="mr-1 h-4 w-4 animate-spin" aria-hidden />
+      ) : null}
+      Connect
+    </Button>
   );
 }

--- a/apps/web/lib/mcp-oauth.test.ts
+++ b/apps/web/lib/mcp-oauth.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildAuthorizationUrl,
+  deriveCodeChallenge,
+  discoverOAuthMetadata,
+  exchangeCodeForToken,
+  registerOAuthClient,
+  type AuthorizationServerMetadata,
+} from "./mcp-oauth";
+
+function makeFetcher(handler: (url: string, init: RequestInit) => Response | Promise<Response>) {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    return await handler(url, init ?? {});
+  });
+}
+
+const authServerMetadata: AuthorizationServerMetadata = {
+  issuer: "https://auth.example.com",
+  authorizationEndpoint: "https://auth.example.com/authorize",
+  tokenEndpoint: "https://auth.example.com/token",
+  registrationEndpoint: "https://auth.example.com/register",
+  scopesSupported: ["mcp:read"],
+  responseTypesSupported: ["code"],
+  grantTypesSupported: ["authorization_code", "refresh_token"],
+  codeChallengeMethodsSupported: ["S256"],
+  tokenEndpointAuthMethodsSupported: ["none", "client_secret_post"],
+};
+
+describe("MCP OAuth utilities", () => {
+  it("discovers protected-resource metadata and authorization-server metadata", async () => {
+    const fetcher = makeFetcher((url) => {
+      if (url === "https://mcp.example.com/.well-known/oauth-protected-resource") {
+        return new Response(JSON.stringify({
+          resource: "https://mcp.example.com",
+          authorization_servers: ["https://auth.example.com"],
+          scopes_supported: ["mcp:read"],
+          bearer_methods_supported: ["header"],
+        }));
+      }
+      if (url === "https://auth.example.com/.well-known/oauth-authorization-server") {
+        return new Response(JSON.stringify({
+          issuer: "https://auth.example.com",
+          authorization_endpoint: "https://auth.example.com/authorize",
+          token_endpoint: "https://auth.example.com/token",
+          registration_endpoint: "https://auth.example.com/register",
+          scopes_supported: ["mcp:read"],
+          response_types_supported: ["code"],
+          grant_types_supported: ["authorization_code"],
+          code_challenge_methods_supported: ["S256"],
+          token_endpoint_auth_methods_supported: ["none"],
+        }));
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const result = await discoverOAuthMetadata(
+      "https://mcp.example.com/.well-known/oauth-protected-resource",
+      { fetcher },
+    );
+
+    expect(result.resource.resource).toBe("https://mcp.example.com");
+    expect(result.authServer.authorizationEndpoint).toBe("https://auth.example.com/authorize");
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to OIDC metadata when oauth-authorization-server metadata is unavailable", async () => {
+    const fetcher = makeFetcher((url) => {
+      if (url === "https://mcp.example.com/.well-known/oauth-protected-resource") {
+        return new Response(JSON.stringify({
+          authorization_servers: ["https://auth.example.com"],
+        }));
+      }
+      if (url === "https://auth.example.com/.well-known/oauth-authorization-server") {
+        return new Response("not found", { status: 404 });
+      }
+      if (url === "https://auth.example.com/.well-known/openid-configuration") {
+        return new Response(JSON.stringify({
+          issuer: "https://auth.example.com",
+          authorization_endpoint: "https://auth.example.com/authorize",
+          token_endpoint: "https://auth.example.com/token",
+        }));
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const result = await discoverOAuthMetadata(
+      "https://mcp.example.com/.well-known/oauth-protected-resource",
+      { fetcher },
+    );
+
+    expect(result.authServer.tokenEndpoint).toBe("https://auth.example.com/token");
+    expect(fetcher).toHaveBeenCalledTimes(3);
+  });
+
+  it("uses RFC 8414 path-aware metadata URLs for issuers with paths", async () => {
+    const fetcher = makeFetcher((url) => {
+      if (url === "https://mcp.stripe.com/.well-known/oauth-protected-resource") {
+        return new Response(JSON.stringify({
+          resource: "https://mcp.stripe.com",
+          authorization_servers: ["https://access.stripe.com/mcp"],
+        }));
+      }
+      if (url === "https://access.stripe.com/.well-known/oauth-authorization-server/mcp") {
+        return new Response(JSON.stringify({
+          issuer: "https://access.stripe.com/mcp",
+          authorization_endpoint: "https://access.stripe.com/mcp/oauth2/authorize",
+          token_endpoint: "https://access.stripe.com/mcp/oauth2/token",
+          registration_endpoint: "https://access.stripe.com/mcp/oauth2/register",
+          scopes_supported: ["mcp"],
+          response_types_supported: ["code"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+          code_challenge_methods_supported: ["S256"],
+          token_endpoint_auth_methods_supported: ["none"],
+        }));
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const result = await discoverOAuthMetadata(
+      "https://mcp.stripe.com/.well-known/oauth-protected-resource",
+      { fetcher },
+    );
+
+    expect(result.authServer.issuer).toBe("https://access.stripe.com/mcp");
+    expect(result.authServer.authorizationEndpoint).toBe(
+      "https://access.stripe.com/mcp/oauth2/authorize",
+    );
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("registers a dynamic client with redirect URI and scope", async () => {
+    const fetcher = makeFetcher((_url, init) => {
+      if (typeof init.body !== "string") {
+        throw new Error("Expected JSON string body.");
+      }
+      const body = JSON.parse(init.body) as {
+        redirect_uris: string[];
+        scope: string;
+      };
+      expect(body.redirect_uris).toEqual(["http://localhost:3100/callback"]);
+      expect(body.scope).toBe("mcp:read");
+      return new Response(JSON.stringify({
+        client_id: "client-123",
+        client_secret: "secret-456",
+      }));
+    });
+
+    const client = await registerOAuthClient({
+      asMetadata: authServerMetadata,
+      redirectUri: "http://localhost:3100/callback",
+      clientName: "DenchClaw (acme)",
+      scope: "mcp:read",
+      fetcher,
+    });
+
+    expect(client).toMatchObject({
+      clientId: "client-123",
+      clientSecret: "secret-456",
+    });
+  });
+
+  it("derives the RFC 7636 S256 challenge correctly", () => {
+    expect(deriveCodeChallenge("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")).toBe(
+      "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+    );
+  });
+
+  it("builds an authorization URL with PKCE, state, scope, and resource", () => {
+    const params = buildAuthorizationUrl({
+      asMetadata: authServerMetadata,
+      client: {
+        clientId: "client-123",
+        clientSecret: null,
+        registrationAccessToken: null,
+        registrationClientUri: null,
+      },
+      redirectUri: "http://localhost:3100/callback",
+      codeVerifier: "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+      state: "state-123",
+      scope: "mcp:read",
+      resource: "https://mcp.example.com",
+    });
+
+    const url = new URL(params.authorizationUrl);
+    expect(url.origin + url.pathname).toBe("https://auth.example.com/authorize");
+    expect(url.searchParams.get("client_id")).toBe("client-123");
+    expect(url.searchParams.get("code_challenge")).toBe("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM");
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("state")).toBe("state-123");
+    expect(url.searchParams.get("scope")).toBe("mcp:read");
+    expect(url.searchParams.get("resource")).toBe("https://mcp.example.com");
+  });
+
+  it("exchanges an authorization code for tokens using PKCE", async () => {
+    const fetcher = makeFetcher((_url, init) => {
+      const body = init.body as URLSearchParams;
+      expect(body.get("grant_type")).toBe("authorization_code");
+      expect(body.get("code")).toBe("code-123");
+      expect(body.get("code_verifier")).toBe("verifier-123");
+      expect(body.get("client_id")).toBe("client-123");
+      return new Response(JSON.stringify({
+        access_token: "access-123",
+        token_type: "Bearer",
+        refresh_token: "refresh-123",
+        expires_in: 3600,
+      }));
+    });
+
+    const token = await exchangeCodeForToken({
+      asMetadata: authServerMetadata,
+      client: {
+        clientId: "client-123",
+        clientSecret: null,
+        registrationAccessToken: null,
+        registrationClientUri: null,
+      },
+      code: "code-123",
+      codeVerifier: "verifier-123",
+      redirectUri: "http://localhost:3100/callback",
+      fetcher,
+    });
+
+    expect(token).toMatchObject({
+      accessToken: "access-123",
+      refreshToken: "refresh-123",
+      expiresIn: 3600,
+    });
+  });
+});

--- a/apps/web/lib/mcp-oauth.ts
+++ b/apps/web/lib/mcp-oauth.ts
@@ -1,0 +1,601 @@
+/**
+ * MCP OAuth 2.1 client utilities.
+ *
+ * Implements the discovery + dynamic-client-registration + PKCE pieces of
+ * the MCP authorization spec, which composes:
+ *
+ *   - RFC 9728  : Protected Resource Metadata
+ *   - RFC 8414  : Authorization Server Metadata
+ *   - RFC 7591  : Dynamic Client Registration (DCR)
+ *   - RFC 7636  : PKCE
+ *   - RFC 6749  : OAuth 2.0 base
+ *
+ * The flow this module supports:
+ *
+ *   1. Server returns 401 with `WWW-Authenticate: Bearer resource_metadata=...`
+ *      (parsed by mcp-probe.ts).
+ *   2. `discoverOAuthMetadata` follows the resource_metadata URL, then the
+ *      AS metadata document, returning both.
+ *   3. `registerOAuthClient` runs DCR if the AS exposes a registration
+ *      endpoint and we don't already have credentials cached.
+ *   4. `buildAuthorizationUrl` generates a PKCE verifier + challenge, a CSRF
+ *      `state`, and the URL the user's browser opens.
+ *   5. After the user approves, the AS redirects to our callback with `code`
+ *      + `state`; `exchangeCodeForToken` swaps that for an access_token.
+ *
+ * Network failures throw with descriptive messages — the call sites surface
+ * them as `supportsOAuth: false, reason: "..."` to the UI rather than 500s.
+ */
+
+import { Buffer } from "node:buffer";
+import { createHash, randomBytes } from "node:crypto";
+
+type UnknownRecord = Record<string, unknown>;
+
+export type ProtectedResourceMetadata = {
+  resource: string | null;
+  authorizationServers: string[];
+  scopesSupported: string[];
+  bearerMethodsSupported: string[];
+};
+
+export type AuthorizationServerMetadata = {
+  issuer: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  registrationEndpoint: string | null;
+  scopesSupported: string[];
+  responseTypesSupported: string[];
+  grantTypesSupported: string[];
+  codeChallengeMethodsSupported: string[];
+  tokenEndpointAuthMethodsSupported: string[];
+};
+
+export type RegisteredClient = {
+  clientId: string;
+  clientSecret: string | null;
+  registrationAccessToken: string | null;
+  registrationClientUri: string | null;
+};
+
+export type AuthorizationRequestParams = {
+  authorizationUrl: string;
+  state: string;
+  codeVerifier: string;
+  redirectUri: string;
+  scope: string | null;
+};
+
+export type TokenResponse = {
+  accessToken: string;
+  tokenType: string;
+  refreshToken: string | null;
+  expiresIn: number | null;
+  scope: string | null;
+};
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const out: string[] = [];
+  for (const item of value) {
+    const s = readString(item);
+    if (s) {
+      out.push(s);
+    }
+  }
+  return out;
+}
+
+export class McpOAuthError extends Error {
+  reason: string;
+
+  constructor(reason: string, message?: string) {
+    super(message ?? reason);
+    this.name = "McpOAuthError";
+    this.reason = reason;
+  }
+}
+
+async function fetchJson(
+  url: string,
+  init: RequestInit,
+  fetcher: typeof fetch,
+  context: string,
+): Promise<unknown> {
+  let response: Response;
+  try {
+    response = await fetcher(url, init);
+  } catch (error) {
+    throw new McpOAuthError(
+      "network_error",
+      `${context} request to ${url} failed: ${error instanceof Error ? error.message : "unknown error"}`,
+    );
+  }
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new McpOAuthError(
+      "http_error",
+      `${context} request to ${url} returned HTTP ${response.status}${text ? `: ${text.slice(0, 300)}` : ""}`,
+    );
+  }
+  try {
+    return (await response.json()) as unknown;
+  } catch (error) {
+    throw new McpOAuthError(
+      "invalid_json",
+      `${context} response from ${url} was not valid JSON: ${error instanceof Error ? error.message : "unknown error"}`,
+    );
+  }
+}
+
+/**
+ * Walk the RFC 9728 / RFC 8414 discovery chain starting from the
+ * `resource_metadata` URL advertised in the MCP server's WWW-Authenticate
+ * challenge.
+ */
+export async function discoverOAuthMetadata(
+  resourceMetadataUrl: string,
+  options?: { fetcher?: typeof fetch },
+): Promise<{
+  resource: ProtectedResourceMetadata;
+  authServer: AuthorizationServerMetadata;
+}> {
+  const fetcher = options?.fetcher ?? fetch;
+
+  const resourceRaw = await fetchJson(
+    resourceMetadataUrl,
+    { method: "GET", headers: { accept: "application/json" } },
+    fetcher,
+    "Protected resource metadata",
+  );
+  const resourceRec = asRecord(resourceRaw);
+  if (!resourceRec) {
+    throw new McpOAuthError(
+      "invalid_resource_metadata",
+      `Resource metadata at ${resourceMetadataUrl} was not a JSON object.`,
+    );
+  }
+  const authorizationServers = readStringArray(resourceRec.authorization_servers);
+  if (authorizationServers.length === 0) {
+    throw new McpOAuthError(
+      "no_authorization_servers",
+      `Resource metadata at ${resourceMetadataUrl} did not list any authorization_servers.`,
+    );
+  }
+
+  const resource: ProtectedResourceMetadata = {
+    resource: readString(resourceRec.resource) ?? null,
+    authorizationServers,
+    scopesSupported: readStringArray(resourceRec.scopes_supported),
+    bearerMethodsSupported: readStringArray(resourceRec.bearer_methods_supported),
+  };
+
+  // Try authorization servers in order; first one that yields valid metadata wins.
+  let lastError: McpOAuthError | null = null;
+  for (const issuer of authorizationServers) {
+    try {
+      const authServer = await fetchAuthorizationServerMetadata(issuer, fetcher);
+      return { resource, authServer };
+    } catch (error) {
+      lastError = error instanceof McpOAuthError
+        ? error
+        : new McpOAuthError("unknown_error", error instanceof Error ? error.message : String(error));
+    }
+  }
+  throw lastError ?? new McpOAuthError(
+    "no_valid_authorization_server",
+    "Could not load metadata for any advertised authorization server.",
+  );
+}
+
+async function fetchAuthorizationServerMetadata(
+  issuer: string,
+  fetcher: typeof fetch,
+): Promise<AuthorizationServerMetadata> {
+  // Per RFC 8414, issuers with paths place the well-known segment before
+  // the issuer path:
+  //   https://example.com       → https://example.com/.well-known/oauth-authorization-server
+  //   https://example.com/tenant → https://example.com/.well-known/oauth-authorization-server/tenant
+  // Try OAuth metadata first, then OpenID Connect's well-known path as a
+  // common fallback (some providers only expose OIDC).
+  const candidates = buildMetadataUrls(issuer);
+  let lastError: McpOAuthError | null = null;
+  for (const url of candidates) {
+    try {
+      const raw = await fetchJson(
+        url,
+        { method: "GET", headers: { accept: "application/json" } },
+        fetcher,
+        "Authorization server metadata",
+      );
+      const rec = asRecord(raw);
+      if (!rec) {
+        lastError = new McpOAuthError(
+          "invalid_as_metadata",
+          `Authorization server metadata at ${url} was not a JSON object.`,
+        );
+        continue;
+      }
+      const authorizationEndpoint = readString(rec.authorization_endpoint);
+      const tokenEndpoint = readString(rec.token_endpoint);
+      if (!authorizationEndpoint || !tokenEndpoint) {
+        lastError = new McpOAuthError(
+          "incomplete_as_metadata",
+          `Authorization server metadata at ${url} is missing authorization_endpoint or token_endpoint.`,
+        );
+        continue;
+      }
+      return {
+        issuer: readString(rec.issuer) ?? issuer,
+        authorizationEndpoint,
+        tokenEndpoint,
+        registrationEndpoint: readString(rec.registration_endpoint) ?? null,
+        scopesSupported: readStringArray(rec.scopes_supported),
+        responseTypesSupported: readStringArray(rec.response_types_supported),
+        grantTypesSupported: readStringArray(rec.grant_types_supported),
+        codeChallengeMethodsSupported: readStringArray(rec.code_challenge_methods_supported),
+        tokenEndpointAuthMethodsSupported: readStringArray(
+          rec.token_endpoint_auth_methods_supported,
+        ),
+      };
+    } catch (error) {
+      lastError = error instanceof McpOAuthError
+        ? error
+        : new McpOAuthError("unknown_error", error instanceof Error ? error.message : String(error));
+    }
+  }
+  throw lastError ?? new McpOAuthError(
+    "no_as_metadata",
+    `Could not load authorization server metadata for issuer ${issuer}.`,
+  );
+}
+
+function buildMetadataUrls(issuer: string): string[] {
+  const trimmed = issuer.endsWith("/") ? issuer.slice(0, -1) : issuer;
+  const pathAwareOAuth = buildPathAwareWellKnownUrl(
+    trimmed,
+    "oauth-authorization-server",
+  );
+  const pathAwareOidc = buildPathAwareWellKnownUrl(
+    trimmed,
+    "openid-configuration",
+  );
+  return [
+    pathAwareOAuth,
+    `${trimmed}/.well-known/oauth-authorization-server`,
+    pathAwareOidc,
+    `${trimmed}/.well-known/openid-configuration`,
+  ].filter((url, index, urls): url is string => Boolean(url) && urls.indexOf(url) === index);
+}
+
+function buildPathAwareWellKnownUrl(
+  issuer: string,
+  wellKnownSuffix: string,
+): string | null {
+  try {
+    const parsed = new URL(issuer);
+    const issuerPath = parsed.pathname === "/"
+      ? ""
+      : parsed.pathname.replace(/\/$/u, "");
+    parsed.pathname = `/.well-known/${wellKnownSuffix}${issuerPath}`;
+    parsed.search = "";
+    parsed.hash = "";
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run RFC 7591 dynamic client registration. Throws `McpOAuthError` with
+ * `reason: "no_registration_endpoint"` if the AS doesn't support DCR — the
+ * caller then falls back to the paste-a-token UI.
+ */
+export async function registerOAuthClient(params: {
+  asMetadata: AuthorizationServerMetadata;
+  redirectUri: string;
+  clientName: string;
+  scope?: string | null;
+  fetcher?: typeof fetch;
+}): Promise<RegisteredClient> {
+  const fetcher = params.fetcher ?? fetch;
+  const endpoint = params.asMetadata.registrationEndpoint;
+  if (!endpoint) {
+    throw new McpOAuthError(
+      "no_registration_endpoint",
+      `Authorization server ${params.asMetadata.issuer} does not advertise a registration_endpoint.`,
+    );
+  }
+
+  const body: UnknownRecord = {
+    redirect_uris: [params.redirectUri],
+    token_endpoint_auth_method:
+      params.asMetadata.tokenEndpointAuthMethodsSupported.includes("none")
+        ? "none"
+        : params.asMetadata.tokenEndpointAuthMethodsSupported[0] ?? "client_secret_post",
+    grant_types: ["authorization_code", "refresh_token"],
+    response_types: ["code"],
+    client_name: params.clientName,
+    application_type: "web",
+  };
+  if (params.scope) {
+    body.scope = params.scope;
+  }
+
+  let response: Response;
+  try {
+    response = await fetcher(endpoint, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (error) {
+    throw new McpOAuthError(
+      "registration_network_error",
+      `DCR request to ${endpoint} failed: ${error instanceof Error ? error.message : "unknown error"}`,
+    );
+  }
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new McpOAuthError(
+      "registration_failed",
+      `DCR request to ${endpoint} returned HTTP ${response.status}${text ? `: ${text.slice(0, 300)}` : ""}`,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = (await response.json()) as unknown;
+  } catch (error) {
+    throw new McpOAuthError(
+      "registration_invalid_json",
+      `DCR response was not valid JSON: ${error instanceof Error ? error.message : "unknown error"}`,
+    );
+  }
+  const rec = asRecord(parsed);
+  const clientId = readString(rec?.client_id);
+  if (!clientId) {
+    throw new McpOAuthError(
+      "registration_missing_client_id",
+      "DCR response did not include a client_id.",
+    );
+  }
+  return {
+    clientId,
+    clientSecret: readString(rec?.client_secret) ?? null,
+    registrationAccessToken: readString(rec?.registration_access_token) ?? null,
+    registrationClientUri: readString(rec?.registration_client_uri) ?? null,
+  };
+}
+
+function base64UrlEncode(buffer: Buffer): string {
+  return buffer.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export function generateCodeVerifier(): string {
+  // 32 bytes → 43-char base64url string, well within RFC 7636's 43..128 range.
+  return base64UrlEncode(randomBytes(32));
+}
+
+export function deriveCodeChallenge(verifier: string): string {
+  return base64UrlEncode(createHash("sha256").update(verifier).digest());
+}
+
+export function generateState(): string {
+  return base64UrlEncode(randomBytes(24));
+}
+
+export function buildAuthorizationUrl(params: {
+  asMetadata: AuthorizationServerMetadata;
+  client: RegisteredClient;
+  redirectUri: string;
+  scope?: string | null;
+  resource?: string | null;
+  codeVerifier?: string;
+  state?: string;
+}): AuthorizationRequestParams {
+  const codeVerifier = params.codeVerifier ?? generateCodeVerifier();
+  const codeChallenge = deriveCodeChallenge(codeVerifier);
+  const state = params.state ?? generateState();
+
+  const url = new URL(params.asMetadata.authorizationEndpoint);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", params.client.clientId);
+  url.searchParams.set("redirect_uri", params.redirectUri);
+  url.searchParams.set("state", state);
+  url.searchParams.set("code_challenge", codeChallenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  if (params.scope) {
+    url.searchParams.set("scope", params.scope);
+  }
+  if (params.resource) {
+    // RFC 8707 — bind the access token to the protected resource.
+    url.searchParams.set("resource", params.resource);
+  }
+
+  return {
+    authorizationUrl: url.toString(),
+    state,
+    codeVerifier,
+    redirectUri: params.redirectUri,
+    scope: params.scope ?? null,
+  };
+}
+
+function parseTokenResponse(rec: UnknownRecord, context: string): TokenResponse {
+  const accessToken = readString(rec.access_token);
+  if (!accessToken) {
+    throw new McpOAuthError(
+      "missing_access_token",
+      `${context} response did not include an access_token.`,
+    );
+  }
+  const tokenType = readString(rec.token_type) ?? "Bearer";
+  const expiresInRaw = rec.expires_in;
+  const expiresIn = typeof expiresInRaw === "number" && Number.isFinite(expiresInRaw)
+    ? expiresInRaw
+    : null;
+  return {
+    accessToken,
+    tokenType,
+    refreshToken: readString(rec.refresh_token) ?? null,
+    expiresIn,
+    scope: readString(rec.scope) ?? null,
+  };
+}
+
+async function postTokenEndpoint(params: {
+  endpoint: string;
+  formBody: URLSearchParams;
+  client: { clientId: string; clientSecret: string | null };
+  authMethod: string;
+  fetcher: typeof fetch;
+  context: string;
+}): Promise<TokenResponse> {
+  const body = new URLSearchParams(params.formBody);
+  const headers: Record<string, string> = {
+    "content-type": "application/x-www-form-urlencoded",
+    accept: "application/json",
+  };
+  if (params.authMethod === "client_secret_basic" && params.client.clientSecret) {
+    const encoded = Buffer.from(`${params.client.clientId}:${params.client.clientSecret}`).toString("base64");
+    headers.authorization = `Basic ${encoded}`;
+  } else {
+    body.set("client_id", params.client.clientId);
+    if (params.client.clientSecret) {
+      body.set("client_secret", params.client.clientSecret);
+    }
+  }
+  let response: Response;
+  try {
+    response = await params.fetcher(params.endpoint, {
+      method: "POST",
+      headers,
+      body,
+    });
+  } catch (error) {
+    throw new McpOAuthError(
+      "token_network_error",
+      `${params.context} request to ${params.endpoint} failed: ${error instanceof Error ? error.message : "unknown error"}`,
+    );
+  }
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new McpOAuthError(
+      "token_request_failed",
+      `${params.context} request to ${params.endpoint} returned HTTP ${response.status}${text ? `: ${text.slice(0, 300)}` : ""}`,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = (await response.json()) as unknown;
+  } catch (error) {
+    throw new McpOAuthError(
+      "token_invalid_json",
+      `${params.context} response was not valid JSON: ${error instanceof Error ? error.message : "unknown error"}`,
+    );
+  }
+  const rec = asRecord(parsed);
+  if (!rec) {
+    throw new McpOAuthError(
+      "token_invalid_payload",
+      `${params.context} response was not a JSON object.`,
+    );
+  }
+  return parseTokenResponse(rec, params.context);
+}
+
+function pickTokenAuthMethod(asMetadata: AuthorizationServerMetadata, hasSecret: boolean): string {
+  const supported = asMetadata.tokenEndpointAuthMethodsSupported;
+  if (!hasSecret) {
+    if (supported.length === 0 || supported.includes("none")) {
+      return "none";
+    }
+    return supported.includes("client_secret_post") ? "client_secret_post" : supported[0];
+  }
+  if (supported.includes("client_secret_basic")) {
+    return "client_secret_basic";
+  }
+  if (supported.includes("client_secret_post")) {
+    return "client_secret_post";
+  }
+  return supported[0] ?? "client_secret_basic";
+}
+
+export async function exchangeCodeForToken(params: {
+  asMetadata: AuthorizationServerMetadata;
+  client: RegisteredClient;
+  code: string;
+  codeVerifier: string;
+  redirectUri: string;
+  resource?: string | null;
+  fetcher?: typeof fetch;
+}): Promise<TokenResponse> {
+  const fetcher = params.fetcher ?? fetch;
+  const formBody = new URLSearchParams();
+  formBody.set("grant_type", "authorization_code");
+  formBody.set("code", params.code);
+  formBody.set("redirect_uri", params.redirectUri);
+  formBody.set("code_verifier", params.codeVerifier);
+  if (params.resource) {
+    formBody.set("resource", params.resource);
+  }
+
+  return postTokenEndpoint({
+    endpoint: params.asMetadata.tokenEndpoint,
+    formBody,
+    client: params.client,
+    authMethod: pickTokenAuthMethod(params.asMetadata, Boolean(params.client.clientSecret)),
+    fetcher,
+    context: "Token exchange",
+  });
+}
+
+export async function refreshAccessToken(params: {
+  asMetadata: AuthorizationServerMetadata;
+  client: RegisteredClient;
+  refreshToken: string;
+  scope?: string | null;
+  resource?: string | null;
+  fetcher?: typeof fetch;
+}): Promise<TokenResponse> {
+  const fetcher = params.fetcher ?? fetch;
+  const formBody = new URLSearchParams();
+  formBody.set("grant_type", "refresh_token");
+  formBody.set("refresh_token", params.refreshToken);
+  if (params.scope) {
+    formBody.set("scope", params.scope);
+  }
+  if (params.resource) {
+    formBody.set("resource", params.resource);
+  }
+  return postTokenEndpoint({
+    endpoint: params.asMetadata.tokenEndpoint,
+    formBody,
+    client: params.client,
+    authMethod: pickTokenAuthMethod(params.asMetadata, Boolean(params.client.clientSecret)),
+    fetcher,
+    context: "Token refresh",
+  });
+}
+
+export function computeTokenExpiresAt(expiresIn: number | null): string | null {
+  if (expiresIn === null) {
+    return null;
+  }
+  return new Date(Date.now() + expiresIn * 1000).toISOString();
+}

--- a/apps/web/lib/mcp-probe.test.ts
+++ b/apps/web/lib/mcp-probe.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest";
+import { parseWwwAuthenticate, probeMcpServer } from "./mcp-probe";
+
+describe("parseWwwAuthenticate", () => {
+  it("returns null for missing or empty headers", () => {
+    expect(parseWwwAuthenticate(null)).toBeNull();
+    expect(parseWwwAuthenticate("")).toBeNull();
+    expect(parseWwwAuthenticate("   ")).toBeNull();
+  });
+
+  it("returns null when no Bearer challenge is present", () => {
+    expect(parseWwwAuthenticate("Basic realm=\"acme\"")).toBeNull();
+  });
+
+  it("parses a bare Bearer challenge", () => {
+    const challenge = parseWwwAuthenticate("Bearer");
+    expect(challenge).toEqual({
+      scheme: "Bearer",
+      realm: null,
+      resourceMetadataUrl: null,
+      scope: null,
+      errorCode: null,
+      errorDescription: null,
+    });
+  });
+
+  it("parses RFC 9728 resource_metadata with all auxiliary fields", () => {
+    const challenge = parseWwwAuthenticate(
+      'Bearer realm="acme", resource_metadata="https://acme.com/.well-known/oauth-protected-resource", scope="mcp:read mcp:write", error="invalid_token", error_description="The access token expired"',
+    );
+    expect(challenge).toEqual({
+      scheme: "Bearer",
+      realm: "acme",
+      resourceMetadataUrl: "https://acme.com/.well-known/oauth-protected-resource",
+      scope: "mcp:read mcp:write",
+      errorCode: "invalid_token",
+      errorDescription: "The access token expired",
+    });
+  });
+
+  it("handles values containing commas inside quotes", () => {
+    const challenge = parseWwwAuthenticate(
+      'Bearer error_description="Token expired, please refresh", scope="read"',
+    );
+    expect(challenge?.errorDescription).toBe("Token expired, please refresh");
+    expect(challenge?.scope).toBe("read");
+  });
+
+  it("preserves embedded escaped quotes", () => {
+    const challenge = parseWwwAuthenticate(
+      'Bearer error_description="Quote inside: \\"value\\""',
+    );
+    expect(challenge?.errorDescription).toBe('Quote inside: "value"');
+  });
+
+  it("parses unquoted parameter values", () => {
+    const challenge = parseWwwAuthenticate("Bearer error=invalid_token");
+    expect(challenge?.errorCode).toBe("invalid_token");
+  });
+});
+
+function makeFetchSpy(handler: (input: RequestInfo | URL, init?: RequestInit) => Response | Promise<Response>) {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => handler(input, init));
+}
+
+describe("probeMcpServer", () => {
+  const URL = "https://mcp.example.com";
+
+  it("returns connected with tool count for a JSON tools/list response", async () => {
+    const fetcher = makeFetchSpy(() =>
+      new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            tools: [
+              { name: "alpha" },
+              { name: "beta" },
+              { name: "gamma" },
+            ],
+          },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+
+    const result = await probeMcpServer({ url: URL, fetcher });
+    expect(result.status).toBe("connected");
+    expect(result.toolCount).toBe(3);
+    expect(result.detail).toMatch(/3 tools/);
+    expect(result.authChallenge).toBeNull();
+    expect(result.httpStatus).toBe(200);
+  });
+
+  it("counts tools in an SSE-framed response", async () => {
+    const sseBody = [
+      "event: message",
+      "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"name\":\"x\"},{\"name\":\"y\"}]}}",
+      "",
+      "data: [DONE]",
+    ].join("\n");
+    const fetcher = makeFetchSpy(() =>
+      new Response(sseBody, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      }),
+    );
+
+    const result = await probeMcpServer({ url: URL, fetcher });
+    expect(result.status).toBe("connected");
+    expect(result.toolCount).toBe(2);
+  });
+
+  it("classifies 401 with WWW-Authenticate as needs_auth and surfaces the resource_metadata URL", async () => {
+    const fetcher = makeFetchSpy(() =>
+      new Response("", {
+        status: 401,
+        headers: {
+          "www-authenticate":
+            'Bearer resource_metadata="https://auth.example.com/.well-known/oauth-protected-resource", error="invalid_token"',
+        },
+      }),
+    );
+
+    const result = await probeMcpServer({ url: URL, fetcher });
+    expect(result.status).toBe("needs_auth");
+    expect(result.toolCount).toBeNull();
+    expect(result.authChallenge?.resourceMetadataUrl).toBe(
+      "https://auth.example.com/.well-known/oauth-protected-resource",
+    );
+    expect(result.authChallenge?.errorCode).toBe("invalid_token");
+    expect(result.httpStatus).toBe(401);
+  });
+
+  it("returns needs_auth even when the 401 has no WWW-Authenticate header", async () => {
+    const fetcher = makeFetchSpy(() => new Response("", { status: 401 }));
+    const result = await probeMcpServer({ url: URL, fetcher });
+    expect(result.status).toBe("needs_auth");
+    expect(result.authChallenge).toBeNull();
+  });
+
+  it("classifies non-auth HTTP errors as error", async () => {
+    const fetcher = makeFetchSpy(() =>
+      new Response("Internal Server Error", { status: 500 }),
+    );
+    const result = await probeMcpServer({ url: URL, fetcher });
+    expect(result.status).toBe("error");
+    expect(result.detail).toMatch(/HTTP 500/);
+    expect(result.httpStatus).toBe(500);
+  });
+
+  it("classifies a 200 with malformed JSON as error", async () => {
+    const fetcher = makeFetchSpy(() =>
+      new Response("not-json-at-all", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const result = await probeMcpServer({ url: URL, fetcher });
+    expect(result.status).toBe("error");
+  });
+
+  it("forwards extra request headers (used to send the Authorization header)", async () => {
+    const fetcher = makeFetchSpy((_input, init) => {
+      const headers = new Headers(init?.headers as HeadersInit);
+      expect(headers.get("authorization")).toBe("Bearer abc");
+      return new Response(
+        JSON.stringify({ result: { tools: [] } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+    const result = await probeMcpServer({
+      url: URL,
+      headers: { Authorization: "Bearer abc" },
+      fetcher,
+    });
+    expect(result.status).toBe("connected");
+    expect(result.toolCount).toBe(0);
+  });
+
+  it("returns error when the fetcher throws", async () => {
+    const fetcher = vi.fn(async () => {
+      throw new Error("network unreachable");
+    });
+    const result = await probeMcpServer({ url: URL, fetcher });
+    expect(result.status).toBe("error");
+    expect(result.detail).toContain("network unreachable");
+    expect(result.httpStatus).toBeNull();
+  });
+});

--- a/apps/web/lib/mcp-probe.ts
+++ b/apps/web/lib/mcp-probe.ts
@@ -1,0 +1,289 @@
+/**
+ * MCP server probe — performs a JSON-RPC `tools/list` call against a remote
+ * MCP server over streamable-http and classifies the response into one of
+ * three states:
+ *
+ *   - "connected"   : 200 OK with a parseable tool list. Returns the count.
+ *   - "needs_auth"  : 401/403, optionally with an RFC 9728 WWW-Authenticate
+ *                     challenge that Phase 2 (OAuth) consumes for discovery.
+ *   - "error"       : anything else (network failure, malformed response,
+ *                     non-auth HTTP error, etc.).
+ *
+ * Handles both `application/json` and `text/event-stream` response bodies,
+ * because some MCP servers return SSE-framed JSON-RPC messages even for a
+ * simple `tools/list` reply.
+ *
+ * The SSE / JSON parsing is intentionally similar to the Composio gateway
+ * client in `apps/web/lib/composio.ts` — kept as a separate module so the
+ * generic MCP code path doesn't depend on Composio-specific gateway logic.
+ */
+
+type UnknownRecord = Record<string, unknown>;
+
+export type McpProbeStatus = "connected" | "needs_auth" | "error";
+
+/**
+ * Parsed `WWW-Authenticate: Bearer ...` challenge per RFC 6750 / RFC 9728.
+ *
+ * `resourceMetadataUrl` is the RFC 9728 hint that Phase 2 follows to discover
+ * the protected-resource metadata document. If missing, the server doesn't
+ * advertise OAuth and the UI should fall back to manual token entry.
+ */
+export type McpAuthChallenge = {
+  scheme: string;
+  realm: string | null;
+  resourceMetadataUrl: string | null;
+  scope: string | null;
+  errorCode: string | null;
+  errorDescription: string | null;
+};
+
+export type McpProbeResult = {
+  status: McpProbeStatus;
+  toolCount: number | null;
+  authChallenge: McpAuthChallenge | null;
+  detail: string;
+  checkedAt: string;
+  httpStatus: number | null;
+};
+
+export type McpProbeOptions = {
+  url: string;
+  headers?: Record<string, string>;
+  fetcher?: typeof fetch;
+  timeoutMs?: number;
+};
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+/**
+ * Parse a single `WWW-Authenticate` header value. Accepts the most common
+ * Bearer-challenge shapes:
+ *
+ *   Bearer
+ *   Bearer realm="acme"
+ *   Bearer realm="acme", error="invalid_token", error_description="expired"
+ *   Bearer resource_metadata="https://...", scope="mcp:read"
+ *
+ * Multi-scheme headers (e.g. `Basic ..., Bearer ...`) are not common for MCP
+ * servers; we only return the first Bearer challenge we find. Anything else
+ * yields `null`.
+ */
+export function parseWwwAuthenticate(header: string | null): McpAuthChallenge | null {
+  if (!header) {
+    return null;
+  }
+
+  const trimmed = header.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const bearerMatch = /(?:^|,\s*)Bearer\b\s*(.*)$/iu.exec(trimmed);
+  if (!bearerMatch) {
+    return null;
+  }
+
+  const paramsRaw = bearerMatch[1] ?? "";
+  const params = new Map<string, string>();
+  let buffer = "";
+  let inQuotes = false;
+  const segments: string[] = [];
+  for (const ch of paramsRaw) {
+    if (ch === "\"") {
+      inQuotes = !inQuotes;
+      buffer += ch;
+    } else if (ch === "," && !inQuotes) {
+      segments.push(buffer);
+      buffer = "";
+    } else {
+      buffer += ch;
+    }
+  }
+  if (buffer.trim()) {
+    segments.push(buffer);
+  }
+
+  for (const segment of segments) {
+    const eqIndex = segment.indexOf("=");
+    if (eqIndex === -1) {
+      continue;
+    }
+    const rawKey = segment.slice(0, eqIndex).trim();
+    let rawValue = segment.slice(eqIndex + 1).trim();
+    if (!rawKey) {
+      continue;
+    }
+    if (rawValue.startsWith("\"") && rawValue.endsWith("\"") && rawValue.length >= 2) {
+      rawValue = rawValue.slice(1, -1).replace(/\\"/g, "\"");
+    }
+    params.set(rawKey.toLowerCase(), rawValue);
+  }
+
+  return {
+    scheme: "Bearer",
+    realm: params.get("realm") ?? null,
+    resourceMetadataUrl: params.get("resource_metadata") ?? null,
+    scope: params.get("scope") ?? null,
+    errorCode: params.get("error") ?? null,
+    errorDescription: params.get("error_description") ?? null,
+  };
+}
+
+function extractToolCountFromJsonRpcMessage(payload: unknown): number | null {
+  const rec = asRecord(payload);
+  const result = asRecord(rec?.result);
+  const tools = result?.tools;
+  if (!Array.isArray(tools)) {
+    return null;
+  }
+  return tools.filter((item) => readString(asRecord(item)?.name)).length;
+}
+
+function parseSseToolCount(body: string): number | null {
+  let lastPayload: unknown = null;
+  for (const line of body.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("data:")) {
+      continue;
+    }
+    const raw = trimmed.slice(5).trim();
+    if (raw === "[DONE]" || raw === "") {
+      continue;
+    }
+    try {
+      lastPayload = JSON.parse(raw);
+    } catch {
+      // ignore non-JSON SSE frames
+    }
+  }
+  return lastPayload === null ? null : extractToolCountFromJsonRpcMessage(lastPayload);
+}
+
+async function parseToolsListResponse(res: Response): Promise<number | null> {
+  const contentType = res.headers.get("content-type") ?? "";
+  const text = await res.text();
+  if (contentType.includes("text/event-stream")) {
+    const fromSse = parseSseToolCount(text);
+    if (fromSse !== null) {
+      return fromSse;
+    }
+  }
+  try {
+    const fromJson = extractToolCountFromJsonRpcMessage(JSON.parse(text) as unknown);
+    if (fromJson !== null) {
+      return fromJson;
+    }
+  } catch {
+    // fall through to SSE parsing
+  }
+  return parseSseToolCount(text);
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+/**
+ * Probe a remote MCP server with a JSON-RPC `tools/list` request and return
+ * a structured classification of the response. Never throws — network errors
+ * and malformed responses are mapped to `status: "error"`.
+ */
+export async function probeMcpServer(options: McpProbeOptions): Promise<McpProbeResult> {
+  const fetcher = options.fetcher ?? fetch;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const checkedAt = nowIso();
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetcher(options.url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        ...options.headers,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      }),
+      signal: controller.signal,
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      const wwwAuthenticate = response.headers.get("www-authenticate")
+        ?? response.headers.get("WWW-Authenticate");
+      const challenge = parseWwwAuthenticate(wwwAuthenticate);
+      const detail = challenge?.errorDescription
+        ?? challenge?.errorCode
+        ?? `HTTP ${response.status} from MCP server.`;
+      return {
+        status: "needs_auth",
+        toolCount: null,
+        authChallenge: challenge,
+        detail,
+        checkedAt,
+        httpStatus: response.status,
+      };
+    }
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      return {
+        status: "error",
+        toolCount: null,
+        authChallenge: null,
+        detail: `tools/list returned HTTP ${response.status}${body ? `: ${body.slice(0, 200)}` : ""}`,
+        checkedAt,
+        httpStatus: response.status,
+      };
+    }
+
+    const toolCount = await parseToolsListResponse(response);
+    if (toolCount === null) {
+      return {
+        status: "error",
+        toolCount: null,
+        authChallenge: null,
+        detail: "tools/list returned a response that did not contain a tool list.",
+        checkedAt,
+        httpStatus: response.status,
+      };
+    }
+
+    return {
+      status: "connected",
+      toolCount,
+      authChallenge: null,
+      detail: `Connected. ${toolCount} tool${toolCount === 1 ? "" : "s"} available.`,
+      checkedAt,
+      httpStatus: response.status,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "tools/list request failed.";
+    return {
+      status: "error",
+      toolCount: null,
+      authChallenge: null,
+      detail: message,
+      checkedAt,
+      httpStatus: null,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/apps/web/lib/mcp-secrets.test.ts
+++ b/apps/web/lib/mcp-secrets.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+let stateDir = "";
+
+vi.mock("@/lib/workspace", () => ({
+  resolveOpenClawStateDir: vi.fn(() => stateDir),
+}));
+
+const {
+  clearTransientOAuthFields,
+  getMcpServerSecret,
+  setMcpServerSecret,
+} = await import("./mcp-secrets");
+
+describe("mcp OAuth secrets", () => {
+  beforeEach(() => {
+    stateDir = path.join(os.tmpdir(), `dench-mcp-secrets-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(stateDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("clears callback-only OAuth fields after token exchange", () => {
+    setMcpServerSecret("acme", {
+      clientId: "client-123",
+      clientSecret: null,
+      refreshToken: "refresh-123",
+      tokenExpiresAt: "2026-04-29T01:00:00.000Z",
+      asMetadataUrl: "https://mcp.example.com/.well-known/oauth-protected-resource",
+      authServerIssuer: "https://auth.example.com",
+      registeredRedirectUri: "http://localhost:3100/api/settings/mcp/connect/callback",
+      codeVerifier: "verifier-123",
+      oauthState: "state-123",
+      redirectUri: "http://localhost:3100/api/settings/mcp/connect/callback",
+      scope: "mcp:read",
+    });
+
+    clearTransientOAuthFields("acme");
+
+    expect(getMcpServerSecret("acme")).toEqual({
+      clientId: "client-123",
+      clientSecret: null,
+      refreshToken: "refresh-123",
+      tokenExpiresAt: "2026-04-29T01:00:00.000Z",
+      asMetadataUrl: "https://mcp.example.com/.well-known/oauth-protected-resource",
+      authServerIssuer: "https://auth.example.com",
+      registeredRedirectUri: "http://localhost:3100/api/settings/mcp/connect/callback",
+      codeVerifier: null,
+      oauthState: null,
+      redirectUri: null,
+      scope: "mcp:read",
+    });
+  });
+});

--- a/apps/web/lib/mcp-secrets.ts
+++ b/apps/web/lib/mcp-secrets.ts
@@ -1,0 +1,196 @@
+/**
+ * Sidecar storage for OAuth secrets attached to user-added MCP servers.
+ *
+ * Lives at `${resolveOpenClawStateDir()}/.mcp-secrets.json` with mode 0600.
+ *
+ * We deliberately keep secrets out of `openclaw.json`:
+ *   - The agent runtime reads `openclaw.json` and surfaces parts of it in
+ *     debug logs and exports; refresh tokens must never end up there.
+ *   - Some users sync `openclaw.json` to share configuration; secrets must
+ *     stay machine-local.
+ *
+ * The shape stored per server key is everything the OAuth callback +
+ * refresh paths need to recover an access token without touching the
+ * upstream auth server's user consent prompt:
+ *
+ *   {
+ *     clientId, clientSecret?,
+ *     refreshToken,
+ *     tokenExpiresAt,
+ *     asMetadataUrl,         // resolved RFC 8414 metadata document URL
+ *     authServerIssuer?,     // best-effort identifier for diagnostics
+ *     registeredRedirectUri?, // redirect URI used for DCR client registration
+ *
+ *     // Transient (cleared after `exchangeCodeForToken`):
+ *     codeVerifier?,         // PKCE
+ *     oauthState?,           // CSRF nonce
+ *     redirectUri?,          // pinned at /connect/start time
+ *
+ *     scope?,                // retained for refresh-token grants
+ *   }
+ */
+
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { resolveOpenClawStateDir } from "@/lib/workspace";
+
+type UnknownRecord = Record<string, unknown>;
+
+const SECRETS_FILENAME = ".mcp-secrets.json";
+const SECRETS_FILE_MODE = 0o600;
+
+export type McpServerSecret = {
+  clientId: string;
+  clientSecret: string | null;
+  refreshToken: string | null;
+  tokenExpiresAt: string | null;
+  asMetadataUrl: string;
+  authServerIssuer: string | null;
+  /** Redirect URI registered with the OAuth client. */
+  registeredRedirectUri: string | null;
+  /** PKCE verifier — only present between /connect/start and /connect/callback. */
+  codeVerifier: string | null;
+  /** CSRF nonce — only present between /connect/start and /connect/callback. */
+  oauthState: string | null;
+  /** Redirect URI used at authorize time, must match at token exchange time. */
+  redirectUri: string | null;
+  /** Requested scope string at authorize time. */
+  scope: string | null;
+};
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function secretsPath(): string {
+  return join(resolveOpenClawStateDir(), SECRETS_FILENAME);
+}
+
+function ensureStateDir(): void {
+  const stateDir = resolveOpenClawStateDir();
+  if (!existsSync(stateDir)) {
+    mkdirSync(stateDir, { recursive: true });
+  }
+}
+
+function emptySecret(): McpServerSecret {
+  return {
+    clientId: "",
+    clientSecret: null,
+    refreshToken: null,
+    tokenExpiresAt: null,
+    asMetadataUrl: "",
+    authServerIssuer: null,
+    registeredRedirectUri: null,
+    codeVerifier: null,
+    oauthState: null,
+    redirectUri: null,
+    scope: null,
+  };
+}
+
+function readAll(): Record<string, McpServerSecret> {
+  const path = secretsPath();
+  if (!existsSync(path)) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+    const record = asRecord(parsed);
+    if (!record) {
+      return {};
+    }
+    const out: Record<string, McpServerSecret> = {};
+    for (const [key, value] of Object.entries(record)) {
+      const entry = asRecord(value);
+      if (!entry) {
+        continue;
+      }
+      out[key] = {
+        clientId: readString(entry.clientId) ?? "",
+        clientSecret: readString(entry.clientSecret) ?? null,
+        refreshToken: readString(entry.refreshToken) ?? null,
+        tokenExpiresAt: readString(entry.tokenExpiresAt) ?? null,
+        asMetadataUrl: readString(entry.asMetadataUrl) ?? "",
+        authServerIssuer: readString(entry.authServerIssuer) ?? null,
+        registeredRedirectUri: readString(entry.registeredRedirectUri) ?? null,
+        codeVerifier: readString(entry.codeVerifier) ?? null,
+        oauthState: readString(entry.oauthState) ?? null,
+        redirectUri: readString(entry.redirectUri) ?? null,
+        scope: readString(entry.scope) ?? null,
+      };
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function writeAll(secrets: Record<string, McpServerSecret>): void {
+  ensureStateDir();
+  const path = secretsPath();
+  writeFileSync(path, JSON.stringify(secrets, null, 2) + "\n", "utf-8");
+  // chmod 600 — best-effort; on platforms without POSIX semantics this is a
+  // no-op, but on macOS/Linux it ensures the file is owner-only readable
+  // even if the surrounding directory is more permissive.
+  try {
+    chmodSync(path, SECRETS_FILE_MODE);
+  } catch {
+    // ignore — chmod failure shouldn't block the OAuth flow
+  }
+}
+
+export function getMcpServerSecret(key: string): McpServerSecret | null {
+  return readAll()[key] ?? null;
+}
+
+export function setMcpServerSecret(
+  key: string,
+  patch: Partial<McpServerSecret>,
+): McpServerSecret {
+  const all = readAll();
+  const current = all[key] ?? emptySecret();
+  const next: McpServerSecret = { ...current, ...patch };
+  all[key] = next;
+  writeAll(all);
+  return next;
+}
+
+export function deleteMcpServerSecret(key: string): void {
+  const all = readAll();
+  if (all[key]) {
+    delete all[key];
+    writeAll(all);
+  }
+}
+
+/**
+ * Wipe transient PKCE/state fields after a successful token exchange. Keeps
+ * `clientId`/`clientSecret`/`refreshToken` etc. for future refresh calls.
+ */
+export function clearTransientOAuthFields(key: string): void {
+  const all = readAll();
+  const current = all[key];
+  if (!current) {
+    return;
+  }
+  all[key] = {
+    ...current,
+    codeVerifier: null,
+    oauthState: null,
+    redirectUri: null,
+  };
+  writeAll(all);
+}

--- a/apps/web/lib/mcp-servers.test.ts
+++ b/apps/web/lib/mcp-servers.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+let stateDir = "";
+
+vi.mock("@/lib/workspace", () => ({
+  resolveOpenClawStateDir: vi.fn(() => stateDir),
+}));
+
+const {
+  addMcpServer,
+  removeMcpServer,
+  setAuthorizationHeader,
+} = await import("./mcp-servers");
+const {
+  getMcpServerSecret,
+  setMcpServerSecret,
+} = await import("./mcp-secrets");
+
+function configPath(): string {
+  return path.join(stateDir, "openclaw.json");
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(configPath(), "utf-8")) as Record<string, unknown>;
+}
+
+describe("mcp server config helpers", () => {
+  beforeEach(() => {
+    stateDir = path.join(os.tmpdir(), `dench-mcp-servers-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(stateDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("refuses to add the reserved composio key", () => {
+    expect(() => {
+      addMcpServer({
+        key: "composio",
+        url: "https://mcp.example.com",
+      });
+    }).toThrow("managed internally");
+  });
+
+  it("does not mutate the reserved composio runtime server", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        mcp: {
+          servers: {
+            composio: {
+              url: "https://gateway.example.com/v1/composio/mcp",
+              transport: "streamable-http",
+            },
+            acme: {
+              url: "https://mcp.example.com",
+              transport: "streamable-http",
+            },
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    expect(() => setAuthorizationHeader("composio", "Bearer nope")).toThrow("managed internally");
+    expect(() => removeMcpServer("composio")).toThrow("managed internally");
+
+    const config = readConfig() as {
+      mcp: { servers: Record<string, { url: string; transport: string }> };
+    };
+    expect(config.mcp.servers.composio).toEqual({
+      url: "https://gateway.example.com/v1/composio/mcp",
+      transport: "streamable-http",
+    });
+    expect(config.mcp.servers.acme).toEqual({
+      url: "https://mcp.example.com",
+      transport: "streamable-http",
+    });
+  });
+
+  it("deletes OAuth secrets when removing a server", () => {
+    addMcpServer({
+      key: "acme",
+      url: "https://mcp.example.com",
+    });
+    setMcpServerSecret("acme", {
+      clientId: "client-123",
+      refreshToken: "refresh-123",
+      asMetadataUrl: "https://mcp.example.com/.well-known/oauth-protected-resource",
+      codeVerifier: "verifier-123",
+      oauthState: "state-123",
+    });
+
+    removeMcpServer("acme");
+
+    expect(getMcpServerSecret("acme")).toBeNull();
+  });
+});

--- a/apps/web/lib/mcp-servers.ts
+++ b/apps/web/lib/mcp-servers.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { deleteMcpServerSecret } from "@/lib/mcp-secrets";
 import { resolveOpenClawStateDir } from "@/lib/workspace";
 
 type UnknownRecord = Record<string, unknown>;
@@ -10,11 +11,25 @@ export type McpServerConfig = {
   headers?: Record<string, string>;
 };
 
+/**
+ * Lifecycle of a user-added MCP server in the settings UI:
+ *
+ *   untested    : just added, never probed
+ *   connected   : probe succeeded, tools are reachable
+ *   needs_auth  : probe returned 401/403; user must click Connect
+ *   error       : probe failed for non-auth reasons (network, malformed)
+ */
+export type McpServerState = "untested" | "connected" | "needs_auth" | "error";
+
 export type McpServerEntry = {
   key: string;
   url: string;
   transport: string;
   hasAuth: boolean;
+  state: McpServerState;
+  toolCount: number | null;
+  lastCheckedAt: string | null;
+  lastDetail: string | null;
 };
 
 export class McpServerError extends Error {
@@ -30,6 +45,7 @@ export class McpServerError extends Error {
 const RESERVED_MCP_SERVER_KEYS = new Set(["composio"]);
 const MCP_SERVER_KEY_PATTERN = /^[A-Za-z0-9_-]+$/;
 const REMOTE_MCP_TRANSPORT = "streamable-http";
+const STATE_SIDECAR_FILENAME = ".mcp-states.json";
 
 function asRecord(value: unknown): UnknownRecord | undefined {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -45,6 +61,10 @@ function openClawConfigPath(): string {
   return join(resolveOpenClawStateDir(), "openclaw.json");
 }
 
+function statesSidecarPath(): string {
+  return join(resolveOpenClawStateDir(), STATE_SIDECAR_FILENAME);
+}
+
 function readConfig(): UnknownRecord {
   const configPath = openClawConfigPath();
   if (!existsSync(configPath)) {
@@ -57,12 +77,70 @@ function readConfig(): UnknownRecord {
   }
 }
 
-function writeConfig(config: UnknownRecord): void {
+function ensureStateDir(): void {
   const stateDir = resolveOpenClawStateDir();
   if (!existsSync(stateDir)) {
     mkdirSync(stateDir, { recursive: true });
   }
+}
+
+function writeConfig(config: UnknownRecord): void {
+  ensureStateDir();
   writeFileSync(openClawConfigPath(), JSON.stringify(config, null, 2) + "\n", "utf-8");
+}
+
+type StateRecord = {
+  state: McpServerState;
+  toolCount: number | null;
+  lastCheckedAt: string | null;
+  lastDetail: string | null;
+};
+
+function readStatesSidecar(): Record<string, StateRecord> {
+  const path = statesSidecarPath();
+  if (!existsSync(path)) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+    const record = asRecord(parsed);
+    if (!record) {
+      return {};
+    }
+    const out: Record<string, StateRecord> = {};
+    for (const [key, value] of Object.entries(record)) {
+      const entry = asRecord(value);
+      if (!entry) {
+        continue;
+      }
+      const state = readString(entry.state);
+      out[key] = {
+        state: isMcpServerState(state) ? state : "untested",
+        toolCount: typeof entry.toolCount === "number" ? entry.toolCount : null,
+        lastCheckedAt: readString(entry.lastCheckedAt) ?? null,
+        lastDetail: readString(entry.lastDetail) ?? null,
+      };
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function writeStatesSidecar(states: Record<string, StateRecord>): void {
+  ensureStateDir();
+  writeFileSync(
+    statesSidecarPath(),
+    JSON.stringify(states, null, 2) + "\n",
+    "utf-8",
+  );
+}
+
+function isMcpServerState(value: string | undefined): value is McpServerState {
+  return value === "untested"
+    || value === "connected"
+    || value === "needs_auth"
+    || value === "error";
 }
 
 function ensureRecord(parent: UnknownRecord, key: string): UnknownRecord {
@@ -135,7 +213,20 @@ function formatAuthorizationHeader(authToken?: string | null): string | null {
   return `Bearer ${tokenWithoutPrefix}`;
 }
 
-function toServerEntry(key: string, rawServer: UnknownRecord): McpServerEntry | null {
+function defaultStateRecord(): StateRecord {
+  return {
+    state: "untested",
+    toolCount: null,
+    lastCheckedAt: null,
+    lastDetail: null,
+  };
+}
+
+function buildEntry(
+  key: string,
+  rawServer: UnknownRecord,
+  states: Record<string, StateRecord>,
+): McpServerEntry | null {
   const url = readString(rawServer.url);
   const transport = readString(rawServer.transport);
   if (!url || !transport) {
@@ -143,11 +234,16 @@ function toServerEntry(key: string, rawServer: UnknownRecord): McpServerEntry | 
   }
 
   const headers = asRecord(rawServer.headers);
+  const stateRecord = states[key] ?? defaultStateRecord();
   return {
     key,
     url,
     transport,
     hasAuth: Boolean(readString(headers?.Authorization)),
+    state: stateRecord.state,
+    toolCount: stateRecord.toolCount,
+    lastCheckedAt: stateRecord.lastCheckedAt,
+    lastDetail: stateRecord.lastDetail,
   };
 }
 
@@ -159,14 +255,65 @@ export function listMcpServers(): McpServerEntry[] {
     return [];
   }
 
+  const states = readStatesSidecar();
+
   return Object.entries(servers)
     .filter(([key]) => !RESERVED_MCP_SERVER_KEYS.has(key))
     .map(([key, rawServer]) => {
       const server = asRecord(rawServer);
-      return server ? toServerEntry(key, server) : null;
+      return server ? buildEntry(key, server, states) : null;
     })
     .filter((server): server is McpServerEntry => Boolean(server))
-    .sort((a, b) => a.key.localeCompare(b.key));
+    .toSorted((a, b) => a.key.localeCompare(b.key));
+}
+
+export function getMcpServer(key: string): McpServerEntry | null {
+  const normalizedKey = assertServerKey(key);
+  const config = readConfig();
+  const mcp = asRecord(config.mcp);
+  const servers = asRecord(mcp?.servers);
+  const raw = asRecord(servers?.[normalizedKey]);
+  if (!raw) {
+    return null;
+  }
+  return buildEntry(normalizedKey, raw, readStatesSidecar());
+}
+
+/**
+ * Returns the wire-level config (url, transport, headers) for the given
+ * server, or null if the server doesn't exist. Used by the probe and
+ * connect-token routes that need to make outbound requests on behalf of
+ * the user.
+ */
+export function getMcpServerConfig(key: string): McpServerConfig | null {
+  const normalizedKey = assertServerKey(key);
+  const config = readConfig();
+  const mcp = asRecord(config.mcp);
+  const servers = asRecord(mcp?.servers);
+  const raw = asRecord(servers?.[normalizedKey]);
+  if (!raw) {
+    return null;
+  }
+  const url = readString(raw.url);
+  const transport = readString(raw.transport);
+  if (!url || !transport) {
+    return null;
+  }
+  const headersRaw = asRecord(raw.headers);
+  const headers: Record<string, string> = {};
+  if (headersRaw) {
+    for (const [hKey, hValue] of Object.entries(headersRaw)) {
+      const stringValue = readString(hValue);
+      if (stringValue) {
+        headers[hKey] = stringValue;
+      }
+    }
+  }
+  return {
+    url,
+    transport,
+    ...(Object.keys(headers).length > 0 ? { headers } : {}),
+  };
 }
 
 export function addMcpServer(input: {
@@ -198,12 +345,104 @@ export function addMcpServer(input: {
   servers[key] = nextServer;
 
   writeConfig(config);
+
+  // New servers start untested — the caller is expected to probe immediately
+  // afterward and the result will overwrite this default.
+  const states = readStatesSidecar();
+  states[key] = defaultStateRecord();
+  writeStatesSidecar(states);
+
   return {
     key,
     url,
     transport,
     hasAuth: Boolean(authorizationHeader),
+    state: "untested",
+    toolCount: null,
+    lastCheckedAt: null,
+    lastDetail: null,
   };
+}
+
+/**
+ * Replace the `Authorization` header on an existing server. Pass `null` to
+ * clear it (e.g. after a disconnect or token revocation).
+ *
+ * Used by the Connect flow's token route (Phase 1) and the OAuth callback
+ * route (Phase 2) — both ultimately end up writing a Bearer header here.
+ */
+export function setAuthorizationHeader(
+  key: string,
+  header: string | null,
+): McpServerEntry {
+  const normalizedKey = assertServerKey(key);
+  const config = readConfig();
+  const mcp = asRecord(config.mcp);
+  const servers = asRecord(mcp?.servers);
+  const existing = asRecord(servers?.[normalizedKey]);
+  if (!servers || !existing) {
+    throw new McpServerError(404, `MCP server '${normalizedKey}' was not found.`);
+  }
+
+  const headers = asRecord(existing.headers) ?? {};
+  if (header === null) {
+    delete headers.Authorization;
+    if (Object.keys(headers).length === 0) {
+      delete existing.headers;
+    } else {
+      existing.headers = headers;
+    }
+  } else {
+    headers.Authorization = header;
+    existing.headers = headers;
+  }
+
+  writeConfig(config);
+
+  const entry = buildEntry(normalizedKey, existing, readStatesSidecar());
+  if (!entry) {
+    throw new McpServerError(500, "Failed to read server entry after update.");
+  }
+  return entry;
+}
+
+/**
+ * Persist the result of a probe (or any other state change) for a given
+ * server. Stored in a sidecar file so we don't pollute the wire-level
+ * `mcp.servers.<key>` config that the agent runtime consumes.
+ */
+export function recordServerState(
+  key: string,
+  update: {
+    state: McpServerState;
+    toolCount?: number | null;
+    detail?: string | null;
+    checkedAt?: string;
+  },
+): McpServerEntry {
+  const normalizedKey = assertServerKey(key);
+  const config = readConfig();
+  const mcp = asRecord(config.mcp);
+  const servers = asRecord(mcp?.servers);
+  const existing = asRecord(servers?.[normalizedKey]);
+  if (!existing) {
+    throw new McpServerError(404, `MCP server '${normalizedKey}' was not found.`);
+  }
+
+  const states = readStatesSidecar();
+  states[normalizedKey] = {
+    state: update.state,
+    toolCount: update.toolCount ?? null,
+    lastCheckedAt: update.checkedAt ?? new Date().toISOString(),
+    lastDetail: update.detail ?? null,
+  };
+  writeStatesSidecar(states);
+
+  const entry = buildEntry(normalizedKey, existing, states);
+  if (!entry) {
+    throw new McpServerError(500, "Failed to read server entry after state update.");
+  }
+  return entry;
 }
 
 export function removeMcpServer(key: string): void {
@@ -226,4 +465,11 @@ export function removeMcpServer(key: string): void {
   }
 
   writeConfig(config);
+
+  const states = readStatesSidecar();
+  if (states[normalizedKey]) {
+    delete states[normalizedKey];
+    writeStatesSidecar(states);
+  }
+  deleteMcpServerSecret(normalizedKey);
 }


### PR DESCRIPTION
## Summary
- Adds probe-driven MCP server state so newly added remote servers show connected, needs-auth, or error status based on tools/list.
- Adds Connect endpoints for OAuth PKCE/DCR, manual Bearer-token fallback, refresh-token recovery, and Stripe-compatible OAuth discovery.
- Updates Settings UI with row-level Connect, retry, tool-count badges, popup callback handling, and re-add probe regression coverage.

## Test plan
- pnpm --dir apps/web test lib/mcp-probe.test.ts lib/mcp-oauth.test.ts lib/mcp-secrets.test.ts lib/mcp-servers.test.ts app/api/settings/mcp/route.test.ts app/api/settings/mcp/probe/route.test.ts app/api/settings/mcp/connect/token/route.test.ts app/api/settings/mcp/connect/start/route.test.ts app/api/settings/mcp/connect/callback/route.test.ts app/components/settings/mcp-servers-section.test.tsx
- Live Stripe smoke check: verified protected resource metadata, path-aware authorization server metadata, DCR, and authorize redirect to Stripe login without invalid redirect error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication/token handling and introduces new persistence for refresh tokens plus OAuth callback/popup messaging, where mistakes can cause security issues or broken connectivity. The change spans UI, API routes, and local sidecar storage, increasing integration risk.
> 
> **Overview**
> Adds an end-to-end **MCP Connect** flow: new API routes for probing (`/mcp/probe`), starting OAuth (`/mcp/connect/start`), handling the OAuth callback (`/mcp/connect/callback`), and a manual Bearer-token fallback (`/mcp/connect/token`). The OAuth path performs RFC 9728/8414 discovery, dynamic client registration + PKCE, persists refresh-token secrets in a new `.mcp-secrets.json` sidecar, and posts a `postMessage` result back to the opener.
> 
> Introduces probe-driven per-server state (`untested`/`needs_auth`/`connected`/`error`) stored in a `.mcp-states.json` sidecar, updates `apps/web/lib/mcp-servers.ts` to read/write this state, probe immediately after adding a server, refresh tokens on `invalid_token`, and delete secrets/state on server removal.
> 
> Updates the Settings UI to remove “auth token on add”, show state/tool-count badges, provide row-level **Connect** and **Retry** actions with OAuth popup handling, and adds broad Vitest coverage for the new routes/utilities and UI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28497ed2889196fc8e27caabd46f994f7aef7fa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->