### PR TITLE
Hide CRM sync folders by default

### DIFF
--- a/apps/web/app/api/workspace/tree-browse.test.ts
+++ b/apps/web/app/api/workspace/tree-browse.test.ts
@@ -197,10 +197,10 @@ describe("Workspace Tree & Browse API", () => {
       expect(rootPaths).not.toContain("~skills");
     });
 
-    it("shows every DuckDB object table in the filesystem tree", async () => {
+    it("hides noisy CRM sync object folders by default without hiding ordinary object folders", async () => {
       // The left CRM navigation can still choose what belongs in the product
-      // nav, but the filesystem tree should reflect the actual object folders
-      // in the workspace, including synced CRM tables.
+      // nav, but the filesystem tree should reflect real object folders while
+      // keeping noisy sync backing tables behind the hidden-files toggle.
       const { resolveWorkspaceRoot, duckdbQueryAllAsync } = await import("@/lib/workspace");
       vi.mocked(resolveWorkspaceRoot).mockReturnValue("/ws");
       vi.mocked(duckdbQueryAllAsync).mockResolvedValue([
@@ -208,6 +208,8 @@ describe("Workspace Tree & Browse API", () => {
         { name: "company", default_view: "table", hidden_in_sidebar: "false" },
         { name: "opportunity", default_view: "kanban", hidden_in_sidebar: "false" },
         { name: "email_message", default_view: "table", hidden_in_sidebar: "true" },
+        { name: "email_thread", default_view: "table", hidden_in_sidebar: "true" },
+        { name: "calendar_event", default_view: "table", hidden_in_sidebar: "true" },
         { name: "secret", default_view: "table", hidden_in_sidebar: "true" },
       ] as never);
 
@@ -220,6 +222,8 @@ describe("Workspace Tree & Browse API", () => {
             makeDirent("opportunity", true),
             makeDirent("secret", true),
             makeDirent("email_message", true),
+            makeDirent("email_thread", true),
+            makeDirent("calendar_event", true),
           ] as unknown as never[]);
         }
         return Promise.resolve([] as unknown as never[]);
@@ -234,8 +238,44 @@ describe("Workspace Tree & Browse API", () => {
       expect(rootPaths).toContain("people");
       expect(rootPaths).toContain("company");
       expect(rootPaths).toContain("opportunity");
-      expect(rootPaths).toContain("email_message");
       expect(rootPaths).toContain("secret");
+      expect(rootPaths).not.toContain("email_message");
+      expect(rootPaths).not.toContain("email_thread");
+      expect(rootPaths).not.toContain("calendar_event");
+    });
+
+    it("shows CRM sync object folders when hidden files are revealed", async () => {
+      const { resolveWorkspaceRoot, duckdbQueryAllAsync } = await import("@/lib/workspace");
+      vi.mocked(resolveWorkspaceRoot).mockReturnValue("/ws");
+      vi.mocked(duckdbQueryAllAsync).mockResolvedValue([
+        { name: "people", default_view: "table" },
+        { name: "email_message", default_view: "table" },
+        { name: "email_thread", default_view: "table" },
+        { name: "calendar_event", default_view: "table" },
+      ] as never);
+
+      const { readdir: mockReaddir } = await import("node:fs/promises");
+      vi.mocked(mockReaddir).mockImplementation((dir) => {
+        if (String(dir) === "/ws") {
+          return Promise.resolve([
+            makeDirent("people", true),
+            makeDirent("email_message", true),
+            makeDirent("email_thread", true),
+            makeDirent("calendar_event", true),
+          ] as unknown as never[]);
+        }
+        return Promise.resolve([] as unknown as never[]);
+      });
+
+      const { GET } = await import("./tree/route.js");
+      const req = new Request("http://localhost/api/workspace/tree?showHidden=1");
+      const res = await GET(req);
+      const json = await res.json();
+      const rootPaths = (json.tree as Array<{ path: string }>).map((n) => n.path);
+      expect(rootPaths).toContain("people");
+      expect(rootPaths).toContain("email_message");
+      expect(rootPaths).toContain("email_thread");
+      expect(rootPaths).toContain("calendar_event");
     });
 
     it("yields before tree discovery completes (prevents UI freeze during active agent runs)", async () => {

--- a/apps/web/app/api/workspace/tree-browse.test.ts
+++ b/apps/web/app/api/workspace/tree-browse.test.ts
@@ -210,6 +210,7 @@ describe("Workspace Tree & Browse API", () => {
         { name: "email_message", default_view: "table", hidden_in_sidebar: "true" },
         { name: "email_thread", default_view: "table", hidden_in_sidebar: "true" },
         { name: "calendar_event", default_view: "table", hidden_in_sidebar: "true" },
+        { name: "interaction", default_view: "table", hidden_in_sidebar: "true" },
         { name: "secret", default_view: "table", hidden_in_sidebar: "true" },
       ] as never);
 
@@ -224,6 +225,7 @@ describe("Workspace Tree & Browse API", () => {
             makeDirent("email_message", true),
             makeDirent("email_thread", true),
             makeDirent("calendar_event", true),
+            makeDirent("interaction", true),
           ] as unknown as never[]);
         }
         return Promise.resolve([] as unknown as never[]);
@@ -242,6 +244,7 @@ describe("Workspace Tree & Browse API", () => {
       expect(rootPaths).not.toContain("email_message");
       expect(rootPaths).not.toContain("email_thread");
       expect(rootPaths).not.toContain("calendar_event");
+      expect(rootPaths).not.toContain("interaction");
     });
 
     it("shows CRM sync object folders when hidden files are revealed", async () => {
@@ -252,6 +255,7 @@ describe("Workspace Tree & Browse API", () => {
         { name: "email_message", default_view: "table" },
         { name: "email_thread", default_view: "table" },
         { name: "calendar_event", default_view: "table" },
+        { name: "interaction", default_view: "table" },
       ] as never);
 
       const { readdir: mockReaddir } = await import("node:fs/promises");
@@ -262,6 +266,7 @@ describe("Workspace Tree & Browse API", () => {
             makeDirent("email_message", true),
             makeDirent("email_thread", true),
             makeDirent("calendar_event", true),
+            makeDirent("interaction", true),
           ] as unknown as never[]);
         }
         return Promise.resolve([] as unknown as never[]);
@@ -276,6 +281,7 @@ describe("Workspace Tree & Browse API", () => {
       expect(rootPaths).toContain("email_message");
       expect(rootPaths).toContain("email_thread");
       expect(rootPaths).toContain("calendar_event");
+      expect(rootPaths).toContain("interaction");
     });
 
     it("yields before tree discovery completes (prevents UI freeze during active agent runs)", async () => {

--- a/apps/web/app/api/workspace/tree/route.ts
+++ b/apps/web/app/api/workspace/tree/route.ts
@@ -87,6 +87,7 @@ const ROOT_ONLY_HIDDEN_SYNC_OBJECTS = new Set([
   "calendar_event",
   "email_message",
   "email_thread",
+  "interaction",
 ]);
 
 async function loadDbObjects(): Promise<Map<string, DbObject>> {

--- a/apps/web/app/api/workspace/tree/route.ts
+++ b/apps/web/app/api/workspace/tree/route.ts
@@ -80,9 +80,15 @@ async function readObjectMeta(
  * directories even when .object.yaml files are missing.
  * Shallower databases win on name conflicts (parent priority).
  *
- * The file tree intentionally shows every object table now, including CRM
- * sync tables that remain hidden from the left CRM navigation.
+ * The file tree intentionally shows object table folders, while a short list
+ * of noisy sync backing tables follows the same show-hidden toggle as dotfiles.
  */
+const ROOT_ONLY_HIDDEN_SYNC_OBJECTS = new Set([
+  "calendar_event",
+  "email_message",
+  "email_thread",
+]);
+
 async function loadDbObjects(): Promise<Map<string, DbObject>> {
   const objects = new Map<string, DbObject>();
   const rows = await duckdbQueryAllAsync<DbObject & { name: string }>(
@@ -157,6 +163,9 @@ async function buildTree(
     // .object.yaml is always needed for metadata; also shown as a node when showHidden is on
     if (e.name === ".object.yaml") {return true;}
     if (e.name.startsWith(".")) {return showHidden;}
+    if (relativeBase === "" && ROOT_ONLY_HIDDEN_SYNC_OBJECTS.has(e.name)) {
+      return showHidden;
+    }
     return true;
   });
 


### PR DESCRIPTION
## Summary
- Hide root-level CRM sync backing folders (`calendar_event`, `email_thread`, `email_message`) from the workspace tree by default.
- Keep ordinary object folders visible and reveal the sync folders again through the existing show-hidden/dotfiles toggle.
- Add regression coverage for both default hidden behavior and `showHidden=1` visibility.

## Test plan
- `pnpm --filter denchclaw-web exec vitest run app/api/workspace/tree-browse.test.ts`
- `pnpm --filter denchclaw-web exec tsc --noEmit`
- `ReadLints` on changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, isolated filtering change to the workspace tree listing plus tests; potential impact is limited to which root folders appear by default.
> 
> **Overview**
> Updates `GET /api/workspace/tree` to **hide a small allowlist of root-level CRM sync backing folders** (e.g. `email_message`, `email_thread`, `calendar_event`, `interaction`) unless `showHidden=1` is set, matching the existing hidden-files toggle behavior.
> 
> Adds/updates tests to assert these folders are excluded by default while **ordinary object folders remain visible**, and that the hidden CRM folders reappear when `showHidden` is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbdfbf8a45e23ea5e0ce00b3f1f3f4a1a4d5dcac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->