### PR TITLE
fix(web): move composio cache invalidation out of route module

### DIFF
--- a/apps/web/app/api/composio/callback/route.test.ts
+++ b/apps/web/app/api/composio/callback/route.test.ts
@@ -5,7 +5,7 @@ const { invalidateComposioConnectionsCacheMock } = vi.hoisted(() => ({
   invalidateComposioConnectionsCacheMock: vi.fn(),
 }));
 
-vi.mock("../connections/route", () => ({
+vi.mock("../connections/cache", () => ({
   invalidateComposioConnectionsCache: invalidateComposioConnectionsCacheMock,
 }));
 

--- a/apps/web/app/api/composio/callback/route.ts
+++ b/apps/web/app/api/composio/callback/route.ts
@@ -3,7 +3,7 @@ import {
   resolveComposioApiKey,
   resolveComposioGatewayUrl,
 } from "@/lib/composio";
-import { invalidateComposioConnectionsCache } from "../connections/route";
+import { invalidateComposioConnectionsCache } from "../connections/cache";
 import {
   extractComposioConnections,
   normalizeComposioConnections,

--- a/apps/web/app/api/composio/connections/cache.ts
+++ b/apps/web/app/api/composio/connections/cache.ts
@@ -1,0 +1,102 @@
+import type { ComposioConnectionsResponse, ComposioToolkit } from "@/lib/composio";
+
+const CONNECTIONS_CACHE_TTL_MS = 60_000;
+const TOOLKIT_LOOKUP_CACHE_TTL_MS = 5 * 60_000;
+const RESOLVED_TOOLKITS_CACHE_TTL_MS = 60_000;
+
+type CacheEntry<T> =
+  | {
+      expiresAt: number;
+      value: T;
+    }
+  | {
+      expiresAt: number;
+      promise: Promise<T>;
+    };
+
+const connectionsCache = new Map<string, CacheEntry<ComposioConnectionsResponse>>();
+const toolkitBulkCache = new Map<string, CacheEntry<ComposioToolkit[]>>();
+const resolvedToolkitsCache = new Map<string, CacheEntry<ComposioToolkit[]>>();
+
+function buildCacheKey(gatewayUrl: string, apiKey: string, suffix = ""): string {
+  return `${gatewayUrl}::${apiKey}${suffix ? `::${suffix}` : ""}`;
+}
+
+async function readThroughCache<T>(
+  cache: Map<string, CacheEntry<T>>,
+  key: string,
+  ttlMs: number,
+  loader: () => Promise<T>,
+): Promise<T> {
+  const now = Date.now();
+  const cached = cache.get(key);
+  if (cached && cached.expiresAt > now) {
+    if ("value" in cached) {
+      return cached.value;
+    }
+    return cached.promise;
+  }
+
+  const promise = loader();
+  cache.set(key, {
+    expiresAt: now + ttlMs,
+    promise,
+  });
+
+  try {
+    const value = await promise;
+    cache.set(key, {
+      expiresAt: Date.now() + ttlMs,
+      value,
+    });
+    return value;
+  } catch (error) {
+    cache.delete(key);
+    throw error;
+  }
+}
+
+export function invalidateComposioConnectionsCache(): void {
+  connectionsCache.clear();
+  resolvedToolkitsCache.clear();
+}
+
+export async function fetchConnectionsCached(
+  gatewayUrl: string,
+  apiKey: string,
+  loader: () => Promise<ComposioConnectionsResponse>,
+): Promise<ComposioConnectionsResponse> {
+  return await readThroughCache(
+    connectionsCache,
+    buildCacheKey(gatewayUrl, apiKey, "connections"),
+    CONNECTIONS_CACHE_TTL_MS,
+    loader,
+  );
+}
+
+export async function fetchBulkToolkitsCached(
+  gatewayUrl: string,
+  apiKey: string,
+  loader: () => Promise<ComposioToolkit[]>,
+): Promise<ComposioToolkit[]> {
+  return await readThroughCache(
+    toolkitBulkCache,
+    buildCacheKey(gatewayUrl, apiKey, "toolkits-bulk:100"),
+    TOOLKIT_LOOKUP_CACHE_TTL_MS,
+    loader,
+  );
+}
+
+export async function fetchResolvedToolkitsCached(
+  gatewayUrl: string,
+  apiKey: string,
+  activeSlugs: string[],
+  loader: () => Promise<ComposioToolkit[]>,
+): Promise<ComposioToolkit[]> {
+  return await readThroughCache(
+    resolvedToolkitsCache,
+    buildCacheKey(gatewayUrl, apiKey, `resolved-toolkits:${[...activeSlugs].toSorted().join(",")}`),
+    RESOLVED_TOOLKITS_CACHE_TTL_MS,
+    loader,
+  );
+}

--- a/apps/web/app/api/composio/connections/route.test.ts
+++ b/apps/web/app/api/composio/connections/route.test.ts
@@ -111,7 +111,8 @@ describe("Composio connections API", () => {
           },
         ],
       });
-    const { GET, invalidateComposioConnectionsCache } = await import("./route");
+    const { GET } = await import("./route");
+    const { invalidateComposioConnectionsCache } = await import("./cache");
     const request = new Request("http://localhost/api/composio/connections?include_toolkits=1");
 
     const cachedResponse = await GET(request);

--- a/apps/web/app/api/composio/connections/route.ts
+++ b/apps/web/app/api/composio/connections/route.ts
@@ -16,71 +16,16 @@ import {
   normalizeComposioToolkitName,
   normalizeComposioToolkitSlug,
 } from "@/lib/composio-normalization";
+import {
+  fetchBulkToolkitsCached as fetchBulkToolkitsThroughCache,
+  fetchConnectionsCached as fetchConnectionsThroughCache,
+  fetchResolvedToolkitsCached,
+} from "./cache";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-const CONNECTIONS_CACHE_TTL_MS = 60_000;
-const TOOLKIT_LOOKUP_CACHE_TTL_MS = 5 * 60_000;
 const CONNECTED_TOOLKIT_BULK_LIMIT = 100;
-const RESOLVED_TOOLKITS_CACHE_TTL_MS = 60_000;
-
-type CacheEntry<T> =
-  | {
-      expiresAt: number;
-      value: T;
-    }
-  | {
-      expiresAt: number;
-      promise: Promise<T>;
-    };
-
-const connectionsCache = new Map<string, CacheEntry<ComposioConnectionsResponse>>();
-const toolkitBulkCache = new Map<string, CacheEntry<ComposioToolkit[]>>();
-const resolvedToolkitsCache = new Map<string, CacheEntry<ComposioToolkit[]>>();
-
-export function invalidateComposioConnectionsCache(): void {
-  connectionsCache.clear();
-  resolvedToolkitsCache.clear();
-}
-
-function buildCacheKey(gatewayUrl: string, apiKey: string, suffix = ""): string {
-  return `${gatewayUrl}::${apiKey}${suffix ? `::${suffix}` : ""}`;
-}
-
-async function readThroughCache<T>(
-  cache: Map<string, CacheEntry<T>>,
-  key: string,
-  ttlMs: number,
-  loader: () => Promise<T>,
-): Promise<T> {
-  const now = Date.now();
-  const cached = cache.get(key);
-  if (cached && cached.expiresAt > now) {
-    if ("value" in cached) {
-      return cached.value;
-    }
-    return cached.promise;
-  }
-
-  const promise = loader();
-  cache.set(key, {
-    expiresAt: now + ttlMs,
-    promise,
-  });
-
-  try {
-    const value = await promise;
-    cache.set(key, {
-      expiresAt: Date.now() + ttlMs,
-      value,
-    });
-    return value;
-  } catch (error) {
-    cache.delete(key);
-    throw error;
-  }
-}
 
 function createToolkitPlaceholder(slug: string, name: string): ComposioToolkit {
   return {
@@ -99,10 +44,9 @@ async function fetchConnectionsCached(
   gatewayUrl: string,
   apiKey: string,
 ): Promise<ComposioConnectionsResponse> {
-  return await readThroughCache(
-    connectionsCache,
-    buildCacheKey(gatewayUrl, apiKey, "connections"),
-    CONNECTIONS_CACHE_TTL_MS,
+  return await fetchConnectionsThroughCache(
+    gatewayUrl,
+    apiKey,
     async () => await fetchComposioConnections(gatewayUrl, apiKey),
   );
 }
@@ -111,10 +55,9 @@ async function fetchBulkToolkitsCached(
   gatewayUrl: string,
   apiKey: string,
 ): Promise<ComposioToolkit[]> {
-  return await readThroughCache(
-    toolkitBulkCache,
-    buildCacheKey(gatewayUrl, apiKey, `toolkits-bulk:${CONNECTED_TOOLKIT_BULK_LIMIT}`),
-    TOOLKIT_LOOKUP_CACHE_TTL_MS,
+  return await fetchBulkToolkitsThroughCache(
+    gatewayUrl,
+    apiKey,
     async () => extractComposioToolkits(await fetchComposioToolkits(gatewayUrl, apiKey, {
       limit: CONNECTED_TOOLKIT_BULK_LIMIT,
     })).items,
@@ -139,16 +82,10 @@ async function resolveConnectedToolkits(
     return [];
   }
 
-  const resolvedCacheKey = buildCacheKey(
+  return await fetchResolvedToolkitsCached(
     gatewayUrl,
     apiKey,
-    `resolved-toolkits:${[...activeSlugs].toSorted().join(",")}`,
-  );
-
-  return await readThroughCache(
-    resolvedToolkitsCache,
-    resolvedCacheKey,
-    RESOLVED_TOOLKITS_CACHE_TTL_MS,
+    activeSlugs,
     async () => {
       const bulkToolkits = preFetchedBulkToolkits
         ?? await fetchBulkToolkitsCached(gatewayUrl, apiKey).catch(() => []);


### PR DESCRIPTION
## Summary
- extract Composio connection/toolkit cache state and invalidation into `app/api/composio/connections/cache.ts`
- keep `app/api/composio/connections/route.ts` limited to valid Next.js route exports and handlers
- update callback + tests to import cache invalidation from the new helper module

## Test plan
- [x] Run `pnpm web:build`
- [x] Confirm Next.js route typecheck no longer reports invalid export fields

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of caching utilities and imports with minimal logic change; main risk is subtle cache-key/TTL regressions impacting connection/toolkit freshness.
> 
> **Overview**
> Refactors Composio connections/toolkit caching by moving the in-memory cache state, read-through logic, and `invalidateComposioConnectionsCache()` out of the Next.js `connections/route.ts` module into a new `connections/cache.ts` helper.
> 
> Updates the Composio callback route and related tests to import cache invalidation (and, in `connections/route.ts`, cache-backed fetch helpers) from the new module, keeping the route file limited to Next.js handler exports while preserving the existing caching behavior and invalidation semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5899a8457a45d7069b23c0d977f5a5323b9b6c20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->