### PR TITLE
Fix onboarding Composio connection state

### DIFF
--- a/apps/web/app/api/composio/callback/route.test.ts
+++ b/apps/web/app/api/composio/callback/route.test.ts
@@ -1,8 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GET } from "./route";
 
-const { invalidateComposioConnectionsCacheMock } = vi.hoisted(() => ({
+const {
+  invalidateComposioConnectionsCacheMock,
+  readOnboardingStateMock,
+  writeConnectionMock,
+  writeOnboardingStateMock,
+} = vi.hoisted(() => ({
   invalidateComposioConnectionsCacheMock: vi.fn(),
+  readOnboardingStateMock: vi.fn(),
+  writeConnectionMock: vi.fn(),
+  writeOnboardingStateMock: vi.fn(),
 }));
 
 vi.mock("../connections/cache", () => ({
@@ -17,6 +25,12 @@ vi.mock("@/lib/composio", () => ({
   fetchComposioConnections: vi.fn(),
   resolveComposioApiKey: vi.fn(() => "dench_test_key"),
   resolveComposioGatewayUrl: vi.fn(() => "https://gateway.example.com"),
+}));
+
+vi.mock("@/lib/denchclaw-state", () => ({
+  readOnboardingState: readOnboardingStateMock,
+  writeConnection: writeConnectionMock,
+  writeOnboardingState: writeOnboardingStateMock,
 }));
 
 const { refreshIntegrationsRuntime } = await import("@/lib/integrations");
@@ -36,6 +50,13 @@ describe("Composio callback API", () => {
       restarted: true,
       error: null,
       profile: "dench",
+    });
+    readOnboardingStateMock.mockReturnValue({
+      version: 1,
+      currentStep: "connect-gmail",
+      completedSteps: ["welcome", "identity", "dench-cloud"],
+      startedAt: "2026-04-01T00:00:00.000Z",
+      updatedAt: "2026-04-01T00:00:00.000Z",
     });
     mockedFetchComposioConnections.mockResolvedValue({
       connections: [
@@ -72,6 +93,46 @@ describe("Composio callback API", () => {
     expect(html).toContain('"connected_account_id":"acct_123"');
     expect(html).toContain('"connected_toolkit_slug":"x"');
     expect(html).toContain('"connected_toolkit_name":"X"');
+  });
+
+  it("persists Gmail callback connections for the sync runner", async () => {
+    mockedFetchComposioConnections.mockResolvedValue({
+      connections: [
+        {
+          id: "acct_gmail",
+          toolkit_slug: "gmail",
+          toolkit_name: "Gmail",
+          status: "ACTIVE",
+          created_at: "2026-04-02T00:00:00.000Z",
+          account_email: "person@example.com",
+        },
+      ],
+    } as never);
+
+    const response = await GET(
+      new Request(
+        "http://localhost/api/composio/callback?status=success&connected_account_id=acct_gmail",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(writeConnectionMock).toHaveBeenCalledWith(
+      "gmail",
+      expect.objectContaining({
+        connectionId: "acct_gmail",
+        toolkitSlug: "gmail",
+        accountEmail: "person@example.com",
+      }),
+    );
+    expect(writeOnboardingStateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connections: expect.objectContaining({
+          gmail: expect.objectContaining({
+            connectionId: "acct_gmail",
+          }),
+        }),
+      }),
+    );
   });
 
   it("does not rebuild when the callback is unsuccessful", async () => {

--- a/apps/web/app/api/composio/callback/route.ts
+++ b/apps/web/app/api/composio/callback/route.ts
@@ -8,8 +8,15 @@ import {
   extractComposioConnections,
   normalizeComposioConnections,
 } from "@/lib/composio-client";
+import {
+  readOnboardingState,
+  writeConnection,
+  writeOnboardingState,
+  type ConnectionRecord,
+} from "@/lib/denchclaw-state";
 import { refreshIntegrationsRuntime } from "@/lib/integrations";
 import { resolveAppPublicOrigin } from "@/lib/public-origin";
+import type { NormalizedComposioConnection } from "@/lib/composio";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -18,26 +25,59 @@ function serializeForInlineScript(value: unknown): string {
   return JSON.stringify(value).replace(/</g, "\\u003c");
 }
 
-async function resolveConnectedToolkitSummary(connectedAccountId: string): Promise<{
-  toolkit_slug: string | null;
-  toolkit_name: string | null;
-  status: string | null;
-}> {
+function syncToolkitFromConnection(
+  connection: NormalizedComposioConnection,
+): "gmail" | "calendar" | null {
+  if (connection.normalized_toolkit_slug === "gmail") {
+    return "gmail";
+  }
+  if (
+    connection.normalized_toolkit_slug === "google-calendar" ||
+    connection.normalized_toolkit_slug === "googlecalendar"
+  ) {
+    return "calendar";
+  }
+  return null;
+}
+
+function persistLocalSyncConnection(connection: NormalizedComposioConnection): void {
+  if (!connection.is_active) {
+    return;
+  }
+  const toolkit = syncToolkitFromConnection(connection);
+  if (!toolkit) {
+    return;
+  }
+
+  const record: ConnectionRecord = {
+    connectionId: connection.id,
+    toolkitSlug: connection.normalized_toolkit_slug,
+    accountEmail: connection.account_email ?? connection.account?.email ?? undefined,
+    accountLabel: connection.display_label,
+    connectedAt: new Date().toISOString(),
+  };
+  writeConnection(toolkit, record);
+
+  const current = readOnboardingState();
+  writeOnboardingState({
+    ...current,
+    connections: {
+      ...current.connections,
+      [toolkit]: record,
+    },
+  });
+}
+
+async function resolveConnectedConnection(
+  connectedAccountId: string,
+): Promise<NormalizedComposioConnection | null> {
   if (!connectedAccountId) {
-    return {
-      toolkit_slug: null,
-      toolkit_name: null,
-      status: null,
-    };
+    return null;
   }
 
   const apiKey = resolveComposioApiKey();
   if (!apiKey) {
-    return {
-      toolkit_slug: null,
-      toolkit_name: null,
-      status: null,
-    };
+    return null;
   }
 
   try {
@@ -46,18 +86,9 @@ async function resolveConnectedToolkitSummary(connectedAccountId: string): Promi
         await fetchComposioConnections(resolveComposioGatewayUrl(), apiKey),
       ),
     );
-    const match = connections.find((connection) => connection.id === connectedAccountId);
-    return {
-      toolkit_slug: match?.normalized_toolkit_slug ?? null,
-      toolkit_name: match?.toolkit_name ?? null,
-      status: match?.normalized_status ?? null,
-    };
+    return connections.find((connection) => connection.id === connectedAccountId) ?? null;
   } catch {
-    return {
-      toolkit_slug: null,
-      toolkit_name: null,
-      status: null,
-    };
+    return null;
   }
 }
 
@@ -75,11 +106,14 @@ export async function GET(request: Request) {
 
   const success = status === "success";
   let resolvedConnection:
-    | Awaited<ReturnType<typeof resolveConnectedToolkitSummary>>
+    | Awaited<ReturnType<typeof resolveConnectedConnection>>
     | undefined;
   if (success) {
     invalidateComposioConnectionsCache();
-    resolvedConnection = await resolveConnectedToolkitSummary(connectedAccountId);
+    resolvedConnection = await resolveConnectedConnection(connectedAccountId);
+    if (resolvedConnection) {
+      persistLocalSyncConnection(resolvedConnection);
+    }
     void (async () => {
       try {
         await refreshIntegrationsRuntime();
@@ -90,9 +124,9 @@ export async function GET(request: Request) {
     type: "composio-callback",
     status,
     connected_account_id: connectedAccountId,
-    connected_toolkit_slug: resolvedConnection?.toolkit_slug ?? null,
+    connected_toolkit_slug: resolvedConnection?.normalized_toolkit_slug ?? null,
     connected_toolkit_name: resolvedConnection?.toolkit_name ?? null,
-    connected_status: resolvedConnection?.status ?? null,
+    connected_status: resolvedConnection?.normalized_status ?? null,
   });
   const targetOriginJson = serializeForInlineScript(targetOrigin);
 

--- a/apps/web/app/api/composio/connect/route.test.ts
+++ b/apps/web/app/api/composio/connect/route.test.ts
@@ -123,7 +123,7 @@ describe("Composio connect API", () => {
     );
   });
 
-  it("rejects a second active connection for the same app", async () => {
+  it("returns the existing active connection for the same app", async () => {
     fetchComposioConnectionsMock.mockResolvedValue({
       connections: [
         {
@@ -132,6 +132,7 @@ describe("Composio connect API", () => {
           toolkit_name: "Gmail",
           status: "ACTIVE",
           created_at: "2026-04-01T00:00:00.000Z",
+          account_email: "person@example.com",
         },
       ],
     });
@@ -144,16 +145,20 @@ describe("Composio connect API", () => {
       }),
     );
 
-    expect(response.status).toBe(409);
+    expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
-      code: "APP_ALREADY_CONNECTED",
+      already_connected: true,
       connection_id: "ca_gmail_1",
+      connected_account_id: "ca_gmail_1",
       toolkit: "gmail",
+      connected_toolkit_slug: "gmail",
+      connected_toolkit_name: "Gmail",
+      account_email: "person@example.com",
     });
     expect(initiateComposioConnectMock).not.toHaveBeenCalled();
   });
 
-  it("treats Google Calendar connect slug aliases as the same app", async () => {
+  it("returns an existing Google Calendar connection for connect slug aliases", async () => {
     fetchComposioConnectionsMock.mockResolvedValue({
       connections: [
         {
@@ -174,11 +179,13 @@ describe("Composio connect API", () => {
       }),
     );
 
-    expect(response.status).toBe(409);
+    expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
-      code: "APP_ALREADY_CONNECTED",
+      already_connected: true,
       connection_id: "ca_calendar_1",
+      connected_account_id: "ca_calendar_1",
       toolkit: "google-calendar",
+      connected_toolkit_slug: "google-calendar",
     });
     expect(initiateComposioConnectMock).not.toHaveBeenCalled();
   });

--- a/apps/web/app/api/composio/connect/route.test.ts
+++ b/apps/web/app/api/composio/connect/route.test.ts
@@ -7,12 +7,18 @@ const {
   resolveComposioApiKeyMock,
   resolveComposioEligibilityMock,
   resolveComposioGatewayUrlMock,
+  readOnboardingStateMock,
+  writeConnectionMock,
+  writeOnboardingStateMock,
 } = vi.hoisted(() => ({
   fetchComposioConnectionsMock: vi.fn(),
   initiateComposioConnectMock: vi.fn(),
   resolveComposioApiKeyMock: vi.fn(),
   resolveComposioEligibilityMock: vi.fn(),
   resolveComposioGatewayUrlMock: vi.fn(),
+  readOnboardingStateMock: vi.fn(),
+  writeConnectionMock: vi.fn(),
+  writeOnboardingStateMock: vi.fn(),
 }));
 
 vi.mock("@/lib/composio", () => ({
@@ -21,6 +27,12 @@ vi.mock("@/lib/composio", () => ({
   resolveComposioApiKey: resolveComposioApiKeyMock,
   resolveComposioEligibility: resolveComposioEligibilityMock,
   resolveComposioGatewayUrl: resolveComposioGatewayUrlMock,
+}));
+
+vi.mock("@/lib/denchclaw-state", () => ({
+  readOnboardingState: readOnboardingStateMock,
+  writeConnection: writeConnectionMock,
+  writeOnboardingState: writeOnboardingStateMock,
 }));
 
 const ORIGINAL_PUBLIC_URL = process.env.DENCHCLAW_PUBLIC_URL;
@@ -39,6 +51,13 @@ describe("Composio connect API", () => {
     fetchComposioConnectionsMock.mockResolvedValue({ connections: [] });
     initiateComposioConnectMock.mockResolvedValue({
       redirect_url: "https://composio.example/connect/zoho",
+    });
+    readOnboardingStateMock.mockReturnValue({
+      version: 1,
+      currentStep: "connect-gmail",
+      completedSteps: ["welcome", "identity", "dench-cloud"],
+      startedAt: "2026-04-01T00:00:00.000Z",
+      updatedAt: "2026-04-01T00:00:00.000Z",
     });
   });
 
@@ -156,6 +175,23 @@ describe("Composio connect API", () => {
       account_email: "person@example.com",
     });
     expect(initiateComposioConnectMock).not.toHaveBeenCalled();
+    expect(writeConnectionMock).toHaveBeenCalledWith(
+      "gmail",
+      expect.objectContaining({
+        connectionId: "ca_gmail_1",
+        toolkitSlug: "gmail",
+        accountEmail: "person@example.com",
+      }),
+    );
+    expect(writeOnboardingStateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connections: expect.objectContaining({
+          gmail: expect.objectContaining({
+            connectionId: "ca_gmail_1",
+          }),
+        }),
+      }),
+    );
   });
 
   it("returns an existing Google Calendar connection for connect slug aliases", async () => {

--- a/apps/web/app/api/composio/connect/route.ts
+++ b/apps/web/app/api/composio/connect/route.ts
@@ -10,8 +10,15 @@ import {
   normalizeComposioConnections,
   normalizeComposioToolkitSlug,
 } from "@/lib/composio-client";
+import {
+  readOnboardingState,
+  writeConnection,
+  writeOnboardingState,
+  type ConnectionRecord,
+} from "@/lib/denchclaw-state";
 import { resolveComposioConnectToolkitSlug } from "@/lib/composio-normalization";
 import { resolveAppPublicOrigin } from "@/lib/public-origin";
+import type { NormalizedComposioConnection } from "@/lib/composio";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -19,6 +26,49 @@ export const runtime = "nodejs";
 type ConnectRequestBody = {
   toolkit?: unknown;
 };
+
+function syncToolkitFromConnection(
+  connection: NormalizedComposioConnection,
+): "gmail" | "calendar" | null {
+  if (connection.normalized_toolkit_slug === "gmail") {
+    return "gmail";
+  }
+  if (
+    connection.normalized_toolkit_slug === "google-calendar" ||
+    connection.normalized_toolkit_slug === "googlecalendar"
+  ) {
+    return "calendar";
+  }
+  return null;
+}
+
+function persistLocalSyncConnection(connection: NormalizedComposioConnection): void {
+  if (!connection.is_active) {
+    return;
+  }
+  const toolkit = syncToolkitFromConnection(connection);
+  if (!toolkit) {
+    return;
+  }
+
+  const record: ConnectionRecord = {
+    connectionId: connection.id,
+    toolkitSlug: connection.normalized_toolkit_slug,
+    accountEmail: connection.account_email ?? connection.account?.email ?? undefined,
+    accountLabel: connection.display_label,
+    connectedAt: new Date().toISOString(),
+  };
+  writeConnection(toolkit, record);
+
+  const current = readOnboardingState();
+  writeOnboardingState({
+    ...current,
+    connections: {
+      ...current.connections,
+      [toolkit]: record,
+    },
+  });
+}
 
 export async function POST(request: Request) {
   const apiKey = resolveComposioApiKey();
@@ -68,6 +118,7 @@ export async function POST(request: Request) {
     ).find((connection) => connection.normalized_toolkit_slug === normalizedToolkit && connection.is_active);
 
     if (activeConnection) {
+      persistLocalSyncConnection(activeConnection);
       return Response.json({
         already_connected: true,
         connection_id: activeConnection.id,

--- a/apps/web/app/api/composio/connect/route.ts
+++ b/apps/web/app/api/composio/connect/route.ts
@@ -68,15 +68,18 @@ export async function POST(request: Request) {
     ).find((connection) => connection.normalized_toolkit_slug === normalizedToolkit && connection.is_active);
 
     if (activeConnection) {
-      return Response.json(
-        {
-          error: "This app is already connected. Disconnect it before connecting another account.",
-          code: "APP_ALREADY_CONNECTED",
-          connection_id: activeConnection.id,
-          toolkit: normalizedToolkit,
-        },
-        { status: 409 },
-      );
+      return Response.json({
+        already_connected: true,
+        connection_id: activeConnection.id,
+        connected_account_id: activeConnection.id,
+        requested_toolkit: requestedToolkit,
+        connect_toolkit: connectToolkit,
+        toolkit: normalizedToolkit,
+        connected_toolkit_slug: activeConnection.normalized_toolkit_slug,
+        connected_toolkit_name: activeConnection.toolkit_name,
+        account_email: activeConnection.account_email ?? activeConnection.account?.email ?? null,
+        account_label: activeConnection.display_label,
+      });
     }
 
     const data = await initiateComposioConnect(

--- a/apps/web/app/api/composio/status/route.test.ts
+++ b/apps/web/app/api/composio/status/route.test.ts
@@ -55,7 +55,7 @@ describe("Composio status API", () => {
     const body = await response.json();
     expect(response.status).toBe(200);
     expect(body.summary.level).toBe("healthy");
-    expect(mockedGetComposioMcpHealth).toHaveBeenCalledWith();
+    expect(mockedGetComposioMcpHealth).toHaveBeenCalledWith({ autoRepairConfig: true });
   });
 
   it("GET uses Dench Integrations branding for fallback load errors", async () => {
@@ -83,6 +83,18 @@ describe("Composio status API", () => {
     });
   });
 
+  it("POST refresh_status also self-heals missing MCP registration", async () => {
+    const request = new Request("http://localhost/api/composio/status", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "refresh_status" }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+    expect(mockedGetComposioMcpHealth).toHaveBeenCalledWith({ autoRepairConfig: true });
+  });
+
   it("POST runs the live-agent probe when requested", async () => {
     const request = new Request("http://localhost/api/composio/status", {
       method: "POST",
@@ -92,7 +104,10 @@ describe("Composio status API", () => {
 
     const response = await POST(request);
     expect(response.status).toBe(200);
-    expect(mockedGetComposioMcpHealth).toHaveBeenCalledWith({ includeLiveAgentProbe: true });
+    expect(mockedGetComposioMcpHealth).toHaveBeenCalledWith({
+      autoRepairConfig: true,
+      includeLiveAgentProbe: true,
+    });
   });
 
   it("POST uses Dench Integrations branding for fallback update errors", async () => {

--- a/apps/web/app/api/composio/status/route.ts
+++ b/apps/web/app/api/composio/status/route.ts
@@ -10,7 +10,7 @@ type PostBody = {
 
 export async function GET() {
   try {
-    const status = await getComposioMcpHealth();
+    const status = await getComposioMcpHealth({ autoRepairConfig: true });
     return Response.json(status);
   } catch (error) {
     return Response.json(
@@ -33,7 +33,7 @@ export async function POST(request: Request) {
 
   try {
     if (!body.action || body.action === "refresh_status") {
-      return Response.json(await getComposioMcpHealth());
+      return Response.json(await getComposioMcpHealth({ autoRepairConfig: true }));
     }
     if (body.action === "repair_mcp") {
       return Response.json(await getComposioMcpHealth({
@@ -42,7 +42,10 @@ export async function POST(request: Request) {
       }));
     }
     if (body.action === "probe_live_agent") {
-      return Response.json(await getComposioMcpHealth({ includeLiveAgentProbe: true }));
+      return Response.json(await getComposioMcpHealth({
+        autoRepairConfig: true,
+        includeLiveAgentProbe: true,
+      }));
     }
     return Response.json(
       { error: "Unknown action. Use 'refresh_status', 'repair_mcp', or 'probe_live_agent'." },

--- a/apps/web/app/components/integrations/chat-composio-modal-host.test.tsx
+++ b/apps/web/app/components/integrations/chat-composio-modal-host.test.tsx
@@ -1,8 +1,42 @@
 // @vitest-environment jsdom
 
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ComposioChatAction } from "@/lib/composio-chat-actions";
 import { ChatComposioModalHost } from "./chat-composio-modal-host";
+
+function requestUrl(input: RequestInfo | URL): string {
+  return typeof input === "string"
+    ? input
+    : input instanceof URL
+      ? input.toString()
+      : input.url;
+}
+
+function mockSlackModalFetch() {
+  global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = requestUrl(input);
+    if (url === "/api/composio/connections?include_toolkits=1&fresh=1") {
+      return new Response(JSON.stringify({ connections: [], toolkits: [] }));
+    }
+    if (url.startsWith("/api/composio/toolkits?")) {
+      return new Response(JSON.stringify({
+        items: [{
+          slug: "slack",
+          name: "Slack",
+          description: "Messages and channels",
+          logo: "https://gateway.example/slack.svg",
+          categories: ["Communication"],
+          auth_schemes: ["oauth2"],
+          tools_count: 4,
+        }],
+      }));
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  }) as typeof fetch;
+}
 
 describe("ChatComposioModalHost", () => {
   beforeEach(() => {
@@ -10,26 +44,7 @@ describe("ChatComposioModalHost", () => {
   });
 
   it("opens the composio modal directly for assistant connect links", async () => {
-    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
-      const url = typeof input === "string" ? input : input.toString();
-      if (url === "/api/composio/connections?include_toolkits=1&fresh=1") {
-        return new Response(JSON.stringify({ connections: [], toolkits: [] }));
-      }
-      if (url.startsWith("/api/composio/toolkits?")) {
-        return new Response(JSON.stringify({
-          items: [{
-            slug: "slack",
-            name: "Slack",
-            description: "Messages and channels",
-            logo: "https://gateway.example/slack.svg",
-            categories: ["Communication"],
-            auth_schemes: ["oauth2"],
-            tools_count: 4,
-          }],
-        }));
-      }
-      throw new Error(`Unexpected fetch: ${url}`);
-    }) as typeof fetch;
+    mockSlackModalFetch();
 
     const onFallbackToIntegrations = vi.fn();
 
@@ -49,7 +64,7 @@ describe("ChatComposioModalHost", () => {
 
   it("keeps reconnect actions on the direct-open modal path", async () => {
     global.fetch = vi.fn(async (input: RequestInfo | URL) => {
-      const url = typeof input === "string" ? input : input.toString();
+      const url = requestUrl(input);
       if (url === "/api/composio/connections?include_toolkits=1&fresh=1") {
         return new Response(JSON.stringify({
           connections: [{
@@ -115,5 +130,50 @@ describe("ChatComposioModalHost", () => {
     });
     expect(global.fetch).not.toHaveBeenCalled();
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("consumes assistant connect requests so closed modals do not reopen on remount", async () => {
+    mockSlackModalFetch();
+    const user = userEvent.setup();
+
+    function Harness() {
+      const [mounted, setMounted] = useState(true);
+      const [request, setRequest] = useState<ComposioChatAction | null>({
+        action: "connect",
+        toolkitSlug: "slack",
+        toolkitName: "Slack",
+      });
+
+      return (
+        <>
+          <button type="button" onClick={() => setMounted((value) => !value)}>
+            Toggle host
+          </button>
+          {mounted && (
+            <ChatComposioModalHost
+              request={request}
+              onRequestHandled={() => setRequest(null)}
+              onFallbackToIntegrations={() => {}}
+            />
+          )}
+        </>
+      );
+    }
+
+    render(<Harness />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Connect Slack" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getAllByRole("button", { name: "Close" })[0]);
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Connect Slack" })).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Toggle host" }));
+    await user.click(screen.getByRole("button", { name: "Toggle host" }));
+
+    expect(screen.queryByRole("button", { name: "Connect Slack" })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/app/components/integrations/chat-composio-modal-host.tsx
+++ b/apps/web/app/components/integrations/chat-composio-modal-host.tsx
@@ -65,9 +65,11 @@ async function resolveModalData(toolkitSlug: string, toolkitName?: string | null
 
 export function ChatComposioModalHost({
   request,
+  onRequestHandled,
   onFallbackToIntegrations,
 }: {
   request: ComposioChatAction | null;
+  onRequestHandled?: () => void;
   onFallbackToIntegrations: () => void;
 }) {
   const [open, setOpen] = useState(false);
@@ -119,8 +121,10 @@ export function ChatComposioModalHost({
     if (!request) {
       return;
     }
-    void hydrateModalTarget(request);
-  }, [hydrateModalTarget, request]);
+    const nextRequest = request;
+    onRequestHandled?.();
+    void hydrateModalTarget(nextRequest);
+  }, [hydrateModalTarget, onRequestHandled, request]);
 
   const handleConnectionChange = useCallback((payload?: {
     toolkit?: ComposioToolkit | null;

--- a/apps/web/app/components/integrations/composio-connect-modal.test.tsx
+++ b/apps/web/app/components/integrations/composio-connect-modal.test.tsx
@@ -38,7 +38,11 @@ describe("ComposioConnectModal", () => {
     vi.restoreAllMocks();
     vi.useRealTimers();
     global.fetch = vi.fn(async (input: RequestInfo | URL) => {
-      const url = typeof input === "string" ? input : input.toString();
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
       if (url.startsWith("/api/composio/toolkits?")) {
         return new Response(JSON.stringify({
           items: [{
@@ -170,6 +174,37 @@ describe("ComposioConnectModal", () => {
     });
     expect(onOpenChange).toHaveBeenCalledWith(false);
     expect(screen.getByRole("button", { name: "Connect Gmail" })).toBeEnabled();
+  });
+
+  it("adopts an already-connected account without opening the OAuth popup", async () => {
+    const user = userEvent.setup();
+    const onConnectionChange = vi.fn();
+    const onOpenChange = vi.fn();
+    const openSpy = vi.spyOn(window, "open");
+    global.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({
+        already_connected: true,
+        connected_account_id: "ca_existing",
+        connected_toolkit_slug: "gmail",
+        connected_toolkit_name: "Gmail",
+      }))
+    ) as typeof fetch;
+
+    renderModal({ onConnectionChange, onOpenChange });
+
+    await user.click(screen.getByRole("button", { name: "Connect Gmail" }));
+
+    await waitFor(() => {
+      expect(onConnectionChange).toHaveBeenCalledWith({
+        toolkit,
+        connected: true,
+        connectedToolkitSlug: "gmail",
+        connectedToolkitName: "Gmail",
+        shouldProbeLiveAgent: true,
+      });
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(openSpy).not.toHaveBeenCalled();
   });
 
   it("ignores callback messages from a different origin", async () => {

--- a/apps/web/app/components/integrations/composio-connect-modal.tsx
+++ b/apps/web/app/components/integrations/composio-connect-modal.tsx
@@ -6,7 +6,6 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "../ui/dialog";
@@ -142,8 +141,12 @@ export function ComposioConnectModal({
 
   useEffect(() => {
     function handleMessage(event: MessageEvent) {
-      if (event.data?.type !== "composio-callback") return;
-      if (event.origin !== window.location.origin) return;
+      if (event.data?.type !== "composio-callback") {
+        return;
+      }
+      if (event.origin !== window.location.origin) {
+        return;
+      }
 
       callbackHandledRef.current = true;
       stopPopupPolling();
@@ -173,7 +176,9 @@ export function ComposioConnectModal({
   }, [onConnectionChange, onOpenChange, stopPopupPolling, toolkit]);
 
   const handleConnect = useCallback(async () => {
-    if (!toolkit) return;
+    if (!toolkit) {
+      return;
+    }
     if (connected) {
       setError(`Disconnect ${toolkit.name} before connecting a different account.`);
       return;
@@ -191,6 +196,28 @@ export function ComposioConnectModal({
       if (!res.ok) {
         throw new Error(data.error ?? "Failed to start connection.");
       }
+      const existingConnectionId = data.connected_account_id ?? data.connection_id;
+      if (data.already_connected && existingConnectionId) {
+        onConnectionChange({
+          toolkit,
+          connected: true,
+          connectedToolkitSlug:
+            typeof data.connected_toolkit_slug === "string"
+              ? data.connected_toolkit_slug
+              : toolkit.slug,
+          connectedToolkitName:
+            typeof data.connected_toolkit_name === "string"
+              ? data.connected_toolkit_name
+              : toolkit.name,
+          shouldProbeLiveAgent: true,
+        });
+        setConnecting(false);
+        onOpenChange(false);
+        return;
+      }
+      if (!data.redirect_url) {
+        throw new Error(data.error ?? "Failed to start connection.");
+      }
       const popup = window.open(
         data.redirect_url,
         "_blank",
@@ -205,7 +232,9 @@ export function ComposioConnectModal({
       popup.focus?.();
       popupPollRef.current = window.setInterval(() => {
         const currentPopup = popupRef.current;
-        if (!currentPopup || !currentPopup.closed) return;
+        if (!currentPopup || !currentPopup.closed) {
+          return;
+        }
 
         stopPopupPolling();
         popupRef.current = null;
@@ -242,7 +271,9 @@ export function ComposioConnectModal({
     }
   }, [onConnectionChange]);
 
-  if (!toolkit) return null;
+  if (!toolkit) {
+    return null;
+  }
 
   const authLabel = toolkit.auth_schemes.length > 0
     ? toolkit.auth_schemes.map(formatAuthScheme).join(", ")

--- a/apps/web/app/components/onboarding/setup-step.test.tsx
+++ b/apps/web/app/components/onboarding/setup-step.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OnboardingState } from "@/lib/denchclaw-state";
+import { SetupStep } from "./setup-step";
+
+const baseState: OnboardingState = {
+  version: 1,
+  currentStep: "connect-gmail",
+  completedSteps: ["welcome", "identity", "dench-cloud"],
+  identity: {
+    name: "Vedant",
+    email: "vedant@example.com",
+    capturedAt: "2026-04-29T18:45:14.895Z",
+  },
+  denchCloud: {
+    source: "cli",
+    skipped: false,
+    configuredAt: "2026-04-29T18:45:15.517Z",
+  },
+  startedAt: "2026-04-29T18:45:14.580Z",
+  updatedAt: "2026-04-29T18:45:15.517Z",
+};
+
+function Harness({ onAdvance }: { onAdvance: (state: OnboardingState) => void }) {
+  const [state, setState] = useState(baseState);
+  return (
+    <SetupStep
+      state={state}
+      onAdvance={(next) => {
+        setState(next);
+        onAdvance(next);
+      }}
+      onRefresh={async () => {}}
+      onStageChange={() => {}}
+    />
+  );
+}
+
+describe("SetupStep", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("adopts an existing active Gmail connection before asking the user to connect", async () => {
+    const onAdvance = vi.fn();
+    const nextState: OnboardingState = {
+      ...baseState,
+      currentStep: "connect-calendar",
+      completedSteps: ["welcome", "identity", "dench-cloud", "connect-gmail"],
+      connections: {
+        gmail: {
+          connectionId: "ca_existing_gmail",
+          toolkitSlug: "gmail",
+          accountEmail: "person@example.com",
+          connectedAt: "2026-04-30T00:00:00.000Z",
+        },
+      },
+    };
+    const bodies: unknown[] = [];
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+      if (url === "/api/onboarding/dench-cloud") {
+        return new Response(JSON.stringify({
+          configured: true,
+          source: "cli",
+          primaryModel: "dench-cloud/gpt-5.5",
+        }));
+      }
+      if (url === "/api/composio/connections?include_toolkits=1&fresh=1") {
+        return new Response(JSON.stringify({
+          connections: [
+            {
+              id: "ca_existing_gmail",
+              toolkit_slug: "gmail",
+              toolkit_name: "Gmail",
+              status: "ACTIVE",
+              account_email: "person@example.com",
+              created_at: "2026-04-30T00:00:00.000Z",
+            },
+          ],
+        }));
+      }
+      if (url === "/api/onboarding/connections") {
+        if (typeof init?.body !== "string") {
+          throw new Error("Expected string JSON body.");
+        }
+        bodies.push(JSON.parse(init.body));
+        return new Response(JSON.stringify(nextState));
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+
+    render(<Harness onAdvance={onAdvance} />);
+
+    await waitFor(() => {
+      expect(onAdvance).toHaveBeenCalledWith(nextState);
+    });
+    expect(bodies).toEqual([
+      {
+        toolkit: "gmail",
+        connectionId: "ca_existing_gmail",
+        toolkitSlug: "gmail",
+        accountEmail: "person@example.com",
+        fromStep: "connect-gmail",
+        toStep: "connect-calendar",
+      },
+    ]);
+    expect(await screen.findByText("person@example.com")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/components/onboarding/setup-step.test.tsx
+++ b/apps/web/app/components/onboarding/setup-step.test.tsx
@@ -39,6 +39,14 @@ function Harness({ onAdvance }: { onAdvance: (state: OnboardingState) => void })
   );
 }
 
+function requestUrl(input: RequestInfo | URL): string {
+  return typeof input === "string"
+    ? input
+    : input instanceof URL
+      ? input.toString()
+      : input.url;
+}
+
 describe("SetupStep", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -61,11 +69,7 @@ describe("SetupStep", () => {
     };
     const bodies: unknown[] = [];
     global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === "string"
-        ? input
-        : input instanceof URL
-          ? input.toString()
-          : input.url;
+      const url = requestUrl(input);
       if (url === "/api/onboarding/dench-cloud") {
         return new Response(JSON.stringify({
           configured: true,
@@ -113,5 +117,103 @@ describe("SetupStep", () => {
       },
     ]);
     expect(await screen.findByText("person@example.com")).toBeInTheDocument();
+  });
+
+  it("uses the Gmail reconciliation result when adopting Calendar in the same pass", async () => {
+    const onAdvance = vi.fn();
+    const gmailState: OnboardingState = {
+      ...baseState,
+      currentStep: "connect-calendar",
+      completedSteps: ["welcome", "identity", "dench-cloud", "connect-gmail"],
+      connections: {
+        gmail: {
+          connectionId: "ca_existing_gmail",
+          toolkitSlug: "gmail",
+          accountEmail: "person@example.com",
+          connectedAt: "2026-04-30T00:00:00.000Z",
+        },
+      },
+    };
+    const calendarState: OnboardingState = {
+      ...gmailState,
+      currentStep: "backfill",
+      completedSteps: [
+        "welcome",
+        "identity",
+        "dench-cloud",
+        "connect-gmail",
+        "connect-calendar",
+      ],
+      connections: {
+        ...gmailState.connections,
+        calendar: {
+          connectionId: "ca_existing_calendar",
+          toolkitSlug: "google-calendar",
+          accountEmail: "person@example.com",
+          connectedAt: "2026-04-30T00:00:00.000Z",
+        },
+      },
+    };
+    const bodies: unknown[] = [];
+    global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = requestUrl(input);
+      if (url === "/api/onboarding/dench-cloud") {
+        return new Response(JSON.stringify({
+          configured: true,
+          source: "cli",
+          primaryModel: "dench-cloud/gpt-5.5",
+        }));
+      }
+      if (url === "/api/composio/connections?include_toolkits=1&fresh=1") {
+        return new Response(JSON.stringify({
+          connections: [
+            {
+              id: "ca_existing_gmail",
+              toolkit_slug: "gmail",
+              toolkit_name: "Gmail",
+              status: "ACTIVE",
+              account_email: "person@example.com",
+              created_at: "2026-04-30T00:00:00.000Z",
+            },
+            {
+              id: "ca_existing_calendar",
+              toolkit_slug: "google-calendar",
+              toolkit_name: "Google Calendar",
+              status: "ACTIVE",
+              account_email: "person@example.com",
+              created_at: "2026-04-30T00:00:00.000Z",
+            },
+          ],
+        }));
+      }
+      if (url === "/api/onboarding/connections") {
+        if (typeof init?.body !== "string") {
+          throw new Error("Expected string JSON body.");
+        }
+        const body = JSON.parse(init.body) as { toolkit: string };
+        bodies.push(body);
+        return new Response(JSON.stringify(body.toolkit === "gmail" ? gmailState : calendarState));
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+
+    render(<Harness onAdvance={onAdvance} />);
+
+    await waitFor(() => {
+      expect(bodies).toHaveLength(2);
+    });
+    expect(bodies).toEqual([
+      expect.objectContaining({
+        toolkit: "gmail",
+        fromStep: "connect-gmail",
+        toStep: "connect-calendar",
+      }),
+      expect.objectContaining({
+        toolkit: "calendar",
+        fromStep: "connect-calendar",
+        toStep: "backfill",
+      }),
+    ]);
+    expect(onAdvance).toHaveBeenLastCalledWith(calendarState);
   });
 });

--- a/apps/web/app/components/onboarding/setup-step.tsx
+++ b/apps/web/app/components/onboarding/setup-step.tsx
@@ -11,9 +11,16 @@ type DenchCloudStatus = {
 };
 
 type ConnectInitiateResponse = {
+  already_connected?: boolean;
   redirect_url?: string;
   connection_id?: string | null;
+  connected_account_id?: string | null;
   connect_toolkit?: string | null;
+  connected_toolkit_slug?: string | null;
+  connected_toolkit_name?: string | null;
+  account_email?: string | null;
+  account_label?: string | null;
+  code?: string;
   error?: string;
 };
 
@@ -26,6 +33,96 @@ type CallbackPayload = {
 };
 
 type ToolkitKey = "gmail" | "calendar";
+
+type ExistingComposioConnection = {
+  id?: string | null;
+  connectionId?: string | null;
+  toolkit_slug?: string | null;
+  normalized_toolkit_slug?: string | null;
+  toolkit_name?: string | null;
+  status?: string | null;
+  account_email?: string | null;
+  account_label?: string | null;
+  account?: {
+    email?: string | null;
+    label?: string | null;
+  } | null;
+  toolkit?: {
+    slug?: string | null;
+    name?: string | null;
+  } | null;
+};
+
+type ExistingConnectionsResponse = {
+  connections?: ExistingComposioConnection[];
+  items?: ExistingComposioConnection[];
+};
+
+type PersistConnectionInput = {
+  connectionId: string;
+  toolkitSlug: string | null;
+  accountEmail?: string | null;
+};
+
+const ONBOARDING_STEP_ORDER = [
+  "welcome",
+  "identity",
+  "dench-cloud",
+  "connect-gmail",
+  "connect-calendar",
+  "backfill",
+  "complete",
+] as const;
+
+function stepIndex(step: OnboardingState["currentStep"]): number {
+  return ONBOARDING_STEP_ORDER.indexOf(step);
+}
+
+function shouldAdvanceFrom(
+  currentStep: OnboardingState["currentStep"],
+  fromStep: OnboardingState["currentStep"],
+): boolean {
+  const current = stepIndex(currentStep);
+  const from = stepIndex(fromStep);
+  return current >= 0 && from >= 0 && current <= from;
+}
+
+function normalizeToolkitSlug(value: string | null | undefined): string {
+  return (value ?? "").trim().toLowerCase().replace(/_/g, "-");
+}
+
+function readConnectionId(connection: ExistingComposioConnection): string | null {
+  const id = connection.id ?? connection.connectionId;
+  return typeof id === "string" && id.trim() ? id.trim() : null;
+}
+
+function connectionToolkitSlug(connection: ExistingComposioConnection): string {
+  return normalizeToolkitSlug(
+    connection.normalized_toolkit_slug ??
+      connection.toolkit_slug ??
+      connection.toolkit?.slug,
+  );
+}
+
+function connectionAccountEmail(connection: ExistingComposioConnection): string | null {
+  const email = connection.account_email ?? connection.account?.email;
+  return typeof email === "string" && email.includes("@") ? email : null;
+}
+
+function connectionMatchesToolkit(
+  connection: ExistingComposioConnection,
+  toolkit: ToolkitKey,
+): boolean {
+  const status = (connection.status ?? "").trim().toUpperCase();
+  if (status && status !== "ACTIVE") {
+    return false;
+  }
+  const slug = connectionToolkitSlug(connection);
+  if (toolkit === "gmail") {
+    return slug === "gmail";
+  }
+  return slug === "google-calendar" || slug === "googlecalendar";
+}
 
 /**
  * Single compact filled CTA used on active connection rows. Solid surface
@@ -172,6 +269,7 @@ export function SetupStep({
   const popupRef = useRef<Window | null>(null);
   const popupPollRef = useRef<number | null>(null);
   const callbackToolkitRef = useRef<ToolkitKey | null>(null);
+  const reconciledExistingConnectionsRef = useRef(false);
 
   // Derived connection flags. `state.denchCloud` is present whenever the user
   // has either configured it or explicitly skipped — `skipped: true` means
@@ -260,27 +358,27 @@ export function SetupStep({
     }
   }, []);
 
-  const completeToolkit = useCallback(
+  const persistToolkitConnection = useCallback(
     async (
       toolkit: ToolkitKey,
-      connectionId: string,
-      connectionToolkitSlug: string | null,
+      connection: PersistConnectionInput,
+      baseState: OnboardingState = state,
     ) => {
       const fromStep = toolkit === "gmail" ? "connect-gmail" : "connect-calendar";
       const toStep = toolkit === "gmail" ? "connect-calendar" : "backfill";
+      const shouldAdvance = shouldAdvanceFrom(baseState.currentStep, fromStep);
       try {
         const res = await fetch("/api/onboarding/connections", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             toolkit,
-            connectionId,
+            connectionId: connection.connectionId,
             toolkitSlug:
-              connectionToolkitSlug ??
+              connection.toolkitSlug ??
               (toolkit === "gmail" ? "gmail" : "google-calendar"),
-            accountEmail: null,
-            fromStep,
-            toStep,
+            accountEmail: connection.accountEmail ?? null,
+            ...(shouldAdvance ? { fromStep, toStep } : {}),
           }),
         });
         if (!res.ok) {
@@ -289,14 +387,99 @@ export function SetupStep({
         }
         const next = (await res.json()) as OnboardingState;
         onAdvance(next);
+        return next;
       } catch (err) {
         setToolkitError(
           err instanceof Error ? err.message : "Could not save the connection.",
         );
+        return baseState;
       }
     },
-    [onAdvance],
+    [onAdvance, state],
   );
+
+  const completeToolkit = useCallback(
+    async (
+      toolkit: ToolkitKey,
+      connectionId: string,
+      connectionToolkitSlug: string | null,
+    ) => {
+      await persistToolkitConnection(toolkit, {
+        connectionId,
+        toolkitSlug: connectionToolkitSlug,
+      });
+    },
+    [persistToolkitConnection],
+  );
+
+  // Dench Cloud/Composio is the source of truth for OAuth. If a user already
+  // connected Gmail in a prior attempt but local onboarding metadata was never
+  // written, adopt that active account instead of showing a misleading
+  // "Connect" button that can only end in an "already connected" error.
+  useEffect(() => {
+    if (!denchCloudConnected) {
+      return;
+    }
+    if (reconciledExistingConnectionsRef.current) {
+      return;
+    }
+    if (gmailConnected && calendarConnected) {
+      return;
+    }
+    reconciledExistingConnectionsRef.current = true;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch("/api/composio/connections?include_toolkits=1&fresh=1", {
+          cache: "no-store",
+        });
+        if (!res.ok) {
+          return;
+        }
+        const data = (await res.json()) as ExistingConnectionsResponse;
+        const existingConnections = data.connections?.length ? data.connections : data.items ?? [];
+        let nextState = state;
+
+        const existingGmail = gmailConnected
+          ? null
+          : existingConnections.find((connection) => connectionMatchesToolkit(connection, "gmail"));
+        const gmailId = existingGmail ? readConnectionId(existingGmail) : null;
+        if (!cancelled && existingGmail && gmailId) {
+          nextState = await persistToolkitConnection("gmail", {
+            connectionId: gmailId,
+            toolkitSlug: connectionToolkitSlug(existingGmail) || "gmail",
+            accountEmail: connectionAccountEmail(existingGmail),
+          }, nextState);
+        }
+
+        const existingCalendar = calendarConnected
+          ? null
+          : existingConnections.find((connection) => connectionMatchesToolkit(connection, "calendar"));
+        const calendarId = existingCalendar ? readConnectionId(existingCalendar) : null;
+        if (!cancelled && existingCalendar && calendarId) {
+          await persistToolkitConnection("calendar", {
+            connectionId: calendarId,
+            toolkitSlug: connectionToolkitSlug(existingCalendar) || "google-calendar",
+            accountEmail: connectionAccountEmail(existingCalendar),
+          }, nextState);
+        }
+      } catch {
+        // Reconciliation is opportunistic. The Connect button path below still
+        // handles existing-account adoption if this probe fails.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    calendarConnected,
+    denchCloudConnected,
+    gmailConnected,
+    persistToolkitConnection,
+    state,
+  ]);
 
   // Subscribe to the Composio popup's postMessage callback.
   useEffect(() => {
@@ -342,7 +525,37 @@ export function SetupStep({
           body: JSON.stringify({ toolkit: slug }),
         });
         const data = (await res.json()) as ConnectInitiateResponse;
-        if (!res.ok || !data.redirect_url) {
+        const existingConnectionId = data.connected_account_id ?? data.connection_id ?? null;
+        if (data.already_connected && existingConnectionId) {
+          await persistToolkitConnection(toolkit, {
+            connectionId: existingConnectionId,
+            toolkitSlug:
+              data.connected_toolkit_slug ??
+              data.connect_toolkit ??
+              (toolkit === "gmail" ? "gmail" : "google-calendar"),
+            accountEmail: data.account_email ?? null,
+          });
+          setActiveToolkit(null);
+          callbackToolkitRef.current = null;
+          return;
+        }
+        if (!res.ok) {
+          if (data.code === "APP_ALREADY_CONNECTED" && existingConnectionId) {
+            await persistToolkitConnection(toolkit, {
+              connectionId: existingConnectionId,
+              toolkitSlug:
+                data.connected_toolkit_slug ??
+                data.connect_toolkit ??
+                (toolkit === "gmail" ? "gmail" : "google-calendar"),
+              accountEmail: data.account_email ?? null,
+            });
+            setActiveToolkit(null);
+            callbackToolkitRef.current = null;
+            return;
+          }
+          throw new Error(data.error ?? `HTTP ${res.status}`);
+        }
+        if (!data.redirect_url) {
           throw new Error(data.error ?? `HTTP ${res.status}`);
         }
         const popup = window.open(
@@ -378,7 +591,7 @@ export function SetupStep({
         );
       }
     },
-    [stopPopupPolling],
+    [persistToolkitConnection, stopPopupPolling],
   );
 
   async function handleDenchCloudSubmit(event: React.FormEvent) {

--- a/apps/web/app/components/onboarding/setup-step.tsx
+++ b/apps/web/app/components/onboarding/setup-step.tsx
@@ -458,7 +458,7 @@ export function SetupStep({
           : existingConnections.find((connection) => connectionMatchesToolkit(connection, "calendar"));
         const calendarId = existingCalendar ? readConnectionId(existingCalendar) : null;
         if (!cancelled && existingCalendar && calendarId) {
-          await persistToolkitConnection("calendar", {
+          nextState = await persistToolkitConnection("calendar", {
             connectionId: calendarId,
             toolkitSlug: connectionToolkitSlug(existingCalendar) || "google-calendar",
             accountEmail: connectionAccountEmail(existingCalendar),

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -1325,6 +1325,10 @@ function WorkspacePageInner() {
     });
   }, []);
 
+  const handleComposioActionHandled = useCallback(() => {
+    setPendingComposioAction(null);
+  }, []);
+
   const handleComposioFallbackToIntegrations = useCallback(() => {
     handleNavigate("integrations");
   }, [handleNavigate]);
@@ -2605,6 +2609,7 @@ function WorkspacePageInner() {
 
         <ChatComposioModalHost
           request={pendingComposioAction}
+          onRequestHandled={handleComposioActionHandled}
           onFallbackToIntegrations={handleComposioFallbackToIntegrations}
         />
 

--- a/apps/web/lib/composio-mcp-health.test.ts
+++ b/apps/web/lib/composio-mcp-health.test.ts
@@ -1,0 +1,97 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  fetchComposioMcpToolsListMock,
+  refreshIntegrationsRuntimeMock,
+  resolveOpenClawStateDirMock,
+} = vi.hoisted(() => ({
+  fetchComposioMcpToolsListMock: vi.fn(),
+  refreshIntegrationsRuntimeMock: vi.fn(),
+  resolveOpenClawStateDirMock: vi.fn(),
+}));
+
+vi.mock("@/lib/composio", () => ({
+  fetchComposioMcpToolsList: fetchComposioMcpToolsListMock,
+  resolveComposioApiKey: vi.fn(() => "dench_test_key"),
+  resolveComposioEligibility: vi.fn(() => ({
+    eligible: true,
+    lockReason: null,
+    lockBadge: null,
+  })),
+  resolveComposioGatewayUrl: vi.fn(() => "https://gateway.example.com"),
+}));
+
+vi.mock("@/lib/integrations", () => ({
+  refreshIntegrationsRuntime: refreshIntegrationsRuntimeMock,
+}));
+
+vi.mock("@/lib/workspace", () => ({
+  resolveActiveAgentId: vi.fn(() => "main"),
+  resolveOpenClawStateDir: resolveOpenClawStateDirMock,
+  resolveWorkspaceRoot: vi.fn(() => "/tmp/workspace"),
+}));
+
+vi.mock("@/lib/agent-runner", () => ({
+  spawnAgentStartForSession: vi.fn(),
+}));
+
+vi.mock("../../../src/cli/dench-cloud", () => ({
+  buildComposioMcpServerConfig: vi.fn((gatewayUrl: string, apiKey: string) => ({
+    url: `${gatewayUrl}/v1/composio/mcp`,
+    transport: "streamable-http",
+    headers: { Authorization: `Bearer ${apiKey}` },
+  })),
+}));
+
+const { getComposioMcpHealth } = await import("./composio-mcp-health");
+
+describe("Composio MCP health", () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stateDir = mkdtempSync(join(tmpdir(), "dench-composio-health-"));
+    resolveOpenClawStateDirMock.mockReturnValue(stateDir);
+    fetchComposioMcpToolsListMock.mockResolvedValue([{ name: "GMAIL_FETCH_EMAILS" }]);
+    refreshIntegrationsRuntimeMock.mockResolvedValue({
+      attempted: true,
+      restarted: true,
+      error: null,
+      profile: "dench",
+    });
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("self-heals a missing composio MCP server during status refresh", async () => {
+    writeFileSync(join(stateDir, "openclaw.json"), JSON.stringify({ mcp: { servers: {} } }));
+
+    const health = await getComposioMcpHealth({ autoRepairConfig: true });
+    const config = JSON.parse(readFileSync(join(stateDir, "openclaw.json"), "utf-8")) as {
+      mcp?: {
+        servers?: {
+          composio?: {
+            url?: string;
+            transport?: string;
+            headers?: { Authorization?: string };
+          };
+        };
+      };
+    };
+
+    expect(config.mcp?.servers?.composio).toEqual({
+      url: "https://gateway.example.com/v1/composio/mcp",
+      transport: "streamable-http",
+      headers: { Authorization: "Bearer dench_test_key" },
+    });
+    expect(health.config.status).toBe("pass");
+    expect(health.summary.level).toBe("healthy");
+    expect(health.liveAgent.detail).toMatch(/Configuration repaired/);
+    expect(refreshIntegrationsRuntimeMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/lib/composio-mcp-health.ts
+++ b/apps/web/lib/composio-mcp-health.ts
@@ -262,7 +262,7 @@ async function runLiveAgentProbe(): Promise<ComposioMcpHealth["liveAgent"]> {
         })
         .filter((event): event is AgentEvent => Boolean(event));
 
-      const finalChat = [...chatPayloads].reverse().find((event) => {
+      const finalChat = chatPayloads.toReversed().find((event) => {
         if (event.event !== "chat") {
           return false;
         }
@@ -378,6 +378,7 @@ async function applyComposioMcpRepair(
 export async function getComposioMcpHealth(options?: {
   includeLiveAgentProbe?: boolean;
   repairConfig?: boolean;
+  autoRepairConfig?: boolean;
 }): Promise<ComposioMcpHealth> {
   const generatedAt = nowIso();
   const workspaceDir = resolveWorkspaceRoot();
@@ -399,9 +400,18 @@ export async function getComposioMcpHealth(options?: {
 
   let refresh: IntegrationRuntimeRefresh | undefined;
   let latestConfiguredServer = configuredServer;
-  if (options?.repairConfig && apiKey) {
+  let configWasRepaired = false;
+  const shouldRepairConfig = Boolean(
+    apiKey &&
+      (
+        options?.repairConfig ||
+        (options?.autoRepairConfig && !compareServerSnapshots(configuredServer, expectedServer))
+      ),
+  );
+  if (shouldRepairConfig && apiKey) {
     refresh = await applyComposioMcpRepair(gatewayUrl, apiKey);
     latestConfiguredServer = readConfiguredComposioServer(readConfig());
+    configWasRepaired = true;
   }
 
   const matchesExpected = apiKey
@@ -474,7 +484,7 @@ export async function getComposioMcpHealth(options?: {
   if (options?.includeLiveAgentProbe && apiKey) {
     liveAgent = await runLiveAgentProbe();
     cachedLiveAgentCheck = liveAgent;
-  } else if (options?.repairConfig) {
+  } else if (options?.repairConfig || configWasRepaired) {
     liveAgent = {
       status: "unknown",
       detail: LIVE_AGENT_REPAIR_PENDING_DETAIL,


### PR DESCRIPTION
## Summary
- Persist Gmail and Calendar Composio connections into local onboarding state from both OAuth callbacks and already-connected responses so sync can actually start.
- Adopt existing active Composio connections during onboarding and repair missing Dench Integrations MCP registration automatically on status checks.
- Treat chat-generated Composio connect links as one-shot requests so the connect modal does not reopen after close/remount, and preserve sequential Gmail + Calendar reconciliation state.

## Test plan
- `pnpm --filter denchclaw-web exec vitest run app/api/composio/connect/route.test.ts app/api/composio/callback/route.test.ts app/api/composio/status/route.test.ts lib/composio-mcp-health.test.ts`
- `pnpm --filter denchclaw-web exec vitest run app/components/integrations/chat-composio-modal-host.test.tsx app/components/integrations/composio-connect-modal.test.tsx app/components/onboarding/setup-step.test.tsx`
- `pnpm --filter denchclaw-web exec vitest run app/components/chat-message.test.tsx app/components/integrations/chat-composio-modal-host.test.tsx`
- `pnpm exec oxlint --type-aware apps/web/app/components/integrations/chat-composio-modal-host.tsx apps/web/app/components/integrations/chat-composio-modal-host.test.tsx apps/web/app/components/onboarding/setup-step.tsx apps/web/app/components/onboarding/setup-step.test.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches onboarding state progression and integration connection persistence, which can affect users’ setup flow and sync kickoff if edge cases are missed. Also adds automatic MCP config repair that writes local config during status checks, increasing the blast radius of a health call.
> 
> **Overview**
> Fixes onboarding getting stuck when Composio already has active Gmail/Calendar connections by **persisting connection metadata locally** (via `writeConnection` + `writeOnboardingState`) from both the OAuth `GET /api/composio/callback` path and the `POST /api/composio/connect` path.
> 
> Changes `POST /api/composio/connect` to **return `200` with `already_connected` details** (instead of `409`) when an active connection already exists, and updates the UI (`ComposioConnectModal`, onboarding `SetupStep`) to **adopt that connection without opening a popup** and to opportunistically reconcile existing gateway connections on mount while keeping sequential Gmail→Calendar advancement correct.
> 
> Makes chat-triggered connect actions **one-shot** by adding `onRequestHandled` to `ChatComposioModalHost` (clears pending requests so the modal doesn’t reopen on remount), and updates the Composio status API + `getComposioMcpHealth` to **auto-repair missing/incorrect MCP server registration** on normal status refresh (`autoRepairConfig: true`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68caa95cfbeea48762508ef8c7f3e9819f2063ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->