### PR TITLE
Preserve CRM profile history navigation

### DIFF
--- a/apps/web/app/components/crm/company-profile.tsx
+++ b/apps/web/app/components/crm/company-profile.tsx
@@ -72,14 +72,18 @@ type CompanyResponse = {
   };
 };
 
-type Tab = "overview" | "team" | "emails" | "meetings";
+export type CompanyProfileTab = "overview" | "team" | "emails" | "meetings";
 
-const TABS: ReadonlyArray<{ id: Tab; label: string; count: (d: CompanyResponse) => number | null }> = [
+const TABS: ReadonlyArray<{ id: CompanyProfileTab; label: string; count: (d: CompanyResponse) => number | null }> = [
   { id: "overview", label: "Overview", count: () => null },
   { id: "team", label: "Team", count: (d) => d.summary.people_count },
   { id: "emails", label: "Emails", count: (d) => d.summary.thread_count },
   { id: "meetings", label: "Meetings", count: (d) => d.summary.event_count },
 ];
+
+function isCompanyProfileTab(value: string | undefined): value is CompanyProfileTab {
+  return value === "overview" || value === "team" || value === "emails" || value === "meetings";
+}
 
 // ---------------------------------------------------------------------------
 // Top-level
@@ -87,19 +91,32 @@ const TABS: ReadonlyArray<{ id: Tab; label: string; count: (d: CompanyResponse) 
 
 export function CompanyProfile({
   companyId,
+  activeTab,
   onOpenPerson,
   onOpenCompany,
   onBackToList,
+  onTabChange,
 }: {
   companyId: string;
+  activeTab?: string;
   onOpenPerson?: (id: string) => void;
   onOpenCompany?: (id: string) => void;
   onBackToList?: () => void;
+  onTabChange?: (tab: CompanyProfileTab) => void;
 }) {
   const [data, setData] = useState<CompanyResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [tab, setTab] = useState<Tab>("overview");
+  const [localTab, setLocalTab] = useState<CompanyProfileTab>("overview");
+  const tab = isCompanyProfileTab(activeTab) ? activeTab : localTab;
+
+  const handleTabChange = useCallback(
+    (nextTab: CompanyProfileTab) => {
+      setLocalTab(nextTab);
+      onTabChange?.(nextTab);
+    },
+    [onTabChange],
+  );
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -183,7 +200,7 @@ export function CompanyProfile({
       <CompanyHeader
         data={data}
         tab={tab}
-        onTabChange={setTab}
+        onTabChange={handleTabChange}
         onBackToList={onBackToList}
         onSaveName={handleSaveName}
       />
@@ -217,8 +234,8 @@ function CompanyHeader({
   onSaveName,
 }: {
   data: CompanyResponse;
-  tab: Tab;
-  onTabChange: (t: Tab) => void;
+  tab: CompanyProfileTab;
+  onTabChange: (t: CompanyProfileTab) => void;
   onBackToList?: () => void;
   onSaveName: (newName: string) => Promise<void>;
 }) {

--- a/apps/web/app/components/crm/person-profile.tsx
+++ b/apps/web/app/components/crm/person-profile.tsx
@@ -82,9 +82,9 @@ type PersonResponse = {
 // Tabs
 // ---------------------------------------------------------------------------
 
-type Tab = "overview" | "emails" | "calendar" | "activity" | "notes";
+export type PersonProfileTab = "overview" | "emails" | "calendar" | "activity" | "notes";
 
-const TABS: ReadonlyArray<{ id: Tab; label: string; getCount?: (data: PersonResponse) => number | null }> = [
+const TABS: ReadonlyArray<{ id: PersonProfileTab; label: string; getCount?: (data: PersonResponse) => number | null }> = [
   { id: "overview", label: "Overview" },
   { id: "emails", label: "Emails", getCount: (d) => d.threads.length },
   { id: "calendar", label: "Meetings", getCount: (d) => d.events.length },
@@ -92,25 +92,42 @@ const TABS: ReadonlyArray<{ id: Tab; label: string; getCount?: (data: PersonResp
   { id: "notes", label: "Notes" },
 ];
 
+function isPersonProfileTab(value: string | undefined): value is PersonProfileTab {
+  return value === "overview" || value === "emails" || value === "calendar" || value === "activity" || value === "notes";
+}
+
 // ---------------------------------------------------------------------------
 // Top-level component
 // ---------------------------------------------------------------------------
 
 export function PersonProfile({
   personId,
+  activeTab,
   onOpenPerson,
   onOpenCompany,
   onBackToList,
+  onTabChange,
 }: {
   personId: string;
+  activeTab?: string;
   onOpenPerson?: (id: string) => void;
   onOpenCompany?: (id: string) => void;
   onBackToList?: () => void;
+  onTabChange?: (tab: PersonProfileTab) => void;
 }) {
   const [data, setData] = useState<PersonResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [tab, setTab] = useState<Tab>("overview");
+  const [localTab, setLocalTab] = useState<PersonProfileTab>("overview");
+  const tab = isPersonProfileTab(activeTab) ? activeTab : localTab;
+
+  const handleTabChange = useCallback(
+    (nextTab: PersonProfileTab) => {
+      setLocalTab(nextTab);
+      onTabChange?.(nextTab);
+    },
+    [onTabChange],
+  );
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -232,7 +249,7 @@ export function PersonProfile({
       <PersonHeader
         data={data}
         tab={tab}
-        onTabChange={setTab}
+        onTabChange={handleTabChange}
         onOpenCompany={onOpenCompany}
         onBackToList={onBackToList}
         onSaveName={handleSaveName}
@@ -277,8 +294,8 @@ function PersonHeader({
   onSaveName,
 }: {
   data: PersonResponse;
-  tab: Tab;
-  onTabChange: (t: Tab) => void;
+  tab: PersonProfileTab;
+  onTabChange: (t: PersonProfileTab) => void;
   onOpenCompany?: (id: string) => void;
   onBackToList?: () => void;
   onSaveName: (newName: string) => Promise<void>;

--- a/apps/web/app/workspace/content-state.ts
+++ b/apps/web/app/workspace/content-state.ts
@@ -106,5 +106,5 @@ export type ContentState =
   | { kind: "app"; appPath: string; manifest: DenchAppManifest; filename: string }
   | { kind: "crm-inbox" }
   | { kind: "crm-calendar" }
-  | { kind: "crm-person"; entryId: string }
-  | { kind: "crm-company"; entryId: string };
+  | { kind: "crm-person"; entryId: string; profileTab?: string }
+  | { kind: "crm-company"; entryId: string; profileTab?: string };

--- a/apps/web/app/workspace/use-tab-content.ts
+++ b/apps/web/app/workspace/use-tab-content.ts
@@ -297,9 +297,17 @@ function resolveDerivedContent(
     case "crm-calendar":
       return { kind: "crm-calendar" };
     case "crm-person":
-      return { kind: "crm-person", entryId: tab.meta?.entryId ?? "" };
+      return {
+        kind: "crm-person",
+        entryId: tab.meta?.entryId ?? "",
+        profileTab: tab.meta?.profileTab,
+      };
     case "crm-company":
-      return { kind: "crm-company", entryId: tab.meta?.entryId ?? "" };
+      return {
+        kind: "crm-company",
+        entryId: tab.meta?.entryId ?? "",
+        profileTab: tab.meta?.profileTab,
+      };
     default:
       return { kind: "none" };
   }

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -1693,9 +1693,9 @@ function WorkspacePageInner() {
         dispatch({
           type: "openContent",
           tab: {
-            id: contentTabIdFor("crm-company", "companies", { entryId }),
+            id: contentTabIdFor("crm-company", "company", { entryId }),
             kind: "crm-company",
-            path: "companies",
+            path: "company",
             title: "Company",
             meta: { entryId },
             preview: true,
@@ -1713,6 +1713,12 @@ function WorkspacePageInner() {
   // Close entry modal handler — URL sync effect drops `?entry=` automatically.
   const handleCloseEntry = useCallback(() => {
     setEntryModal(null);
+  }, []);
+
+  const handleProfileTabChange = useCallback((profileTab: string) => {
+    const activeId = tabsStateRef.current.activeContentId;
+    if (!activeId) {return;}
+    dispatch({ type: "updateContentMeta", id: activeId, meta: { profileTab } });
   }, []);
 
   // -- URL <-> state bidirectional projection ------------------------------
@@ -2365,6 +2371,7 @@ function WorkspacePageInner() {
       onSendCommand={handleCronSendCommand}
       onMakeTabPermanent={promoteTabByPath}
       onTableSelectionContextChange={setTableSelectionContext}
+      onProfileTabChange={handleProfileTabChange}
     />
   ), [
     workspaceExists, workspaceRoot, tree, activePath, browseDir, treeLoading,
@@ -2373,6 +2380,7 @@ function WorkspacePageInner() {
     searchIndex, handleSelectCronJob, handleBackToCronDashboard,
     cronView, cronCalMode, cronDate, cronRunFilter, cronRun,
     handleCronSendCommand, promoteTabByPath, setTableSelectionContext,
+    handleProfileTabChange,
   ]);
 
   const renderRightPanelPlaceholder = useCallback(() => (
@@ -2743,6 +2751,7 @@ function ContentRenderer({
   onSendCommand,
   onMakeTabPermanent,
   onTableSelectionContextChange,
+  onProfileTabChange,
 }: {
   content: ContentState;
   workspaceExists: boolean;
@@ -2779,6 +2788,7 @@ function ContentRenderer({
   onSendCommand: (message: string) => void;
   onMakeTabPermanent: (path: string) => void;
   onTableSelectionContextChange: (selection: TableSelectionContext | null) => void;
+  onProfileTabChange: (profileTab: string) => void;
 }) {
   switch (content.kind) {
     case "loading":
@@ -3009,9 +3019,11 @@ function ContentRenderer({
       return (
         <PersonProfile
           personId={content.entryId}
+          activeTab={content.profileTab}
           onOpenPerson={(id) => onOpenEntry("people", id)}
           onOpenCompany={(id) => onOpenEntry("company", id)}
           onBackToList={() => onNavigateToObject("people")}
+          onTabChange={onProfileTabChange}
         />
       );
 
@@ -3019,9 +3031,11 @@ function ContentRenderer({
       return (
         <CompanyProfile
           companyId={content.entryId}
+          activeTab={content.profileTab}
           onOpenPerson={(id) => onOpenEntry("people", id)}
           onOpenCompany={(id) => onOpenEntry("company", id)}
           onBackToList={() => onNavigateToObject("company")}
+          onTabChange={onProfileTabChange}
         />
       );
 

--- a/apps/web/lib/workspace-links.ts
+++ b/apps/web/lib/workspace-links.ts
@@ -14,6 +14,7 @@
  *   Skills:      /?path=~skills
  *   Cron views:  /?path=~cron&cronView=calendar&cronCalMode=week&cronDate=2026-03-05
  *   Object view: /?path=leads&viewType=kanban&filters=...&sort=...&search=...&page=1&pageSize=50&cols=a,b,c&view=MyView
+ *   Profile tab: /?entry=company:abc&profileTab=team
  *   Preview:     /?path=file.md&preview=other.md
  *   Send:        /?send=install+duckdb  (consumed immediately)
  *
@@ -46,6 +47,8 @@ export type WorkspaceUrlState = {
   /** File-scoped chat session (active when a file is open in the main panel). */
   fileChat: string | null;
   entry: { objectName: string; entryId: string } | null;
+  /** Active subtab inside a CRM profile page, e.g. company team or person activity. */
+  profileTab: string | null;
   send: string | null;
   browse: string | null;
   hidden: boolean;
@@ -139,6 +142,7 @@ export function parseUrlState(search: string | URLSearchParams): WorkspaceUrlSta
     subagent: params.get("subagent"),
     fileChat: params.get("fileChat"),
     entry,
+    profileTab: params.get("profileTab"),
     send: params.get("send"),
     browse: params.get("browse"),
     hidden: params.get("hidden") === "1",
@@ -176,6 +180,7 @@ export function serializeUrlState(state: Partial<WorkspaceUrlState>): string {
   if (state.entry) {
     params.set("entry", `${state.entry.objectName}:${state.entry.entryId}`);
   }
+  if (state.profileTab) params.set("profileTab", state.profileTab);
   if (state.send) params.set("send", state.send);
   if (state.browse) params.set("browse", state.browse);
   if (state.hidden) params.set("hidden", "1");

--- a/apps/web/lib/workspace-tabs.test.ts
+++ b/apps/web/lib/workspace-tabs.test.ts
@@ -21,6 +21,7 @@ import {
   openChat,
   openContent,
   promoteContent,
+  projectUrlState,
   saveTabsState,
   selectActiveContentTab,
   selectActivePath,
@@ -29,7 +30,7 @@ import {
   workspaceTabsReducer,
   bindChatSession,
 } from "./workspace-tabs";
-import { parseUrlState } from "./workspace-links";
+import { parseUrlState, serializeUrlState } from "./workspace-links";
 
 beforeEach(() => {
   if (typeof window !== "undefined") {
@@ -330,11 +331,54 @@ describe("URL roundtrip / popstate idempotency", () => {
     expect(selectActiveContentTab(state)?.kind).toBe("object");
   });
 
+  it("maps legacy path=companies URLs to the canonical company object", () => {
+    const state = applyUrlToState(EMPTY_TABS_STATE, parseUrlState("path=companies"), {});
+    expect(selectActiveContentTab(state)?.kind).toBe("object");
+    expect(selectActiveContentTab(state)?.path).toBe("company");
+  });
+
   it("applyUrl with entry=people:abc opens a crm-person tab", () => {
     const url = parseUrlState("entry=people:abc");
     const state = applyUrlToState(EMPTY_TABS_STATE, url, {});
     expect(state.activeContentId).toBe("crm-person:abc");
     expect(selectActiveContentTab(state)?.meta?.entryId).toBe("abc");
+  });
+
+  it("round-trips a CRM company profile and selected subtab through browser history", () => {
+    let state: WorkspaceTabsState = openContent(EMPTY_TABS_STATE, {
+      id: contentTabIdFor("crm-company", "company", { entryId: "co_1" }),
+      kind: "crm-company",
+      path: "company",
+      title: "Company",
+      meta: { entryId: "co_1", profileTab: "team" },
+      preview: true,
+    });
+
+    const companyUrl = serializeUrlState(projectUrlState(state, {
+      chatSessionId: null,
+      chatSubagentKey: null,
+      entryModal: null,
+      browseDir: null,
+      showHidden: false,
+      terminalOpen: false,
+      cron: {
+        view: "overview",
+        calMode: "month",
+        date: null,
+        runFilter: "all",
+        run: null,
+      },
+    }));
+    expect(companyUrl).toBe("entry=company%3Aco_1&profileTab=team");
+
+    state = applyUrlToState(state, parseUrlState("entry=people:p_1"), {});
+    expect(selectActiveContentTab(state)?.kind).toBe("crm-person");
+
+    state = applyUrlToState(state, parseUrlState(companyUrl), {});
+    const active = selectActiveContentTab(state);
+    expect(active?.kind).toBe("crm-company");
+    expect(active?.path).toBe("company");
+    expect(active?.meta).toMatchObject({ entryId: "co_1", profileTab: "team" });
   });
 
   it("applyUrl with no path clears the active content", () => {

--- a/apps/web/lib/workspace-tabs.ts
+++ b/apps/web/lib/workspace-tabs.ts
@@ -104,6 +104,8 @@ export type ContentTab = {
 export type ContentTabMeta = {
   /** For `crm-person` / `crm-company`: the entry id to render. */
   entryId?: string;
+  /** For `crm-person` / `crm-company`: the active profile subtab. */
+  profileTab?: string;
   /** For `cron-job`: the cron job id. */
   cronJobId?: string;
   /** For `browse`: the absolute filesystem dir to list. */
@@ -184,6 +186,7 @@ export type WorkspaceTabsAction =
   | { type: "promoteContent"; id: string }
   | { type: "promoteContentByPath"; path: string }
   | { type: "togglePinContent"; id: string }
+  | { type: "updateContentMeta"; id: string; meta: Partial<ContentTabMeta> }
   | { type: "reorderContent"; id: string; toIndex: number }
   | { type: "renameContent"; id: string; title: string }
   | { type: "openChat"; tab: ChatTabInput }
@@ -435,8 +438,24 @@ export function openContent(
   const existingIdx = state.contentTabs.findIndex((t) => t.id === tab.id);
   if (existingIdx !== -1) {
     let nextTabs = state.contentTabs;
-    if (!tab.preview && state.contentTabs[existingIdx].preview) {
+    const existing = state.contentTabs[existingIdx];
+    const metadataChanged =
+      existing.kind !== tab.kind ||
+      existing.path !== tab.path ||
+      JSON.stringify(existing.meta ?? {}) !== JSON.stringify(tab.meta ?? {});
+    if (metadataChanged) {
       nextTabs = [...state.contentTabs];
+      nextTabs[existingIdx] = {
+        ...nextTabs[existingIdx],
+        kind: tab.kind,
+        path: tab.path,
+        meta: tab.meta,
+      };
+    }
+    if (!tab.preview && state.contentTabs[existingIdx].preview) {
+      if (nextTabs === state.contentTabs) {
+        nextTabs = [...state.contentTabs];
+      }
       nextTabs[existingIdx] = { ...nextTabs[existingIdx], preview: false };
     }
     if (nextTabs === state.contentTabs && state.activeContentId === tab.id) {
@@ -557,6 +576,24 @@ export function togglePinContent(
     changed = true;
     const pinned = !t.pinned;
     return { ...t, pinned, preview: pinned ? false : t.preview };
+  });
+  return changed ? { ...state, contentTabs: nextTabs } : state;
+}
+
+export function updateContentMeta(
+  state: WorkspaceTabsState,
+  id: string,
+  meta: Partial<ContentTabMeta>,
+): WorkspaceTabsState {
+  let changed = false;
+  const nextTabs = state.contentTabs.map((tab) => {
+    if (tab.id !== id) return tab;
+    const nextMeta = { ...(tab.meta ?? {}), ...meta };
+    if (JSON.stringify(tab.meta ?? {}) === JSON.stringify(nextMeta)) {
+      return tab;
+    }
+    changed = true;
+    return { ...tab, meta: nextMeta };
   });
   return changed ? { ...state, contentTabs: nextTabs } : state;
 }
@@ -844,7 +881,19 @@ export function projectUrlState(
   const out: Partial<WorkspaceUrlState> = {};
 
   if (tab) {
-    out.path = tab.path;
+    if (tab.kind === "crm-person" && tab.meta?.entryId) {
+      out.entry = { objectName: "people", entryId: tab.meta.entryId };
+      if (tab.meta.profileTab && tab.meta.profileTab !== "overview") {
+        out.profileTab = tab.meta.profileTab;
+      }
+    } else if (tab.kind === "crm-company" && tab.meta?.entryId) {
+      out.entry = { objectName: "company", entryId: tab.meta.entryId };
+      if (tab.meta.profileTab && tab.meta.profileTab !== "overview") {
+        out.profileTab = tab.meta.profileTab;
+      }
+    } else {
+      out.path = tab.path;
+    }
     if (shell.entryModal) {
       out.entry = shell.entryModal;
     }
@@ -904,7 +953,7 @@ export function contentTabFromUrl(
     if (url.crm === "companies") {
       return makeContentTab({
         kind: "object",
-        path: "companies",
+        path: "company",
         title: "Companies",
         preview: false,
       });
@@ -929,6 +978,14 @@ export function contentTabFromUrl(
   }
 
   const path = url.path;
+  if (path === "companies") {
+    return makeContentTab({
+      kind: "object",
+      path: "company",
+      title: "Companies",
+      preview: true,
+    });
+  }
   const kind = shell.resolveKind?.(path) ?? inferContentTabKindFromPath(path);
   return makeContentTab({
     kind,
@@ -957,13 +1014,16 @@ export function applyUrlToState(
     const isCompany = url.entry.objectName === "company" || url.entry.objectName === "companies";
     if (isPerson || isCompany) {
       const kind: ContentTabKind = isPerson ? "crm-person" : "crm-company";
-      const path = isPerson ? "people" : "companies";
+      const path = isPerson ? "people" : "company";
       next = openContent(next, {
         id: contentTabIdFor(kind, path, { entryId: url.entry.entryId }),
         kind,
         path,
         title: isPerson ? "Person" : "Company",
-        meta: { entryId: url.entry.entryId },
+        meta: {
+          entryId: url.entry.entryId,
+          ...(url.profileTab ? { profileTab: url.profileTab } : {}),
+        },
         preview: true,
       });
       return next;
@@ -1121,6 +1181,8 @@ export function workspaceTabsReducer(
       return promoteContentByPath(state, action.path);
     case "togglePinContent":
       return togglePinContent(state, action.id);
+    case "updateContentMeta":
+      return updateContentMeta(state, action.id, action.meta);
     case "reorderContent":
       return reorderContent(state, action.id, action.toIndex);
     case "renameContent":

--- a/apps/web/lib/workspace-url-state.test.ts
+++ b/apps/web/lib/workspace-url-state.test.ts
@@ -52,6 +52,16 @@ describe("deep-link restoration", () => {
     expect(state.entry).toEqual({ objectName: "leads", entryId: "entry-789" });
   });
 
+  it("restores CRM profile subtab from copied URL (prevents Safari back losing team tab)", () => {
+    const qs = serializeUrlState({
+      entry: { objectName: "company", entryId: "co_123" },
+      profileTab: "team",
+    });
+    const state = parseUrlState(qs);
+    expect(state.entry).toEqual({ objectName: "company", entryId: "co_123" });
+    expect(state.profileTab).toBe("team");
+  });
+
   it("restores browse mode from copied URL (prevents lost directory context on refresh)", () => {
     const url = buildBrowseLink("/Users/me/projects/app", true);
     const state = parseUrlState(new URL(url, "http://localhost").search);
@@ -467,6 +477,7 @@ describe("real-world edge cases", () => {
     expect(state.subagent).toBeNull();
     expect(state.fileChat).toBeNull();
     expect(state.entry).toBeNull();
+    expect(state.profileTab).toBeNull();
     expect(state.send).toBeNull();
     expect(state.browse).toBeNull();
     expect(state.hidden).toBe(false);


### PR DESCRIPTION
## Summary
- Preserve CRM profile record IDs and selected subtabs in workspace URL history.
- Make company/person profile tabs controllable from workspace tab state so browser Back returns to the prior company Team tab.
- Map legacy `path=companies` URLs to the canonical `company` object to avoid empty restored views.

## Test plan
- `pnpm --filter denchclaw-web exec vitest run lib/workspace-tabs.test.ts lib/workspace-url-state.test.ts`
- `pnpm --filter denchclaw-web exec tsc --noEmit`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core workspace URL/tab state projection and hydration/popstate behavior; mistakes could break navigation or restore incorrect tabs, though changes are localized and covered by new tests.
> 
> **Overview**
> Preserves CRM profile navigation state by making `PersonProfile` and `CompanyProfile` accept an externally-controlled `activeTab` plus `onTabChange`, and wiring tab clicks to update workspace tab metadata.
> 
> Extends workspace tab/url state to round-trip a `profileTab` query param for `crm-person`/`crm-company` tabs (via new `ContentTabMeta.profileTab` and `updateContentMeta` action), so browser Back/Forward restores the previously selected profile subtab instead of defaulting to overview.
> 
> Normalizes legacy navigation by mapping `path=companies` and `crm=companies` to the canonical `company` object path, and adds tests to cover legacy mapping and profile-tab URL round-tripping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff3da47c1b5451de044f4a92105bef5acb59548d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->