### PR TITLE
fix(workspace): keep CRM folders aligned with pivot views

### DIFF
--- a/apps/web/app/api/workspace/file-ops.test.ts
+++ b/apps/web/app/api/workspace/file-ops.test.ts
@@ -21,6 +21,10 @@ vi.mock("@/lib/workspace", () => ({
   resolveFilesystemPath: vi.fn(),
   isProtectedSystemPath: vi.fn(() => false),
   resolveWorkspaceRoot: vi.fn(() => "/ws"),
+  findDuckDBForObjectAsync: vi.fn(async () => null),
+  duckdbPathAsync: vi.fn(async () => null),
+  duckdbExecOnFileAsync: vi.fn(async () => true),
+  pivotViewIdentifier: vi.fn((name: string) => `"v_${name}"`),
 }));
 
 describe("Workspace File Operations API", () => {
@@ -44,6 +48,10 @@ describe("Workspace File Operations API", () => {
       resolveFilesystemPath: vi.fn(),
       isProtectedSystemPath: vi.fn(() => false),
       resolveWorkspaceRoot: vi.fn(() => "/ws"),
+      findDuckDBForObjectAsync: vi.fn(async () => null),
+      duckdbPathAsync: vi.fn(async () => null),
+      duckdbExecOnFileAsync: vi.fn(async () => true),
+      pivotViewIdentifier: vi.fn((name: string) => `"v_${name}"`),
     }));
   });
 
@@ -247,6 +255,41 @@ describe("Workspace File Operations API", () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.ok).toBe(true);
+    });
+
+    it("drops the object pivot view when deleting an object folder", async () => {
+      const {
+        resolveFilesystemPath,
+        findDuckDBForObjectAsync,
+        duckdbExecOnFileAsync,
+      } = await import("@/lib/workspace");
+      vi.mocked(resolveFilesystemPath).mockReturnValue({
+        absolutePath: "/ws/marketing/YC Founders/yc_company",
+        kind: "workspaceRelative",
+        withinWorkspace: true,
+        workspaceRelativePath: "marketing/YC Founders/yc_company",
+      });
+      vi.mocked(findDuckDBForObjectAsync).mockResolvedValue("/ws/workspace.duckdb");
+
+      const fs = await import("node:fs");
+      vi.mocked(fs.statSync).mockReturnValue({ isDirectory: () => true } as never);
+      vi.mocked(fs.existsSync).mockImplementation((path) => String(path).endsWith(".object.yaml"));
+      vi.mocked(fs.readFileSync).mockReturnValue("name: yc_company\n" as never);
+
+      const { DELETE } = await import("./file/route.js");
+      const req = new Request("http://localhost/api/workspace/file", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path: "marketing/YC Founders/yc_company" }),
+      });
+      const res = await DELETE(req);
+
+      expect(res.status).toBe(200);
+      expect(duckdbExecOnFileAsync).toHaveBeenCalledWith(
+        "/ws/workspace.duckdb",
+        "DROP VIEW IF EXISTS \"v_yc_company\";",
+      );
+      expect(fs.rmSync).toHaveBeenCalledWith("/ws/marketing/YC Founders/yc_company", { recursive: true });
     });
 
     it("returns 403 for system file", async () => {

--- a/apps/web/app/api/workspace/file/route.ts
+++ b/apps/web/app/api/workspace/file/route.ts
@@ -1,10 +1,15 @@
-import { writeFileSync, mkdirSync, rmSync, statSync } from "node:fs";
-import { dirname } from "node:path";
+import { writeFileSync, mkdirSync, rmSync, statSync, existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import YAML from "yaml";
 import {
   readWorkspaceFile,
   safeResolvePath,
   resolveFilesystemPath,
   isProtectedSystemPath,
+  findDuckDBForObjectAsync,
+  duckdbPathAsync,
+  duckdbExecOnFileAsync,
+  pivotViewIdentifier,
 } from "@/lib/workspace";
 
 export const dynamic = "force-dynamic";
@@ -81,6 +86,40 @@ export async function POST(req: Request) {
   }
 }
 
+async function dropObjectPivotViewForDeletedFolder(absPath: string): Promise<{ ok: true } | { ok: false; error: string }> {
+  const yamlPath = join(absPath, ".object.yaml");
+  if (!existsSync(yamlPath)) {
+    return { ok: true };
+  }
+
+  let objectName: string | null = null;
+  try {
+    const parsed = YAML.parse(readFileSync(yamlPath, "utf-8")) as { name?: unknown } | null;
+    objectName = typeof parsed?.name === "string" ? parsed.name.trim() : null;
+  } catch {
+    objectName = null;
+  }
+
+  if (!objectName) {
+    return { ok: true };
+  }
+
+  const dbFile = await findDuckDBForObjectAsync(objectName) ?? await duckdbPathAsync();
+  if (!dbFile) {
+    return { ok: true };
+  }
+
+  const dropped = await duckdbExecOnFileAsync(
+    dbFile,
+    `DROP VIEW IF EXISTS ${pivotViewIdentifier(objectName)};`,
+  );
+  if (!dropped) {
+    return { ok: false, error: `Failed to delete pivot view for object '${objectName}'.` };
+  }
+
+  return { ok: true };
+}
+
 /**
  * DELETE /api/workspace/file
  * Body: { path: string }
@@ -122,6 +161,12 @@ export async function DELETE(req: Request) {
 
   try {
     const stat = statSync(absPath);
+    if (stat.isDirectory()) {
+      const pivotDelete = await dropObjectPivotViewForDeletedFolder(absPath);
+      if (!pivotDelete.ok) {
+        return Response.json({ error: pivotDelete.error }, { status: 500 });
+      }
+    }
     rmSync(absPath, { recursive: stat.isDirectory() });
     return Response.json({ ok: true, path: relPath });
   } catch (err) {

--- a/apps/web/app/api/workspace/tree-browse.test.ts
+++ b/apps/web/app/api/workspace/tree-browse.test.ts
@@ -284,6 +284,43 @@ describe("Workspace Tree & Browse API", () => {
       expect(rootPaths).toContain("interaction");
     });
 
+    it("does not classify nested folders as objects by basename alone", async () => {
+      const { resolveWorkspaceRoot, duckdbQueryAllAsync } = await import("@/lib/workspace");
+      vi.mocked(resolveWorkspaceRoot).mockReturnValue("/ws");
+      vi.mocked(duckdbQueryAllAsync).mockResolvedValue([
+        { name: "opportunity", default_view: "table" },
+      ] as never);
+
+      const { readdir: mockReaddir } = await import("node:fs/promises");
+      vi.mocked(mockReaddir).mockImplementation((dir) => {
+        if (String(dir) === "/ws") {
+          return Promise.resolve([
+            makeDirent("archive", true),
+            makeDirent("opportunity", true),
+          ] as unknown as never[]);
+        }
+        if (String(dir) === "/ws/archive") {
+          return Promise.resolve([
+            makeDirent("opportunity", true),
+          ] as unknown as never[]);
+        }
+        return Promise.resolve([] as unknown as never[]);
+      });
+
+      const { GET } = await import("./tree/route.js");
+      const req = new Request("http://localhost/api/workspace/tree");
+      const res = await GET(req);
+      const json = await res.json();
+      const rootObject = (json.tree as Array<{ path: string; type: string; children?: Array<{ path: string; type: string }> }>)
+        .find((node) => node.path === "opportunity");
+      const archive = (json.tree as Array<{ path: string; type: string; children?: Array<{ path: string; type: string }> }>)
+        .find((node) => node.path === "archive");
+      const nestedFolder = archive?.children?.find((node) => node.path === "archive/opportunity");
+
+      expect(rootObject?.type).toBe("object");
+      expect(nestedFolder?.type).toBe("folder");
+    });
+
     it("yields before tree discovery completes (prevents UI freeze during active agent runs)", async () => {
       const { resolveWorkspaceRoot, duckdbQueryAll, duckdbQueryAllAsync } = await import("@/lib/workspace");
       vi.mocked(resolveWorkspaceRoot).mockReturnValue("/ws");

--- a/apps/web/app/api/workspace/tree/route.ts
+++ b/apps/web/app/api/workspace/tree/route.ts
@@ -93,7 +93,12 @@ const ROOT_ONLY_HIDDEN_SYNC_OBJECTS = new Set([
 async function loadDbObjects(): Promise<Map<string, DbObject>> {
   const objects = new Map<string, DbObject>();
   const rows = await duckdbQueryAllAsync<DbObject & { name: string }>(
-    "SELECT id, name, description, default_view FROM objects",
+    `SELECT o.id, o.name, o.description, o.default_view
+     FROM objects o
+     JOIN information_schema.tables t
+       ON t.table_schema = 'main'
+      AND t.table_type = 'VIEW'
+      AND t.table_name = 'v_' || replace(o.name, '-', '_')`,
     "name",
   );
   for (const row of rows) {
@@ -213,7 +218,11 @@ async function buildTree(
       }
 
       const objectMeta = await readObjectMeta(absPath);
-      const dbObject = dbObjects.get(entry.name);
+      // DB-only object rows are projected to root-level object directories
+      // before we build the tree. Do not classify nested folders by basename
+      // alone, or ordinary folders like `marketing/influencers` duplicate the
+      // `influencers` table in CRM navigation.
+      const dbObject = relativeBase === "" ? dbObjects.get(entry.name) : undefined;
       const children = await buildTree(absPath, relPath, dbObjects, showHidden);
 
       if (objectMeta || dbObject) {

--- a/apps/web/app/components/workspace/file-manager-tree.tsx
+++ b/apps/web/app/components/workspace/file-manager-tree.tsx
@@ -33,6 +33,7 @@ import {
   ContextMenuShortcut,
 } from "../ui/context-menu";
 import { InlineRename, RENAME_SHAKE_STYLE } from "./inline-rename";
+import { CrmObjectIcon } from "./crm-object-icon";
 import {
   classifyWorkspacePath,
   fileWriteUrl,
@@ -160,10 +161,8 @@ function NodeIcon({ node, open }: { node: TreeNode; open?: boolean }) {
     return <ChatBubbleIcon />;
   }
   switch (node.type) {
-    // Object directories are real folders on disk that happen to back a
-    // CRM table. The file tree is a 1:1 view of the workspace, so render
-    // them as folders. The CRM nav still discriminates via node.type.
     case "object":
+      return <CrmObjectIcon name={node.icon} size={18} />;
     case "folder":
       return <FolderIcon open={open} />;
     case "document":

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -342,20 +342,20 @@ const HIDE_NOISY_REVERSE_FOR_OBJECT_NAMES: ReadonlySet<string> = new Set([
 function collectCrmObjectNodes(
   tree: TreeNode[],
 ): Array<{ name: string; icon?: string; defaultView?: "table" | "kanban" }> {
-  const out: Array<{ name: string; icon?: string; defaultView?: "table" | "kanban" }> = [];
+  const byName = new Map<string, { name: string; icon?: string; defaultView?: "table" | "kanban" }>();
   function walk(nodes: TreeNode[]) {
     for (const node of nodes) {
       if (node.type === "object") {
         const name = objectNameFromPath(node.path);
-        if (!CRM_NAV_EXCLUDED_OBJECT_NAMES.has(name)) {
-          out.push({ name, icon: node.icon, defaultView: node.defaultView });
+        if (!CRM_NAV_EXCLUDED_OBJECT_NAMES.has(name) && !byName.has(name)) {
+          byName.set(name, { name, icon: node.icon, defaultView: node.defaultView });
         }
       }
       if (node.children) {walk(node.children);}
     }
   }
   walk(tree);
-  return out.toSorted((a, b) => a.name.localeCompare(b.name));
+  return [...byName.values()].toSorted((a, b) => a.name.localeCompare(b.name));
 }
 
 /**

--- a/apps/web/lib/workspace-projection.test.ts
+++ b/apps/web/lib/workspace-projection.test.ts
@@ -65,6 +65,28 @@ describe("projectObjectToFilesystem", () => {
     expect(existsSync(join(tempRoot, "people", ".object.yaml"))).toBe(true);
   });
 
+  it("does not create a root stub when the object already exists nested", () => {
+    const nestedDir = join(tempRoot, "marketing", "YC Founders", "yc_company");
+    mkdirSync(nestedDir, { recursive: true });
+    writeFileSync(
+      join(nestedDir, ".object.yaml"),
+      "id: id-yc-company\nname: yc_company\nfields:\n  - name: Company Name\n",
+      "utf-8",
+    );
+
+    const result = projectObjectToFilesystem(tempRoot, {
+      name: "yc_company",
+      id: "id-yc-company",
+    });
+
+    expect(result).toEqual({
+      name: "yc_company",
+      status: "skipped",
+      reason: "object_exists_nested",
+    });
+    expect(existsSync(join(tempRoot, "yc_company"))).toBe(false);
+  });
+
   it("is idempotent: running twice when both exist returns skipped", () => {
     projectObjectToFilesystem(tempRoot, { name: "deals", id: "id-3" });
     const second = projectObjectToFilesystem(tempRoot, { name: "deals", id: "id-3" });

--- a/apps/web/lib/workspace-projection.ts
+++ b/apps/web/lib/workspace-projection.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import YAML from "yaml";
 import type { ObjectYamlConfig } from "./workspace";
@@ -24,6 +24,61 @@ export type ProjectionResult = {
   status: ProjectionStatus;
   reason?: string;
 };
+
+const PROJECTION_SCAN_SKIP_DIRS = new Set([
+  ".git",
+  ".next",
+  "node_modules",
+]);
+
+function objectYamlMatchesName(yamlPath: string, objectName: string): boolean {
+  try {
+    const raw = readFileSync(yamlPath, "utf-8");
+    const parsed = YAML.parse(raw) as { name?: unknown } | null;
+    return parsed?.name === objectName;
+  } catch {
+    return false;
+  }
+}
+
+function hasExistingObjectYamlOutsideRootSlot(
+  workspaceRoot: string,
+  objectName: string,
+  rootObjectDir: string,
+): boolean {
+  const resolvedRootObjectDir = resolve(rootObjectDir);
+
+  function walk(dir: string): boolean {
+    let entries: ReturnType<typeof readdirSync>;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return false;
+    }
+
+    const yamlPath = join(dir, ".object.yaml");
+    if (
+      resolve(dir) !== resolvedRootObjectDir &&
+      existsSync(yamlPath) &&
+      objectYamlMatchesName(yamlPath, objectName)
+    ) {
+      return true;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory() || PROJECTION_SCAN_SKIP_DIRS.has(entry.name)) {
+        continue;
+      }
+      if (walk(join(dir, entry.name))) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  return walk(workspaceRoot);
+}
 
 /**
  * Project a single DuckDB object onto the filesystem. Idempotent:
@@ -56,6 +111,14 @@ export function projectObjectToFilesystem(
     return { name, status: "skipped", reason: "outside_workspace" };
   }
 
+  const yamlPath = join(objectDir, ".object.yaml");
+  if (
+    !existsSync(yamlPath) &&
+    hasExistingObjectYamlOutsideRootSlot(resolvedRoot, name, objectDir)
+  ) {
+    return { name, status: "skipped", reason: "object_exists_nested" };
+  }
+
   let createdDir = false;
   if (existsSync(objectDir)) {
     let isDir = false;
@@ -82,7 +145,6 @@ export function projectObjectToFilesystem(
     }
   }
 
-  const yamlPath = join(objectDir, ".object.yaml");
   if (existsSync(yamlPath)) {
     if (createdDir) {
       // We just created the directory but somehow the yaml exists — odd


### PR DESCRIPTION
## Summary
- Only project CRM folders for DuckDB objects that still have live `v_<object>` pivot views.
- Drop the matching pivot view when deleting a CRM object folder so deleted folders do not reappear.
- Deduplicate CRM sidebar entries and restore object icons in the file tree.

## Test plan
- `pnpm --dir apps/web test app/api/workspace/file-ops.test.ts app/api/workspace/tree-browse.test.ts lib/workspace-projection.test.ts`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workspace deletion and tree-discovery logic by coupling filesystem operations to DuckDB view cleanup and filtering; mistakes could hide objects or drop the wrong views.
> 
> **Overview**
> Keeps the workspace tree and CRM object projection in sync with *live* DuckDB pivot views by only loading `objects` rows that still have a corresponding `v_<object>` view, and by avoiding treating nested folders as CRM objects based purely on basename.
> 
> When deleting a directory via `DELETE /api/workspace/file`, the API now detects `.object.yaml`, extracts the object name, and drops the corresponding pivot view before removing the folder (failing the delete if the view drop fails).
> 
> UI tweaks restore CRM-specific icons for `object` nodes in the file tree and deduplicate CRM sidebar object entries by name. Tests were expanded to cover pivot-view dropping on delete, nested-folder classification, and skipping root projections when an object already exists nested.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a9707328d92473155bdc2fcd7000525169e2650. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->