### PR TITLE
Stop object tables flicking to empty/loading on refresh

### DIFF
--- a/apps/web/app/workspace/use-tab-content.test.tsx
+++ b/apps/web/app/workspace/use-tab-content.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useTabContent, type UseTabContentDeps } from "./use-tab-content";
+import type { ContentTab } from "@/lib/workspace-tabs";
+import type { ObjectData } from "./content-state";
+import type { TreeNode } from "../components/workspace/file-manager-tree";
+
+/**
+ * Stale-while-revalidate contract for `useTabContent`.
+ *
+ * Why this matters: the workspace tree watcher fires on every SSE tick
+ * (file edits, log writes, db file touches). When the active tab is an
+ * object, `workspace-content.tsx` calls `refreshActive` to re-fetch the
+ * payload so the right panel stays in sync. Before this contract was
+ * locked in, a refresh would wipe the cached content to `undefined`,
+ * which made the hook return `{kind:"loading"}` for ~100-500ms while
+ * the network round-trip resolved. Visible result: the active right
+ * panel flicked to a centered spinner / empty table on every tick,
+ * destroying scroll/selection/edit state and rendering "No results
+ * found" when the in-flight fetch happened to interleave with an empty
+ * intermediate response.
+ *
+ * The contract: once a tab has cached content, refreshes keep that
+ * content visible until the new payload lands. Initial loads still
+ * surface `{kind:"loading"}` because there is nothing to keep.
+ */
+
+type FetchHandler = (
+  url: string,
+  init: RequestInit | undefined,
+) => Promise<Response>;
+
+let fetchHandler: FetchHandler;
+
+beforeEach(() => {
+  fetchHandler = async () => new Response("not-mocked", { status: 500 });
+  global.fetch = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.href
+        : input.url;
+    return fetchHandler(url, init);
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeObjectTab(name: string): ContentTab {
+  return {
+    id: `object:${name}`,
+    kind: "object",
+    path: name,
+    title: name,
+    preview: false,
+    pinned: false,
+  };
+}
+
+function makeObjectData(overrides?: Partial<ObjectData>): ObjectData {
+  return {
+    object: { id: "obj1", name: "people" },
+    fields: [{ id: "f1", name: "Name", type: "text" }],
+    statuses: [],
+    entries: [{ entry_id: "p1", Name: "Ada" }],
+    ...overrides,
+  };
+}
+
+function makeDeps(overrides?: Partial<UseTabContentDeps>): UseTabContentDeps {
+  return {
+    tree: [] as TreeNode[],
+    cronJobs: [],
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe("useTabContent stale-while-revalidate", () => {
+  it("emits loading on initial load, then resolves to fetched object content", async () => {
+    fetchHandler = async () =>
+      new Response(JSON.stringify(makeObjectData()), { status: 200 });
+
+    const tab = makeObjectTab("people");
+    const deps = makeDeps();
+    const { result } = renderHook(() => useTabContent(tab, deps));
+
+    expect(result.current.content).toEqual({ kind: "loading" });
+
+    await waitFor(() => {
+      expect(result.current.content.kind).toBe("object");
+    });
+    expect(
+      result.current.content.kind === "object"
+        ? result.current.content.data.entries
+        : null,
+    ).toEqual([{ entry_id: "p1", Name: "Ada" }]);
+  });
+
+  it("keeps existing object content visible while refreshActive() is in flight (no spurious loading flicker)", async () => {
+    // Initial fetch resolves immediately with one row.
+    fetchHandler = async () =>
+      new Response(JSON.stringify(makeObjectData()), { status: 200 });
+
+    const tab = makeObjectTab("people");
+    const deps = makeDeps();
+    const { result } = renderHook(() => useTabContent(tab, deps));
+
+    await waitFor(() => {
+      expect(result.current.content.kind).toBe("object");
+    });
+
+    // Refresh fetch is held open until we resolve it manually.
+    const refreshGate = deferred<Response>();
+    fetchHandler = async () => refreshGate.promise;
+
+    act(() => {
+      result.current.refreshActive();
+    });
+
+    // While the refresh is in flight the previously cached content
+    // must still be returned. If we ever revert to wiping cache on
+    // "loading", this assertion catches it — which is exactly the
+    // flicker users reported.
+    expect(result.current.content.kind).toBe("object");
+    expect(
+      result.current.content.kind === "object"
+        ? result.current.content.data.entries
+        : null,
+    ).toEqual([{ entry_id: "p1", Name: "Ada" }]);
+
+    // Resolve the refresh with the new payload.
+    const refreshed = makeObjectData({
+      entries: [
+        { entry_id: "p1", Name: "Ada" },
+        { entry_id: "p2", Name: "Grace" },
+      ],
+    });
+    await act(async () => {
+      refreshGate.resolve(
+        new Response(JSON.stringify(refreshed), { status: 200 }),
+      );
+      // Let the microtask + reducer settle.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.content.kind === "object"
+          ? result.current.content.data.entries.length
+          : 0,
+      ).toBe(2);
+    });
+  });
+
+  it("emits {kind:'loading'} when refreshActive() is called and nothing was ever cached yet", async () => {
+    // Hold the fetch open so the hook stays in its loading state.
+    const initialGate = deferred<Response>();
+    fetchHandler = async () => initialGate.promise;
+
+    const tab = makeObjectTab("people");
+    const deps = makeDeps();
+    const { result } = renderHook(() => useTabContent(tab, deps));
+
+    expect(result.current.content).toEqual({ kind: "loading" });
+
+    // Refreshing a never-cached tab must not produce stale content out of
+    // thin air — the user should still see the loading state.
+    act(() => {
+      result.current.refreshActive();
+    });
+    expect(result.current.content).toEqual({ kind: "loading" });
+
+    // Cleanup: resolve so the hook's pending fetch settles before unmount.
+    initialGate.resolve(
+      new Response(JSON.stringify(makeObjectData()), { status: 200 }),
+    );
+  });
+});

--- a/apps/web/app/workspace/use-tab-content.ts
+++ b/apps/web/app/workspace/use-tab-content.ts
@@ -65,11 +65,21 @@ function cacheReducer(state: CacheState, action: CacheAction): CacheState {
       const order = state.order.includes(action.id)
         ? state.order
         : [...state.order, action.id];
+      // Stale-while-revalidate: when refreshing an entry that already has
+      // cached content (e.g. tree-driven auto refetch, post-edit refresh,
+      // pagination reload), keep the previous content visible until the new
+      // payload lands. This prevents the active right-panel view from
+      // unmounting and flicking to a centered loading spinner / empty
+      // table on every workspace SSE tick.
+      const existing = state.entries[action.id];
       return {
         order: enforceLimit(order),
         entries: {
           ...state.entries,
-          [action.id]: { generation: action.generation, content: undefined },
+          [action.id]: {
+            generation: action.generation,
+            content: existing?.content,
+          },
         },
       };
     }
@@ -131,7 +141,11 @@ export type UseTabContentResult = {
   content: ContentState;
   /**
    * Force-refresh the active tab's payload. No-op for tabs that derive from
-   * live state. Used after destructive actions (e.g. saving an object).
+   * live state. Used after destructive actions (e.g. saving an object) and
+   * by the workspace tree watcher to keep object data in sync with the
+   * underlying DuckDB. Stale-while-revalidate: previous cached content
+   * stays returned from `content` until the refetch resolves, so callers
+   * never see a spurious loading flash mid-refresh.
    */
   refreshActive: () => void;
   /** Drop a single cached entry. Used when a tab is closed. */
@@ -148,6 +162,10 @@ export type UseTabContentResult = {
  *  - When `tab.kind` derives from live state → recompute on every render.
  *  - When `tab.kind` requires a fetch and the cache has no entry → emit
  *    `{kind:"loading"}` while the fetch is in flight, then store the result.
+ *  - When `refreshActive()` re-fetches a tab that already has cached
+ *    content → keep returning the existing content (stale-while-revalidate)
+ *    so the right-panel view doesn't unmount and flick to a spinner / empty
+ *    table on every refresh tick.
  */
 export function useTabContent(
   tab: ContentTab | null,


### PR DESCRIPTION
## Summary
- Make `useTabContent`'s cache stale-while-revalidate so `refreshActive()` keeps the previously cached content visible while a refetch is in flight.
- Stops object/CRM tables from flicking to a loading spinner / "No results found" on every workspace SSE tick, cell save, +Add, or refresh, and stops the active view from unmounting and losing selection/scroll/edit state.

## Test plan
- `pnpm --filter denchclaw-web exec vitest run app/workspace app/components/workspace/object-table.test.tsx app/components/workspace/data-table.test.tsx` — 5 files / 20 tests pass, including the new `useTabContent stale-while-revalidate` regression.
- `pnpm --filter denchclaw-web exec tsc --noEmit` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core right-panel content caching path, changing what users see during refreshes across fetched tab kinds. Main risk is unintentionally masking genuine loading/empty transitions or leaving stale content visible longer if a refetch fails.
> 
> **Overview**
> Updates `useTabContent`'s cache behavior to be **stale-while-revalidate**: dispatching the `loading` action no longer clears a tab’s cached `content`, so `refreshActive()` keeps rendering the previous payload until the new fetch resolves.
> 
> Adds a new Vitest regression suite (`use-tab-content.test.tsx`) that locks in the contract for initial loads, in-flight refreshes (no loading flicker), and refreshes before any content was ever cached.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e24ecbb5b9715e87a4d47ca3ae4a2d007fa2ad3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->