### PR TITLE
fix(web): sync Gmail onboarding integration state

### DIFF
--- a/apps/web/app/api/composio/callback/route.test.ts
+++ b/apps/web/app/api/composio/callback/route.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GET } from "./route";
 
+const { invalidateComposioConnectionsCacheMock } = vi.hoisted(() => ({
+  invalidateComposioConnectionsCacheMock: vi.fn(),
+}));
+
+vi.mock("../connections/route", () => ({
+  invalidateComposioConnectionsCache: invalidateComposioConnectionsCacheMock,
+}));
+
 vi.mock("@/lib/integrations", () => ({
   refreshIntegrationsRuntime: vi.fn(),
 }));
@@ -59,6 +67,7 @@ describe("Composio callback API", () => {
 
     const html = await response.text();
     expect(response.status).toBe(200);
+    expect(invalidateComposioConnectionsCacheMock).toHaveBeenCalledTimes(1);
     expect(mockedRefreshIntegrationsRuntime).toHaveBeenCalledTimes(1);
     expect(html).toContain('"connected_account_id":"acct_123"');
     expect(html).toContain('"connected_toolkit_slug":"x"');
@@ -71,6 +80,7 @@ describe("Composio callback API", () => {
     );
 
     expect(response.status).toBe(200);
+    expect(invalidateComposioConnectionsCacheMock).not.toHaveBeenCalled();
     expect(mockedRefreshIntegrationsRuntime).not.toHaveBeenCalled();
   });
 

--- a/apps/web/app/api/composio/callback/route.ts
+++ b/apps/web/app/api/composio/callback/route.ts
@@ -3,6 +3,7 @@ import {
   resolveComposioApiKey,
   resolveComposioGatewayUrl,
 } from "@/lib/composio";
+import { invalidateComposioConnectionsCache } from "../connections/route";
 import {
   extractComposioConnections,
   normalizeComposioConnections,
@@ -77,6 +78,7 @@ export async function GET(request: Request) {
     | Awaited<ReturnType<typeof resolveConnectedToolkitSummary>>
     | undefined;
   if (success) {
+    invalidateComposioConnectionsCache();
     resolvedConnection = await resolveConnectedToolkitSummary(connectedAccountId);
     void (async () => {
       try {

--- a/apps/web/app/api/composio/connections/route.test.ts
+++ b/apps/web/app/api/composio/connections/route.test.ts
@@ -87,6 +87,48 @@ describe("Composio connections API", () => {
     expect(fetchComposioToolkitsMock).toHaveBeenCalledTimes(1);
   });
 
+  it("invalidates cached connections while preserving cached toolkit metadata", async () => {
+    fetchComposioConnectionsMock
+      .mockResolvedValueOnce({
+        connections: [
+          {
+            id: "ca_twitter_1",
+            toolkit_slug: "twitter",
+            toolkit_name: "Twitter",
+            status: "ACTIVE",
+            created_at: "2026-04-03T00:00:00.000Z",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        connections: [
+          {
+            id: "ca_gmail_1",
+            toolkit_slug: "gmail",
+            toolkit_name: "Gmail",
+            status: "ACTIVE",
+            created_at: "2026-04-04T00:00:00.000Z",
+          },
+        ],
+      });
+    const { GET, invalidateComposioConnectionsCache } = await import("./route");
+    const request = new Request("http://localhost/api/composio/connections?include_toolkits=1");
+
+    const cachedResponse = await GET(request);
+    const cachedBody = await cachedResponse.json();
+    const repeatedResponse = await GET(request);
+    const repeatedBody = await repeatedResponse.json();
+    invalidateComposioConnectionsCache();
+    const invalidatedResponse = await GET(request);
+    const invalidatedBody = await invalidatedResponse.json();
+
+    expect(cachedBody.connections[0].toolkit_slug).toBe("twitter");
+    expect(repeatedBody.connections[0].toolkit_slug).toBe("twitter");
+    expect(invalidatedBody.connections[0].toolkit_slug).toBe("gmail");
+    expect(fetchComposioConnectionsMock).toHaveBeenCalledTimes(2);
+    expect(fetchComposioToolkitsMock).toHaveBeenCalledTimes(1);
+  });
+
   it("uses connection-backed placeholders when the bulk toolkit fetch misses", async () => {
     fetchComposioToolkitsMock.mockResolvedValueOnce({ items: [] });
     fetchComposioConnectionsMock.mockResolvedValue({

--- a/apps/web/app/api/composio/connections/route.ts
+++ b/apps/web/app/api/composio/connections/route.ts
@@ -39,6 +39,11 @@ const connectionsCache = new Map<string, CacheEntry<ComposioConnectionsResponse>
 const toolkitBulkCache = new Map<string, CacheEntry<ComposioToolkit[]>>();
 const resolvedToolkitsCache = new Map<string, CacheEntry<ComposioToolkit[]>>();
 
+export function invalidateComposioConnectionsCache(): void {
+  connectionsCache.clear();
+  resolvedToolkitsCache.clear();
+}
+
 function buildCacheKey(gatewayUrl: string, apiKey: string, suffix = ""): string {
   return `${gatewayUrl}::${apiKey}${suffix ? `::${suffix}` : ""}`;
 }

--- a/apps/web/app/components/integrations/composio-apps-section.test.tsx
+++ b/apps/web/app/components/integrations/composio-apps-section.test.tsx
@@ -239,6 +239,9 @@ describe("ComposioAppsSection", () => {
       expect(screen.getByText("Gmail")).toBeInTheDocument();
     });
 
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/composio/connections?include_toolkits=1&fresh=1",
+    );
     expect(screen.getByText("Your Apps")).toBeInTheDocument();
     expect(screen.getByText("GitHub")).toBeInTheDocument();
 

--- a/apps/web/app/components/integrations/composio-apps-section.tsx
+++ b/apps/web/app/components/integrations/composio-apps-section.tsx
@@ -437,7 +437,7 @@ export function ComposioAppsSection({
         return;
       }
       initialFetchStartedRef.current = true;
-      void fetchData();
+      void fetchData({ fresh: true });
     } else {
       initialFetchStartedRef.current = false;
       setState((prev) => ({ ...prev, loading: false }));


### PR DESCRIPTION
## Summary
- Clear the Composio connections cache after successful OAuth callbacks so newly connected Gmail accounts do not stay hidden behind stale reads.
- Keep toolkit metadata cached while invalidating connection-derived state.
- Make the Integrations page's first Composio read fresh as a fallback when navigating there after onboarding.

## Test plan
- pnpm --dir apps/web test app/api/composio/connections/route.test.ts app/api/composio/callback/route.test.ts app/components/integrations/composio-apps-section.test.tsx app/components/integrations/integrations-panel.test.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized cache-invalidation and fetch-parameter changes around Composio integrations; main risk is increased upstream calls or unexpected cache clearing timing.
> 
> **Overview**
> Fixes stale Composio connection state after OAuth by **clearing the server-side connections-derived caches** via a new exported `invalidateComposioConnectionsCache()` and calling it on successful `/api/composio/callback` before resolving the connected toolkit summary.
> 
> Updates the Integrations UI to **force the initial connections fetch to bypass cache** (`fresh=1`) as a fallback when landing on the page after onboarding, and adds/adjusts tests to assert cache invalidation behavior (while preserving toolkit-metadata caching) and the new initial fetch URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d74e7e37c3d20cac4a8ea94053a107d39e009989. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->