### PR TITLE
Show CRM tables in workspace filesystem

### DIFF
--- a/apps/web/app/api/workspace/tree-browse.test.ts
+++ b/apps/web/app/api/workspace/tree-browse.test.ts
@@ -6,7 +6,9 @@ vi.mock("node:fs", () => ({
   readdirSync: vi.fn(() => []),
   readFileSync: vi.fn(() => ""),
   existsSync: vi.fn(() => false),
+  mkdirSync: vi.fn(),
   statSync: vi.fn(() => ({ isDirectory: () => false, size: 100 })),
+  writeFileSync: vi.fn(),
 }));
 
 vi.mock("node:fs/promises", () => ({
@@ -59,7 +61,9 @@ describe("Workspace Tree & Browse API", () => {
       readdirSync: vi.fn(() => []),
       readFileSync: vi.fn(() => ""),
       existsSync: vi.fn(() => false),
+      mkdirSync: vi.fn(),
       statSync: vi.fn(() => ({ isDirectory: () => false, size: 100 })),
+      writeFileSync: vi.fn(),
     }));
     vi.mock("node:fs/promises", () => ({
       readdir: vi.fn(async () => []),
@@ -193,21 +197,17 @@ describe("Workspace Tree & Browse API", () => {
       expect(rootPaths).not.toContain("~skills");
     });
 
-    it("does not hide objects when DuckDB returns hidden_in_sidebar as the string \"false\"", async () => {
-      // Regression test for #215. DuckDB's `-json` CLI mode serializes
-      // BOOLEAN columns as JSON strings (`"true"` / `"false"`). The
-      // string `"false"` is truthy in JS, so a naive
-      // `if (row.hidden_in_sidebar)` check used to mark every object as
-      // hidden — wiping all CRM folders (people, company, …) from the
-      // sidebar tree.
+    it("shows every DuckDB object table in the filesystem tree", async () => {
+      // The left CRM navigation can still choose what belongs in the product
+      // nav, but the filesystem tree should reflect the actual object folders
+      // in the workspace, including synced CRM tables.
       const { resolveWorkspaceRoot, duckdbQueryAllAsync } = await import("@/lib/workspace");
       vi.mocked(resolveWorkspaceRoot).mockReturnValue("/ws");
       vi.mocked(duckdbQueryAllAsync).mockResolvedValue([
         { name: "people", default_view: "table", hidden_in_sidebar: "false" },
         { name: "company", default_view: "table", hidden_in_sidebar: "false" },
         { name: "opportunity", default_view: "kanban", hidden_in_sidebar: "false" },
-        // Real boolean true should still hide. CRM-only objects stay
-        // hidden either way thanks to HARDCODED_HIDDEN_OBJECT_NAMES.
+        { name: "email_message", default_view: "table", hidden_in_sidebar: "true" },
         { name: "secret", default_view: "table", hidden_in_sidebar: "true" },
       ] as never);
 
@@ -219,7 +219,7 @@ describe("Workspace Tree & Browse API", () => {
             makeDirent("company", true),
             makeDirent("opportunity", true),
             makeDirent("secret", true),
-            makeDirent("email_thread", true),
+            makeDirent("email_message", true),
           ] as unknown as never[]);
         }
         return Promise.resolve([] as unknown as never[]);
@@ -234,10 +234,8 @@ describe("Workspace Tree & Browse API", () => {
       expect(rootPaths).toContain("people");
       expect(rootPaths).toContain("company");
       expect(rootPaths).toContain("opportunity");
-      // The row marked `hidden_in_sidebar = "true"` should be filtered out.
-      expect(rootPaths).not.toContain("secret");
-      // Hardcoded-hidden CRM objects stay hidden regardless of the DB value.
-      expect(rootPaths).not.toContain("email_thread");
+      expect(rootPaths).toContain("email_message");
+      expect(rootPaths).toContain("secret");
     });
 
     it("yields before tree discovery completes (prevents UI freeze during active agent runs)", async () => {

--- a/apps/web/app/api/workspace/tree/route.ts
+++ b/apps/web/app/api/workspace/tree/route.ts
@@ -44,31 +44,7 @@ type DbObject = {
   id?: string | null;
   description?: string | null;
   default_view?: string;
-  /**
-   * DuckDB's `-json` CLI mode serializes BOOLEAN columns as JSON strings
-   * (`"true"` / `"false"`), so the value can arrive as either a real
-   * boolean or the string-coerced form depending on the underlying
-   * driver. Always normalize via `parseDuckdbBool` before reading.
-   */
-  hidden_in_sidebar?: boolean | string | number | null;
 };
-
-/**
- * Parse a value that may be a real boolean OR a DuckDB-CLI string
- * representation (`"true"`/`"false"`/`"0"`/`"1"`). Necessary because
- * `duckdb -json` emits booleans as strings, which makes a naive
- * `if (row.bool_col)` check treat `"false"` as truthy.
- */
-function parseDuckdbBool(value: unknown): boolean {
-  if (value === true) {return true;}
-  if (value === false || value == null) {return false;}
-  if (typeof value === "number") {return value !== 0;}
-  if (typeof value === "string") {
-    const normalized = value.trim().toLowerCase();
-    return normalized === "true" || normalized === "1" || normalized === "t";
-  }
-  return false;
-}
 
 /** Read .object.yaml metadata from a directory if it exists. */
 async function pathExists(path: string): Promise<boolean> {
@@ -100,70 +76,23 @@ async function readObjectMeta(
 }
 
 /**
- * Names that should NEVER appear in the workspace tree, even if a stale
- * .object.yaml file or folder exists on disk for them. Synced when a
- * workspace was created before `hidden_in_sidebar` shipped — the rows
- * still need to be hidden, and re-init'ing the workspace just to trigger
- * the migration is a terrible UX.
- *
- * Kept in sync with the rows the migration marks hidden in
- * `apps/web/lib/workspace-schema-migrations.ts`.
- */
-const HARDCODED_HIDDEN_OBJECT_NAMES: ReadonlySet<string> = new Set([
-  "email_thread",
-  "email_message",
-  "calendar_event",
-  "interaction",
-]);
-
-/**
  * Query ALL discovered DuckDB files for objects so we can identify object
  * directories even when .object.yaml files are missing.
  * Shallower databases win on name conflicts (parent priority).
  *
- * Returns BOTH the visible-object map AND the set of hidden names, so
- * buildTree can drop folders whose name is hidden (e.g. a stale
- * `email_thread/` folder with a `.object.yaml` left over from a previous
- * sync run that pre-dates the hidden_in_sidebar migration).
+ * The file tree intentionally shows every object table now, including CRM
+ * sync tables that remain hidden from the left CRM navigation.
  */
-async function loadDbObjects(): Promise<{
-  visible: Map<string, DbObject>;
-  hidden: Set<string>;
-}> {
-  const visible = new Map<string, DbObject>();
-  const hidden = new Set<string>(HARDCODED_HIDDEN_OBJECT_NAMES);
-  // Tolerate the column not existing on older workspaces — the schema
-  // migration that adds it runs early in workspace init, but if a user
-  // queries before that lands, the COALESCE keeps the query valid.
-  let rows: Array<DbObject & { name: string }> = [];
-  try {
-    rows = await duckdbQueryAllAsync<DbObject & { name: string }>(
-      "SELECT id, name, description, default_view, COALESCE(hidden_in_sidebar, false) AS hidden_in_sidebar FROM objects",
-      "name",
-    );
-  } catch {
-    // Older DuckDB schema — hidden_in_sidebar column doesn't exist. Fall back
-    // to fetching only the columns we know are present; the
-    // HARDCODED_HIDDEN_OBJECT_NAMES set already keeps the CRM-only objects
-    // out of the tree.
-    rows = await duckdbQueryAllAsync<DbObject & { name: string }>(
-      "SELECT id, name, description, default_view FROM objects",
-      "name",
-    );
-  }
+async function loadDbObjects(): Promise<Map<string, DbObject>> {
+  const objects = new Map<string, DbObject>();
+  const rows = await duckdbQueryAllAsync<DbObject & { name: string }>(
+    "SELECT id, name, description, default_view FROM objects",
+    "name",
+  );
   for (const row of rows) {
-    // CRITICAL: `row.hidden_in_sidebar` may arrive as the literal string
-    // `"false"` from DuckDB's `-json` CLI mode (truthy in JS). Use
-    // `parseDuckdbBool` so we don't accidentally hide every object.
-    if (parseDuckdbBool(row.hidden_in_sidebar) || HARDCODED_HIDDEN_OBJECT_NAMES.has(row.name)) {
-      hidden.add(row.name);
-      // Skip CRM-only objects (email_thread / email_message / calendar_event /
-      // interaction). They have dedicated UI and shouldn't show in the tree.
-      continue;
-    }
-    visible.set(row.name, row);
+    objects.set(row.name, row);
   }
-  return { visible, hidden };
+  return objects;
 }
 
 /** Resolve a dirent's effective type, following symlinks to their target. */
@@ -190,7 +119,7 @@ async function readAppManifest(
   dirPath: string,
 ): Promise<TreeNode["appManifest"] | null> {
   const yamlPath = join(dirPath, ".dench.yaml");
-  if (!await pathExists(yamlPath)) return null;
+  if (!await pathExists(yamlPath)) {return null;}
 
   try {
     const content = await readFile(yamlPath, "utf-8");
@@ -213,7 +142,6 @@ async function buildTree(
   absDir: string,
   relativeBase: string,
   dbObjects: Map<string, DbObject>,
-  hiddenObjectNames: Set<string>,
   showHidden = false,
 ): Promise<TreeNode[]> {
   const nodes: TreeNode[] = [];
@@ -229,12 +157,6 @@ async function buildTree(
     // .object.yaml is always needed for metadata; also shown as a node when showHidden is on
     if (e.name === ".object.yaml") {return true;}
     if (e.name.startsWith(".")) {return showHidden;}
-    // Skip top-level folders whose name matches a hidden CRM object
-    // (email_thread / email_message / calendar_event / interaction).
-    // These folders carry stale `.object.yaml` files from earlier
-    // workspace versions that would otherwise still render as objects
-    // in the sidebar tree.
-    if (relativeBase === "" && hiddenObjectNames.has(e.name)) {return false;}
     return true;
   });
 
@@ -267,7 +189,7 @@ async function buildTree(
       if (entry.name.endsWith(".dench.app")) {
         const manifest = await readAppManifest(absPath);
         const displayName = manifest?.name || entry.name.replace(/\.dench\.app$/, "");
-        const children = showHidden ? await buildTree(absPath, relPath, dbObjects, hiddenObjectNames, showHidden) : undefined;
+        const children = showHidden ? await buildTree(absPath, relPath, dbObjects, showHidden) : undefined;
         nodes.push({
           name: displayName,
           path: relPath,
@@ -282,7 +204,7 @@ async function buildTree(
 
       const objectMeta = await readObjectMeta(absPath);
       const dbObject = dbObjects.get(entry.name);
-      const children = await buildTree(absPath, relPath, dbObjects, hiddenObjectNames, showHidden);
+      const children = await buildTree(absPath, relPath, dbObjects, showHidden);
 
       if (objectMeta || dbObject) {
         nodes.push({
@@ -337,7 +259,7 @@ export async function GET(req: Request) {
     return Response.json({ tree, exists: false, workspaceRoot: null, openclawDir, workspace });
   }
 
-  const { visible: dbObjects, hidden: hiddenObjectNames } = await loadDbObjects();
+  const dbObjects = await loadDbObjects();
 
   // ── Self-heal: project DB-only objects to the filesystem ─────────────
   // The tree builder is filesystem-centric: a DuckDB row only becomes a
@@ -385,7 +307,7 @@ export async function GET(req: Request) {
     );
   }
 
-  const tree = await buildTree(root, "", dbObjects, hiddenObjectNames, showHidden);
+  const tree = await buildTree(root, "", dbObjects, showHidden);
 
   return Response.json({ tree, exists: true, workspaceRoot: root, openclawDir, workspace });
 }

--- a/apps/web/app/components/workspace/file-manager-tree.tsx
+++ b/apps/web/app/components/workspace/file-manager-tree.tsx
@@ -5,8 +5,6 @@ import {
   IconFolderFilled,
   IconFolderOpenFilled,
   IconFileFilled,
-  IconTableFilled,
-  IconLayoutKanbanFilled,
   IconDatabaseFilled,
   IconReportAnalyticsFilled,
   IconMessageFilled,
@@ -41,7 +39,6 @@ import {
   isVirtualPath,
   toLocalClipboardPath,
 } from "@/lib/workspace-paths";
-import { displayObjectName } from "@/lib/object-display-name";
 
 // --- Types ---
 
@@ -133,14 +130,6 @@ function FolderIcon({ open }: { open?: boolean }) {
     : <IconFolderFilled size={18} style={{ flexShrink: 0, color: "#60a5fa" }} />;
 }
 
-function TableIcon() {
-  return <IconTableFilled size={18} style={{ flexShrink: 0, color: "#42a97a" }} />;
-}
-
-function KanbanIcon() {
-  return <IconLayoutKanbanFilled size={18} style={{ flexShrink: 0, color: "#8b7cf6" }} />;
-}
-
 function DocumentIcon() {
   return <IconFileFilled size={18} style={{ flexShrink: 0, opacity: 0.7 }} />;
 }
@@ -171,12 +160,14 @@ function NodeIcon({ node, open }: { node: TreeNode; open?: boolean }) {
     return <ChatBubbleIcon />;
   }
   switch (node.type) {
+    // Object directories are real folders on disk that happen to back a
+    // CRM table. The file tree is a 1:1 view of the workspace, so render
+    // them as folders. The CRM nav still discriminates via node.type.
     case "object":
-      return node.defaultView === "kanban" ? <KanbanIcon /> : <TableIcon />;
-    case "document":
-      return <DocumentIcon />;
     case "folder":
       return <FolderIcon open={open} />;
+    case "document":
+      return <DocumentIcon />;
     case "database":
       return <DatabaseIcon />;
     case "report":
@@ -205,7 +196,6 @@ function NodeIcon({ node, open }: { node: TreeNode; open?: boolean }) {
 
 function typeColor(node: TreeNode): string {
   switch (node.type) {
-    case "object": return "var(--color-accent)";
     case "document": return "#60a5fa";
     case "database": return "#c084fc";
     case "report": return "#22c55e";
@@ -541,7 +531,7 @@ function DraggableNode({
           />
         ) : (
           <span className="truncate flex-1">
-            {node.type === "object" ? displayObjectName(node.name) : node.name}
+            {node.name}
           </span>
         )}
 
@@ -626,7 +616,7 @@ function DragOverlayContent({ node }: { node: TreeNode }) {
       <span style={{ color: typeColor(node) }}>
         <NodeIcon node={node} />
       </span>
-      <span>{node.type === "object" ? displayObjectName(node.name) : node.name}</span>
+      <span>{node.name}</span>
     </div>
   );
 }

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -260,9 +260,9 @@ function objectNameFromPath(path: string): string {
 
 /**
  * Locate a workspace object node by its raw object name (e.g. `"people"`,
- * `"company"`, `"vc_lead"`). Walks the raw tree, including nodes that the
- * right-panel file tree hides (CRM_HIDDEN_TREE_PATHS only filters the visible
- * tree, not the underlying data). Returns `null` if no matching node exists.
+ * `"company"`, `"vc_lead"`). Walks the raw tree so CRM navigation can find
+ * objects independently from how the file tree chooses to render them.
+ * Returns `null` if no matching node exists.
  */
 function findCrmObjectNode(nodes: TreeNode[], objectName: string): TreeNode | null {
   for (const node of nodes) {
@@ -1543,12 +1543,8 @@ function WorkspacePageInner() {
     [tree, handleNodeSelect, workspaceRoot],
   );
 
-  // Build the enhanced tree: real tree + workspace management virtual folders
-  // (Chat sessions live in the right sidebar, not in the tree.)
-  // In browse mode, skip virtual folders (they only apply to workspace mode)
-  // Hide CRM-bound object tables from the right panel file tree.
-  // They're accessible via the left sidebar CRM nav (People / Companies / Inbox / Calendar),
-  // so showing them here is redundant and caused a visual flicker when the tree re-fetched.
+  // Paths that should stay out of the CRM nav because they already have
+  // dedicated product pages. The file tree itself should show every table.
   const CRM_HIDDEN_TREE_PATHS = useMemo(() => new Set([
     "people",
     "company",
@@ -1558,18 +1554,7 @@ function WorkspacePageInner() {
     "calendar_event",
     "interaction",
   ]), []);
-  // The file-tree version: hides the hardcoded CRM tables AND any
-  // object-typed node (task, deal, ...) because those already get their
-  // own entry in the sidebar's CRM nav. Keeping them in the file tree
-  // too is duplicate chrome the user has to scroll past.
-  const enhancedTree = useMemo(
-    () =>
-      tree.filter(
-        (node) =>
-          !CRM_HIDDEN_TREE_PATHS.has(node.path) && node.type !== "object",
-      ),
-    [tree, CRM_HIDDEN_TREE_PATHS],
-  );
+  const enhancedTree = tree;
   // The sidebar-nav version: only strips the hardcoded CRM tables (which
   // have their own dedicated pages) so custom objects like `task` still
   // show up under "Home" as dynamic CRM entries.


### PR DESCRIPTION
## Summary
- Show DuckDB-backed CRM tables in the workspace filesystem tree instead of filtering them out server-side.
- Render CRM object nodes as normal filesystem folders with raw folder names.

## Test plan
- Not run locally in this step; branch was already validated before splitting the Safari history fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the workspace tree API and sidebar rendering logic, which can affect navigation UX and tree contents across workspaces; risk is mostly behavioral/regression rather than security-related.
> 
> **Overview**
> The workspace `GET /api/workspace/tree` endpoint now returns **all** DuckDB `objects` as filesystem tree nodes (including CRM sync tables), removing server-side hiding logic (`hidden_in_sidebar` parsing and hardcoded hidden object names).
> 
> The right-panel file tree UI is updated to treat `object` nodes like normal folders (folder icon + raw folder name), and the client no longer filters `object` entries out of the displayed tree; only the CRM left-nav continues to hide its dedicated routes. Tests were updated to assert CRM tables appear in the tree and to extend `node:fs` mocks for new filesystem writes during projection/self-heal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 186be38a7360c0e33cf845ef34edc331326563be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->