### PR TITLE
fix(dench-cloud): recommend Sonnet 4.6 by default

### DIFF
--- a/extensions/dench-ai-gateway/models.ts
+++ b/extensions/dench-ai-gateway/models.ts
@@ -119,7 +119,7 @@ export function buildDenchGatewayCatalogUrl(gatewayUrl: string | undefined): str
   return `${normalizeDenchGatewayUrl(gatewayUrl)}/v1/public/models`;
 }
 
-export const RECOMMENDED_DENCH_CLOUD_MODEL_ID = "kimi-k2.5";
+export const RECOMMENDED_DENCH_CLOUD_MODEL_ID = "claude-sonnet-4.6";
 
 // Fallback list used only when the live gateway catalog is unreachable.
 // Live pricing always comes from the gateway's /v1/public/models response.

--- a/src/cli/dench-cloud.ts
+++ b/src/cli/dench-cloud.ts
@@ -127,7 +127,7 @@ export function buildDenchGatewayCatalogUrl(gatewayUrl: string | undefined): str
   return `${normalizeDenchGatewayUrl(gatewayUrl)}/v1/public/models`;
 }
 
-export const RECOMMENDED_DENCH_CLOUD_MODEL_ID = "kimi-k2.5";
+export const RECOMMENDED_DENCH_CLOUD_MODEL_ID = "claude-sonnet-4.6";
 export const DENCH_COMPOSIO_WRAPPER_TOOLS = [
   "dench_search_integrations",
   "dench_execute_integrations",


### PR DESCRIPTION
## Summary
- switch the Dench Cloud recommended model id from `kimi-k2.5` to `claude-sonnet-4.6`
- keep CLI helper and gateway runtime model metadata in parity so both surfaces recommend Sonnet 4.6
- ensure bootstrap model selection sorts Sonnet 4.6 first as the recommended default

## Test plan
- [x] Verified changed constants in `src/cli/dench-cloud.ts` and `extensions/dench-ai-gateway/models.ts`
- [x] Ran lints for edited files (no errors)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes the default recommended Dench Cloud model ID, affecting which model is preselected when no explicit model is provided.
> 
> **Overview**
> Updates the Dench Cloud *recommended default model* from `kimi-k2.5` to `claude-sonnet-4.6` in both the gateway extension (`extensions/dench-ai-gateway/models.ts`) and the CLI helper (`src/cli/dench-cloud.ts`).
> 
> As a result, any bootstrap/model resolution path that relies on `RECOMMENDED_DENCH_CLOUD_MODEL_ID` will now prefer Sonnet 4.6 when no model is explicitly requested.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 817bdf4a408d3e8062cce3fafaeb15f98ef877b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->