### PR TITLE
feat(workspace): bulk-Enrich button for selected rows + workspace UX/stability fixes

### DIFF
--- a/apps/web/app/api/workspace/objects/[name]/enrich/route.test.ts
+++ b/apps/web/app/api/workspace/objects/[name]/enrich/route.test.ts
@@ -271,6 +271,208 @@ describe("workspace enrichment route", () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
+  it(
+    "narrows the entries SQL to the supplied entryIds (drives the row-selection bulk-Enrich path)",
+    async () => {
+      const { duckdbQueryOnFile } = await import("@/lib/workspace");
+      const seenSqls: string[] = [];
+      vi.mocked(duckdbQueryOnFile).mockImplementation((_dbFile: string, sql: string) => {
+        seenSqls.push(sql);
+        if (sql.includes("SELECT id FROM objects WHERE name")) {
+          return [{ id: "obj_1" }] as never;
+        }
+        if (sql.includes("SELECT id, name, type FROM fields")) {
+          return [{ id: "input_1", name: "email", type: "email" }] as never;
+        }
+        if (sql.includes("SELECT id FROM fields WHERE id")) {
+          return [{ id: "field_1" }] as never;
+        }
+        if (sql.includes("FROM entries e")) {
+          // Mirror what the SQL would actually return: only the selected entry.
+          return [{ entry_id: "entry_2", input_value: "bob@acme.com" }] as never;
+        }
+        if (sql.includes("COUNT(*) as cnt")) {
+          return [{ cnt: 0 }] as never;
+        }
+        return [] as never;
+      });
+
+      global.fetch = vi.fn(async () =>
+        new Response(JSON.stringify({ person: { name: "Bob" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ) as typeof fetch;
+
+      const { POST } = await import("./route.js");
+      const response = await POST(
+        new Request("http://localhost/api/workspace/objects/leads/enrich", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            fieldId: "field_1",
+            apolloPath: "person.name",
+            category: "people",
+            inputFieldName: "email",
+            scope: "all",
+            entryIds: ["entry_2", "entry_4"],
+          }),
+        }),
+        { params: Promise.resolve({ name: "leads" }) },
+      );
+
+      expect(response.status).toBe(200);
+      await response.text();
+
+      const entrySql = seenSqls.find((s) => s.includes("FROM entries e"));
+      expect(entrySql).toBeDefined();
+      // The IN-clause must be present and contain ONLY the supplied IDs.
+      expect(entrySql).toMatch(/AND e\.id IN \('entry_2','entry_4'\)/);
+      // Exactly one upstream Apollo call — the one whose entry_id matched.
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("composes entryIds with scope='empty' so 'enrich the selected rows that are still empty' works", async () => {
+    const { duckdbQueryOnFile } = await import("@/lib/workspace");
+    const seenSqls: string[] = [];
+    vi.mocked(duckdbQueryOnFile).mockImplementation((_dbFile: string, sql: string) => {
+      seenSqls.push(sql);
+      if (sql.includes("SELECT id FROM objects WHERE name")) {
+        return [{ id: "obj_1" }] as never;
+      }
+      if (sql.includes("SELECT id, name, type FROM fields")) {
+        return [{ id: "input_1", name: "email", type: "email" }] as never;
+      }
+      if (sql.includes("SELECT id FROM fields WHERE id")) {
+        return [{ id: "field_1" }] as never;
+      }
+      if (sql.includes("FROM entries e")) {
+        return [] as never;
+      }
+      return [] as never;
+    });
+
+    global.fetch = vi.fn() as typeof fetch;
+
+    const { POST } = await import("./route.js");
+    await POST(
+      new Request("http://localhost/api/workspace/objects/leads/enrich", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          fieldId: "field_1",
+          apolloPath: "person.name",
+          category: "people",
+          inputFieldName: "email",
+          scope: "empty",
+          entryIds: ["entry_1"],
+        }),
+      }),
+      { params: Promise.resolve({ name: "leads" }) },
+    );
+
+    const entrySql = seenSqls.find((s) => s.includes("FROM entries e"));
+    expect(entrySql).toBeDefined();
+    expect(entrySql).toContain("AND e.id IN ('entry_1')");
+    // 'empty' filter still applied — the two filters compose, they don't replace.
+    expect(entrySql).toContain("AND e.id NOT IN");
+  });
+
+  it("rejects entryIds that contain SQL-injection characters (validated before reaching the IN clause)", async () => {
+    const { POST } = await import("./route.js");
+    const response = await POST(
+      new Request("http://localhost/api/workspace/objects/leads/enrich", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          fieldId: "field_1",
+          apolloPath: "person.name",
+          category: "people",
+          inputFieldName: "email",
+          scope: "all",
+          entryIds: ["entry_1", "'; DROP TABLE entries; --"],
+        }),
+      }),
+      { params: Promise.resolve({ name: "leads" }) },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid entry ID.",
+    });
+  });
+
+  it("rejects entryIds payloads that exceed the cap (huge IN clauses are abuse-shaped)", async () => {
+    const { POST } = await import("./route.js");
+    const tooMany = Array.from({ length: 5001 }, (_, i) => `entry_${i}`);
+
+    const response = await POST(
+      new Request("http://localhost/api/workspace/objects/leads/enrich", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          fieldId: "field_1",
+          apolloPath: "person.name",
+          category: "people",
+          inputFieldName: "email",
+          scope: "all",
+          entryIds: tooMany,
+        }),
+      }),
+      { params: Promise.resolve({ name: "leads" }) },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: expect.stringContaining("Too many entryIds"),
+    });
+  });
+
+  it("treats an empty entryIds array as 'no narrowing' so the client doesn't have to special-case empty selections", async () => {
+    const { duckdbQueryOnFile } = await import("@/lib/workspace");
+    const seenSqls: string[] = [];
+    vi.mocked(duckdbQueryOnFile).mockImplementation((_dbFile: string, sql: string) => {
+      seenSqls.push(sql);
+      if (sql.includes("SELECT id FROM objects WHERE name")) {
+        return [{ id: "obj_1" }] as never;
+      }
+      if (sql.includes("SELECT id, name, type FROM fields")) {
+        return [{ id: "input_1", name: "email", type: "email" }] as never;
+      }
+      if (sql.includes("SELECT id FROM fields WHERE id")) {
+        return [{ id: "field_1" }] as never;
+      }
+      if (sql.includes("FROM entries e")) {
+        return [] as never;
+      }
+      return [] as never;
+    });
+
+    global.fetch = vi.fn() as typeof fetch;
+
+    const { POST } = await import("./route.js");
+    await POST(
+      new Request("http://localhost/api/workspace/objects/leads/enrich", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          fieldId: "field_1",
+          apolloPath: "person.name",
+          category: "people",
+          inputFieldName: "email",
+          scope: "all",
+          entryIds: [],
+        }),
+      }),
+      { params: Promise.resolve({ name: "leads" }) },
+    );
+
+    const entrySql = seenSqls.find((s) => s.includes("FROM entries e"));
+    expect(entrySql).toBeDefined();
+    expect(entrySql).not.toContain("AND e.id IN");
+  });
+
   it("surfaces gateway invalid_required_field errors in SSE error events", async () => {
     const { duckdbQueryOnFile } = await import("@/lib/workspace");
     vi.mocked(duckdbQueryOnFile).mockImplementation((_dbFile: string, sql: string) => {

--- a/apps/web/app/api/workspace/objects/[name]/enrich/route.ts
+++ b/apps/web/app/api/workspace/objects/[name]/enrich/route.ts
@@ -30,7 +30,22 @@ type EnrichRequestBody = {
 	category: "people" | "company";
 	inputFieldName: string;
 	scope: "all" | "empty" | number;
+	/**
+	 * Optional explicit list of entry IDs to enrich. When provided, the SQL
+	 * scope is narrowed to these entries (intersected with the `scope`
+	 * filter, so e.g. `scope: "empty"` + `entryIds: [...]` enriches only
+	 * those listed entries that don't already have a value). Used by the
+	 * row-selection "Enrich" bulk action so the user can target the rows
+	 * they checked instead of the whole table.
+	 *
+	 * Capped at MAX_ENTRY_IDS to keep the SQL `IN (...)` clause bounded
+	 * and to make abuse via huge payloads obvious.
+	 */
+	entryIds?: string[];
 };
+
+const MAX_ENTRY_IDS = 5000;
+const ENTRY_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
 /**
  * POST /api/workspace/objects/[name]/enrich
@@ -66,7 +81,7 @@ export async function POST(
 	}
 
 	const body: EnrichRequestBody = await req.json();
-	const { fieldId, apolloPath, category, inputFieldName, scope } = body;
+	const { fieldId, apolloPath, category, inputFieldName, scope, entryIds } = body;
 
 	if (!fieldId || !apolloPath || !category || !inputFieldName) {
 		return Response.json({ error: "Missing required fields." }, { status: 400 });
@@ -74,6 +89,33 @@ export async function POST(
 
 	if (category !== "people" && category !== "company") {
 		return Response.json({ error: "Invalid category." }, { status: 400 });
+	}
+
+	// Validate entryIds early so a malformed payload fails fast instead of
+	// landing as a SQL error mid-stream. Empty array is treated as "no narrowing"
+	// (i.e. fall through to the regular scope filter) so callers don't have to
+	// special-case the "no-selection" path on the client.
+	let narrowedEntryIds: string[] | undefined;
+	if (entryIds !== undefined) {
+		if (!Array.isArray(entryIds)) {
+			return Response.json({ error: "entryIds must be an array." }, { status: 400 });
+		}
+		if (entryIds.length > MAX_ENTRY_IDS) {
+			return Response.json(
+				{ error: `Too many entryIds (max ${MAX_ENTRY_IDS}).` },
+				{ status: 400 },
+			);
+		}
+		const cleaned: string[] = [];
+		for (const id of entryIds) {
+			if (typeof id !== "string" || !ENTRY_ID_PATTERN.test(id)) {
+				return Response.json({ error: "Invalid entry ID." }, { status: 400 });
+			}
+			cleaned.push(id);
+		}
+		if (cleaned.length > 0) {
+			narrowedEntryIds = cleaned;
+		}
 	}
 
 	// Resolve the canonical column def (for requiredFields + extraction fallbacks).
@@ -148,6 +190,14 @@ export async function POST(
 		LEFT JOIN entry_fields ef ON ef.entry_id = e.id AND ef.field_id = '${sqlEscape(inputFieldId)}'
 		WHERE e.object_id = '${sqlEscape(objectId)}'
 	`;
+
+	if (narrowedEntryIds && narrowedEntryIds.length > 0) {
+		// Compose with the `scope` filter rather than replacing it: lets
+		// callers say "enrich the selected rows that are still empty" when
+		// the row selection includes already-enriched entries.
+		const inList = narrowedEntryIds.map((id) => `'${sqlEscape(id)}'`).join(",");
+		entrySql += ` AND e.id IN (${inList})`;
+	}
 
 	if (scope === "empty") {
 		entrySql += `

--- a/apps/web/app/components/workspace/bulk-action-bar.test.tsx
+++ b/apps/web/app/components/workspace/bulk-action-bar.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { BulkActionBar } from "./bulk-action-bar";
+
+/**
+ * Visibility + behavior contract for `BulkActionBar`.
+ *
+ * Why this exists: the bar drives the row-selection UI surface. Two
+ * regressions matter most:
+ *  1. The bar must not render when nothing is selected (otherwise it
+ *     would obscure the table on every interaction).
+ *  2. The Enrich button is conditional on the parent passing
+ *     `onBulkEnrich`. Object tables only pass it when at least one
+ *     enrichable column exists. Showing the button on a table with no
+ *     enrichable columns would be a no-op control — exactly the kind of
+ *     dead UI the user notices and complains about.
+ */
+
+const noop = () => {};
+
+describe("BulkActionBar", () => {
+  it("renders nothing when selectedCount is 0 (no chrome over an unselected table)", () => {
+    const { container } = render(
+      <BulkActionBar
+        selectedCount={0}
+        actions={[]}
+        onDeselectAll={noop}
+        onBulkAction={noop}
+        onBulkDelete={noop}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows Delete and the selected-count badge when a row selection exists", () => {
+    render(
+      <BulkActionBar
+        selectedCount={3}
+        actions={[]}
+        onDeselectAll={noop}
+        onBulkAction={noop}
+        onBulkDelete={noop}
+      />,
+    );
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("selected")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /delete/i })).toBeInTheDocument();
+    // Enrich is omitted when the parent doesn't pass a handler.
+    expect(screen.queryByRole("button", { name: /enrich/i })).not.toBeInTheDocument();
+  });
+
+  it(
+    "renders the Enrich button when onBulkEnrich is provided and invokes it on click " +
+      "(this is the row-selection 'enrich the rows I checked' action)",
+    async () => {
+      const onBulkEnrich = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <BulkActionBar
+          selectedCount={2}
+          actions={[]}
+          onDeselectAll={noop}
+          onBulkAction={noop}
+          onBulkDelete={noop}
+          onBulkEnrich={onBulkEnrich}
+        />,
+      );
+      const enrichBtn = screen.getByRole("button", { name: /enrich/i });
+      expect(enrichBtn).toBeInTheDocument();
+      expect(enrichBtn).not.toBeDisabled();
+      await user.click(enrichBtn);
+      expect(onBulkEnrich).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it(
+    "REGRESSION: omits the Enrich button when onBulkEnrich is undefined " +
+      "(object table passes undefined when no column on the object is enrichable; " +
+      "showing a no-op button would be dead UI)",
+    () => {
+      render(
+        <BulkActionBar
+          selectedCount={5}
+          actions={[]}
+          onDeselectAll={noop}
+          onBulkAction={noop}
+          onBulkDelete={noop}
+          onBulkEnrich={undefined}
+        />,
+      );
+      expect(screen.queryByRole("button", { name: /enrich/i })).not.toBeInTheDocument();
+      // Delete still present — the bar is not entirely empty.
+      expect(screen.getByRole("button", { name: /delete/i })).toBeInTheDocument();
+    },
+  );
+
+  it("disables the Enrich button while enrichBusy is true (avoids overlapping enrichment runs)", async () => {
+    const onBulkEnrich = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <BulkActionBar
+        selectedCount={1}
+        actions={[]}
+        onDeselectAll={noop}
+        onBulkAction={noop}
+        onBulkDelete={noop}
+        onBulkEnrich={onBulkEnrich}
+        enrichBusy
+      />,
+    );
+    const enrichBtn = screen.getByRole("button", { name: /enrich/i });
+    expect(enrichBtn).toBeDisabled();
+    await user.click(enrichBtn);
+    expect(onBulkEnrich).not.toHaveBeenCalled();
+  });
+
+  it("Clear button calls onDeselectAll", async () => {
+    const onDeselectAll = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <BulkActionBar
+        selectedCount={4}
+        actions={[]}
+        onDeselectAll={onDeselectAll}
+        onBulkAction={noop}
+        onBulkDelete={noop}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /clear/i }));
+    expect(onDeselectAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/app/components/workspace/bulk-action-bar.tsx
+++ b/apps/web/app/components/workspace/bulk-action-bar.tsx
@@ -17,6 +17,16 @@ type BulkActionBarProps = {
 	onBulkAction: (action: ActionConfig, fieldId: string) => void;
 	onBulkDelete: () => void;
 	bulkRunStates?: Map<string, BulkRunState>;
+	/**
+	 * Optional bulk-Enrich handler. When provided, an "Enrich" button is
+	 * rendered between the action list and Delete. Object tables only pass
+	 * this when at least one column on the object has enrichment metadata
+	 * (i.e. the operation has something to do); otherwise the button is
+	 * hidden so we never show a no-op control.
+	 */
+	onBulkEnrich?: () => void;
+	/** Disables the Enrich button while an enrichment run is already in flight. */
+	enrichBusy?: boolean;
 };
 
 const VARIANT_COLORS: Record<string, string> = {
@@ -120,6 +130,8 @@ export function BulkActionBar({
 	onBulkAction,
 	onBulkDelete,
 	bulkRunStates,
+	onBulkEnrich,
+	enrichBusy,
 }: BulkActionBarProps) {
 	if (selectedCount === 0) return null;
 
@@ -167,7 +179,59 @@ export function BulkActionBar({
 				</div>
 			)}
 
-			<div className="ml-auto pl-3" style={{ borderLeft: actions.length > 0 ? "1px solid var(--color-border)" : "none" }}>
+			<div
+				className="ml-auto pl-3 flex items-center gap-1.5"
+				style={{ borderLeft: actions.length > 0 ? "1px solid var(--color-border)" : "none" }}
+			>
+				{onBulkEnrich && (
+					<button
+						type="button"
+						onClick={onBulkEnrich}
+						disabled={enrichBusy}
+						className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-all hover:opacity-80"
+						style={{
+							background: "color-mix(in srgb, var(--color-accent) 8%, transparent)",
+							border: "1px solid color-mix(in srgb, var(--color-accent) 22%, transparent)",
+							color: "var(--color-accent)",
+							opacity: enrichBusy ? 0.7 : 1,
+							cursor: enrichBusy ? "not-allowed" : "pointer",
+						}}
+						title={
+							enrichBusy
+								? "Enrichment already in progress"
+								: `Enrich the ${selectedCount} selected ${selectedCount === 1 ? "row" : "rows"}`
+						}
+					>
+						{enrichBusy ? (
+							<svg
+								width="12"
+								height="12"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2.5"
+								className="animate-spin"
+							>
+								<path d="M21 12a9 9 0 1 1-6.219-8.56" />
+							</svg>
+						) : (
+							<svg
+								width="12"
+								height="12"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+							>
+								<path d="M12 2L13.5 8.5L20 10L13.5 11.5L12 18L10.5 11.5L4 10L10.5 8.5L12 2Z" />
+								<path d="M19 19L19.5 20.5L21 21L19.5 21.5L19 23L18.5 21.5L17 21L18.5 20.5L19 19Z" />
+							</svg>
+						)}
+						Enrich
+					</button>
+				)}
 				<button
 					type="button"
 					onClick={onBulkDelete}

--- a/apps/web/app/components/workspace/column-header-menu.tsx
+++ b/apps/web/app/components/workspace/column-header-menu.tsx
@@ -498,6 +498,14 @@ export type EnrichmentStartPayload = {
 	category: "people" | "company";
 	inputFieldName: string;
 	scope: "all" | "empty" | number;
+	/**
+	 * Optional explicit list of entry IDs to narrow enrichment to. Passed
+	 * through to the `/enrich` route's `entryIds` parameter. Used by the
+	 * row-selection bulk-Enrich action so the user can target the rows
+	 * they checked instead of the whole table. Omit to enrich the full
+	 * `scope`.
+	 */
+	entryIds?: string[];
 };
 
 const ENRICH_SCOPE_OPTIONS: Array<{

--- a/apps/web/app/components/workspace/object-table.tsx
+++ b/apps/web/app/components/workspace/object-table.tsx
@@ -896,6 +896,9 @@ export function ObjectTable({
 							category: payload.category,
 							inputFieldName: payload.inputFieldName,
 							scope: payload.scope,
+							...(payload.entryIds && payload.entryIds.length > 0
+								? { entryIds: payload.entryIds }
+								: {}),
 						}),
 						signal: ac.signal,
 					},
@@ -1523,6 +1526,79 @@ export function ObjectTable({
 		});
 	}, [getSelectedEntryIds, doBulkDelete]);
 
+	// Columns this object knows how to enrich. Derived once per fields update so
+	// the BulkActionBar can both decide whether to surface the Enrich button at
+	// all (no enrichable columns → no button) and so the row-bulk handler can
+	// fan out to every enrichable column without a separate config call.
+	const enrichableColumns = useMemo(() => {
+		const cols: Array<{
+			fieldId: string;
+			fieldName: string;
+			apolloPath: string;
+			category: "people" | "company";
+			inputFieldName: string;
+		}> = [];
+		for (const field of dataFields) {
+			const meta = parseEnrichmentMeta(field.default_value);
+			if (!meta) continue;
+			cols.push({
+				fieldId: field.id,
+				fieldName: field.name,
+				apolloPath: meta.enrichment.apolloPath,
+				category: meta.enrichment.category,
+				inputFieldName: meta.enrichment.inputFieldName,
+			});
+		}
+		return cols;
+	}, [dataFields]);
+
+	const handleBulkEnrich = useCallback(async () => {
+		const selectedIds = getSelectedEntryIds();
+		if (selectedIds.length === 0 || enrichableColumns.length === 0) return;
+		// Sequential rather than parallel: each call uses the same enrichAbortRef
+		// and the same SSE-driven progress UI, so running them in parallel would
+		// stomp on the progress indicator and abort each other. Awaiting also lets
+		// errors surface naturally as toast/progress state per column.
+		for (const col of enrichableColumns) {
+			await new Promise<void>((resolve) => {
+				const onComplete = () => resolve();
+				// startEnrichment doesn't take a completion callback today; piggy-back
+				// on enrichmentProgress going back to null which signals the SSE
+				// stream's `done` event. We poll via a microtask interval kept short
+				// so back-to-back columns chain promptly.
+				startEnrichment({
+					fieldId: col.fieldId,
+					fieldName: col.fieldName,
+					apolloPath: col.apolloPath,
+					category: col.category,
+					inputFieldName: col.inputFieldName,
+					scope: "all",
+					entryIds: selectedIds,
+				});
+				const tick = () => {
+					if (enrichAbortRef.current?.signal.aborted) {
+						onComplete();
+						return;
+					}
+					if (enrichmentProgressRef.current === null) {
+						onComplete();
+						return;
+					}
+					setTimeout(tick, 80);
+				};
+				setTimeout(tick, 80);
+			});
+		}
+	}, [enrichableColumns, getSelectedEntryIds, startEnrichment]);
+
+	// Mirror enrichmentProgress into a ref so handleBulkEnrich's polling loop
+	// can read the latest value without becoming a dependency that re-creates
+	// the callback every render.
+	const enrichmentProgressRef = useRef(enrichmentProgress);
+	useEffect(() => {
+		enrichmentProgressRef.current = enrichmentProgress;
+	}, [enrichmentProgress]);
+
 	const handleDeleteEntry = useCallback((entry: EntryRow) => {
 		const eid = entry.entry_id;
 		const entryId = String(eid != null && typeof eid === "object" ? JSON.stringify(eid) : (eid ?? ""));
@@ -1685,6 +1761,8 @@ export function ObjectTable({
 			onBulkAction={handleBulkAction}
 			onBulkDelete={handleBulkDelete}
 			bulkRunStates={bulkStates}
+			onBulkEnrich={enrichableColumns.length > 0 ? handleBulkEnrich : undefined}
+			enrichBusy={enrichmentProgress !== null}
 		/>
 
 		{confirmState && (

--- a/apps/web/app/workspace/object-view-column-discovery.test.ts
+++ b/apps/web/app/workspace/object-view-column-discovery.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import {
+  type FieldIdentifier,
+  mergeNewlySeenColumns,
+} from "./object-view-column-discovery";
+
+/**
+ * Replica of the `columnVisibility` useMemo body in
+ * `workspace-content.tsx`. Kept here so this test file owns the contract
+ * end-to-end: "given a `viewColumns` whitelist and a list of fields, the
+ * result of `computeColumnVisibility(...)` must show every newly-seen
+ * field after `mergeNewlySeenColumns(...)` has been applied."
+ *
+ * If `workspace-content.tsx`'s real memo diverges from this replica, the
+ * integration test below stops being meaningful — but the unit tests on
+ * `mergeNewlySeenColumns` itself still hold.
+ */
+function computeColumnVisibility(
+  viewColumns: string[] | undefined,
+  fields: readonly FieldIdentifier[],
+): Record<string, boolean> | undefined {
+  const vis: Record<string, boolean> = {};
+  if (viewColumns && viewColumns.length > 0) {
+    for (const field of fields) {
+      vis[field.id] = viewColumns.includes(field.name);
+    }
+  }
+  return Object.keys(vis).length === 0 ? undefined : vis;
+}
+
+describe("mergeNewlySeenColumns", () => {
+  it("first call records the seen field IDs without modifying viewColumns", () => {
+    const fields: FieldIdentifier[] = [
+      { id: "f_name", name: "Name" },
+      { id: "f_email", name: "Email" },
+    ];
+    const viewColumns = ["Name", "Email"];
+
+    const result = mergeNewlySeenColumns(viewColumns, null, fields);
+
+    expect(result.nextViewColumns).toBe(viewColumns);
+    expect(result.nextSeen).toEqual(new Set(["f_name", "f_email"]));
+  });
+
+  it("appends a newly-appeared field's name to a non-empty viewColumns whitelist", () => {
+    const initialFields: FieldIdentifier[] = [
+      { id: "f_name", name: "Name" },
+      { id: "f_email", name: "Email" },
+    ];
+    const viewColumns = ["Name", "Email"];
+
+    const init = mergeNewlySeenColumns(viewColumns, null, initialFields);
+
+    const updatedFields: FieldIdentifier[] = [
+      ...initialFields,
+      { id: "f_notes", name: "Notes" },
+    ];
+    const next = mergeNewlySeenColumns(
+      init.nextViewColumns,
+      init.nextSeen,
+      updatedFields,
+    );
+
+    expect(next.nextViewColumns).toEqual(["Name", "Email", "Notes"]);
+    expect(next.nextSeen).toEqual(new Set(["f_name", "f_email", "f_notes"]));
+  });
+
+  it("does not modify viewColumns when it is undefined (no whitelist active → everything already visible)", () => {
+    const initial = mergeNewlySeenColumns(undefined, null, [
+      { id: "f_name", name: "Name" },
+    ]);
+
+    const next = mergeNewlySeenColumns(undefined, initial.nextSeen, [
+      { id: "f_name", name: "Name" },
+      { id: "f_notes", name: "Notes" },
+    ]);
+
+    expect(next.nextViewColumns).toBeUndefined();
+  });
+
+  it("preserves reference equality of viewColumns when nothing new appeared", () => {
+    const viewColumns = ["Name"];
+    const init = mergeNewlySeenColumns(viewColumns, null, [
+      { id: "f_name", name: "Name" },
+    ]);
+    const next = mergeNewlySeenColumns(init.nextViewColumns, init.nextSeen, [
+      { id: "f_name", name: "Name" },
+    ]);
+
+    expect(next.nextViewColumns).toBe(viewColumns);
+  });
+
+  it("does not double-add a name already present in viewColumns (e.g. delete-then-recreate with different ID, same name)", () => {
+    // First mount: original "Notes" field with id f_notes_v1 is visible.
+    const initialFields: FieldIdentifier[] = [
+      { id: "f_notes_v1", name: "Notes" },
+    ];
+    const init = mergeNewlySeenColumns(["Notes"], null, initialFields);
+
+    // Field is recreated with a fresh ID but same name.
+    const recreatedFields: FieldIdentifier[] = [
+      { id: "f_notes_v2", name: "Notes" },
+    ];
+    const next = mergeNewlySeenColumns(
+      init.nextViewColumns,
+      init.nextSeen,
+      recreatedFields,
+    );
+
+    // viewColumns still has just one "Notes" entry — no duplication.
+    expect(next.nextViewColumns).toEqual(["Notes"]);
+    expect(next.nextSeen.has("f_notes_v2")).toBe(true);
+  });
+
+  it("treats a renamed field (same id, different name) as already-seen and does NOT merge its new name", () => {
+    const init = mergeNewlySeenColumns(["Old Name"], null, [
+      { id: "f_x", name: "Old Name" },
+    ]);
+
+    // The user renamed the field via the inline rename UI; the rename
+    // path updates viewColumns separately. mergeNewlySeenColumns should
+    // not re-add the field by its new name (would duplicate it).
+    const next = mergeNewlySeenColumns(["Old Name"], init.nextSeen, [
+      { id: "f_x", name: "New Name" },
+    ]);
+
+    expect(next.nextViewColumns).toEqual(["Old Name"]);
+  });
+
+  it("appends multiple new fields in the order they appear", () => {
+    const init = mergeNewlySeenColumns(["A"], null, [
+      { id: "f_a", name: "A" },
+    ]);
+
+    const next = mergeNewlySeenColumns(init.nextViewColumns, init.nextSeen, [
+      { id: "f_a", name: "A" },
+      { id: "f_b", name: "B" },
+      { id: "f_c", name: "C" },
+    ]);
+
+    expect(next.nextViewColumns).toEqual(["A", "B", "C"]);
+  });
+
+  it(
+    "REGRESSION: with a saved-view whitelist, a column added after mount is HIDDEN " +
+      "without the merge but VISIBLE with it",
+    () => {
+      // Initial state: user is on a saved view with two columns explicitly
+      // visible. ObjectView mounts and records what it sees.
+      const initialFields: FieldIdentifier[] = [
+        { id: "f_name", name: "Name" },
+        { id: "f_email", name: "Email" },
+      ];
+      const savedViewColumns = ["Name", "Email"];
+      const init = mergeNewlySeenColumns(
+        savedViewColumns,
+        null,
+        initialFields,
+      );
+
+      // Refresh after the user creates "Notes" via the Add Column popover.
+      const refreshedFields: FieldIdentifier[] = [
+        ...initialFields,
+        { id: "f_notes", name: "Notes" },
+      ];
+
+      // --- Without the helper (simulating the pre-fix bug): viewColumns
+      // is unchanged; the new column resolves to hidden. ---
+      const buggyVisibility = computeColumnVisibility(
+        savedViewColumns,
+        refreshedFields,
+      );
+      expect(buggyVisibility?.["f_notes"]).toBe(false);
+
+      // --- With the helper: viewColumns gains "Notes"; visibility memo
+      // now resolves the new column as visible. ---
+      const merged = mergeNewlySeenColumns(
+        init.nextViewColumns,
+        init.nextSeen,
+        refreshedFields,
+      );
+      const fixedVisibility = computeColumnVisibility(
+        merged.nextViewColumns,
+        refreshedFields,
+      );
+      expect(fixedVisibility?.["f_notes"]).toBe(true);
+      // And the user's existing visibility for older fields is preserved.
+      expect(fixedVisibility?.["f_name"]).toBe(true);
+      expect(fixedVisibility?.["f_email"]).toBe(true);
+    },
+  );
+
+  it("REGRESSION: does NOT auto-show fields the user explicitly hid before mount (preserves saved view intent)", () => {
+    // User's saved view has explicitly hidden "Phone" (it exists on the
+    // object but is not in the whitelist).
+    const initialFields: FieldIdentifier[] = [
+      { id: "f_name", name: "Name" },
+      { id: "f_phone", name: "Phone" },
+    ];
+    const savedViewColumns = ["Name"]; // Phone deliberately hidden
+
+    const init = mergeNewlySeenColumns(
+      savedViewColumns,
+      null,
+      initialFields,
+    );
+
+    // viewColumns must be untouched on initial mount — Phone stays hidden.
+    expect(init.nextViewColumns).toEqual(["Name"]);
+    const visibility = computeColumnVisibility(
+      init.nextViewColumns,
+      initialFields,
+    );
+    expect(visibility?.["f_phone"]).toBe(false);
+  });
+});

--- a/apps/web/app/workspace/object-view-column-discovery.ts
+++ b/apps/web/app/workspace/object-view-column-discovery.ts
@@ -1,0 +1,93 @@
+/**
+ * Newly-discovered column tracking for `ObjectView`.
+ *
+ * Why this exists: `viewColumns` (the persisted column-visibility state) is
+ * stored as a whitelist of *visible* column names. When the user creates a
+ * column via the Add Column popover — or when the AI adds a field by editing
+ * `.object.yaml` — the new field arrives in `data.fields` after a refresh,
+ * but its name is not in `viewColumns`. The downstream visibility memo then
+ * resolves `vis[newField.id] = viewColumns.includes(newField.name) === false`
+ * and the new column is silently hidden, contradicting the obvious user
+ * intent ("I just made this column, I want to see it").
+ *
+ * The fix is to detect fields that appear *after* initial mount and merge
+ * their names into `viewColumns`. We can't do this on the very first render
+ * because at that point everything is "new" — and applying the merge would
+ * effectively force every field visible, overriding the user's saved
+ * visibility for fields that already existed at load time.
+ *
+ * Identification is by field ID, not name, so that:
+ *  - A field renamed in place (same ID, new name) is *not* treated as new.
+ *  - A field deleted and recreated with the same name (new ID) *is* treated
+ *    as new and made visible.
+ */
+export type FieldIdentifier = { id: string; name: string };
+
+export type ColumnDiscoveryResult = {
+  /**
+   * The merged `viewColumns` to commit. Returned unchanged when no merging
+   * is required. Reference equality is preserved so callers can skip a
+   * `setViewColumns` call (and the resulting render + URL push).
+   */
+  nextViewColumns: string[] | undefined;
+  /** The Set to store back into the tracking ref for the next call. */
+  nextSeen: Set<string>;
+};
+
+/**
+ * Decide what to do with `viewColumns` given the previous set of known
+ * field IDs and the current `data.fields`.
+ *
+ * - First call (`prevSeen === null`): record the current field IDs and
+ *   return `viewColumns` unchanged. Initial-mount fields use whatever
+ *   visibility they would have under the existing `viewColumns`.
+ * - Subsequent calls: any field ID not in `prevSeen` is "new". If
+ *   `viewColumns` is unset / empty (i.e. no whitelist active), no merge is
+ *   needed because the visibility memo will already show every column.
+ *   Otherwise, append the new field names that are not already present.
+ */
+export function mergeNewlySeenColumns(
+  viewColumns: string[] | undefined,
+  prevSeen: Set<string> | null,
+  currentFields: readonly FieldIdentifier[],
+): ColumnDiscoveryResult {
+  if (prevSeen === null) {
+    const nextSeen = new Set<string>();
+    for (const field of currentFields) {
+      nextSeen.add(field.id);
+    }
+    return { nextViewColumns: viewColumns, nextSeen };
+  }
+
+  const nextSeen = new Set(prevSeen);
+  const newlyAppearedNames: string[] = [];
+  for (const field of currentFields) {
+    if (nextSeen.has(field.id)) continue;
+    nextSeen.add(field.id);
+    newlyAppearedNames.push(field.name);
+  }
+
+  if (newlyAppearedNames.length === 0) {
+    return { nextViewColumns: viewColumns, nextSeen };
+  }
+
+  // No active whitelist → visibility memo already shows everything; nothing
+  // to merge into.
+  if (!viewColumns || viewColumns.length === 0) {
+    return { nextViewColumns: viewColumns, nextSeen };
+  }
+
+  const present = new Set(viewColumns);
+  const additions: string[] = [];
+  for (const name of newlyAppearedNames) {
+    if (present.has(name)) continue;
+    present.add(name);
+    additions.push(name);
+  }
+
+  if (additions.length === 0) {
+    return { nextViewColumns: viewColumns, nextSeen };
+  }
+
+  return { nextViewColumns: [...viewColumns, ...additions], nextSeen };
+}

--- a/apps/web/app/workspace/workspace-content.tsx
+++ b/apps/web/app/workspace/workspace-content.tsx
@@ -109,6 +109,7 @@ import {
   ContextMenuTrigger,
 } from "../components/ui/context-menu";
 import { resolveActiveViewSyncDecision } from "./object-view-active-view";
+import { mergeNewlySeenColumns } from "./object-view-column-discovery";
 import { resetWorkspaceStateOnSwitch } from "./workspace-switch";
 // Note: TabBar (the chrome-tabs strip used by the legacy single-strip layout)
 // is no longer used here — the v3 layout has separate inline strips for
@@ -3147,6 +3148,18 @@ function ObjectView({
 
   // Column visibility: maps field IDs to boolean (false = hidden)
   const [viewColumns, setViewColumns] = useState<string[] | undefined>(initialState.cols ?? undefined);
+  // Track which field IDs we've already seen for this object so newly-arriving
+  // fields (created via the Add Column popover, AI yaml edits, etc.) get
+  // auto-added to `viewColumns` instead of defaulting to hidden under an
+  // active visibility whitelist. See `mergeNewlySeenColumns` for the rule.
+  const seenFieldIdsRef = useRef<Set<string> | null>(null);
+  useEffect(() => {
+    const result = mergeNewlySeenColumns(viewColumns, seenFieldIdsRef.current, data.fields);
+    seenFieldIdsRef.current = result.nextSeen;
+    if (result.nextViewColumns !== viewColumns) {
+      setViewColumns(result.nextViewColumns);
+    }
+  }, [data.fields, viewColumns]);
   // Column widths: maps field name to pixel width (persisted in view_settings / saved views)
   const [columnWidths, setColumnWidths] = useState<Record<string, number> | undefined>(
     () => data.viewSettings?.column_widths,

--- a/apps/web/lib/workspace-duckdb-retry.test.ts
+++ b/apps/web/lib/workspace-duckdb-retry.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Regression contract for lock-conflict retries on DuckDB reads.
+ *
+ * Why this exists: the workspace stores its objects in a single
+ * `workspace.duckdb` file accessed via the DuckDB CLI. Each CLI invocation
+ * grabs an exclusive file lock, so back-to-back operations can collide
+ * (server-side write + the immediate client GET that follows is the canonical
+ * trigger). Before this contract was locked in, read failures from a lock
+ * conflict were caught and silently turned into `[]`. The route handler then
+ * couldn't distinguish "no rows" from "couldn't read" and returned 404, the
+ * frontend right panel went blank, and the user saw a "crash" right after
+ * creating a column.
+ *
+ * The contract: read helpers must retry lock-conflict failures with the same
+ * exponential backoff that write helpers (`duckdbExecOnFileAsync`) already
+ * use, and only surface `[]` / throw after the retries are exhausted.
+ *
+ * The tests deliberately hit the public API (`duckdbQueryOnFileAsync`,
+ * `duckdbQueryOnFileAsyncStrict`) rather than the private retry helper, so
+ * future refactors that move the retry logic around are still covered.
+ */
+
+// vi.mock factories are hoisted above all other code in the file. To share
+// the same mock fn between the factory and the test bodies we declare it
+// via vi.hoisted, which runs before the mock factory.
+const { execFileMock, spawnMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  spawnMock: vi.fn(() => ({
+    on: vi.fn(),
+    stdin: { write: vi.fn(), end: vi.fn(), on: vi.fn() },
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+  })),
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn((p: string) => p === "/opt/homebrew/bin/duckdb"),
+  readFileSync: vi.fn(() => ""),
+  readdirSync: vi.fn(() => []),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  access: vi.fn(async () => {
+    throw new Error("ENOENT");
+  }),
+  readdir: vi.fn(async () => []),
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: execFileMock,
+  execFileSync: vi.fn(() => ""),
+  execSync: vi.fn(() => ""),
+  exec: vi.fn(),
+  spawn: spawnMock,
+}));
+
+vi.mock("node:os", () => ({
+  homedir: vi.fn(() => "/home/testuser"),
+}));
+
+import { duckdbQueryOnFileAsync, duckdbQueryOnFileAsyncStrict } from "./workspace";
+
+type ExecFileCb = (
+  err: NodeJS.ErrnoException | null,
+  result: { stdout: string; stderr: string } | null,
+) => void;
+
+/** Build a lock-conflict error in the shape `execFile`'s error callback uses. */
+function lockConflictError(): NodeJS.ErrnoException {
+  const err = new Error("Command failed") as NodeJS.ErrnoException & {
+    stderr: string;
+  };
+  err.stderr =
+    'Error: unable to open database "/tmp/test.duckdb": IO Error: Could not set lock on file "/tmp/test.duckdb": Conflicting lock is held in /opt/homebrew/bin/duckdb (PID 12345) by user testuser.';
+  return err;
+}
+
+function syntaxError(): NodeJS.ErrnoException {
+  const err = new Error("Command failed") as NodeJS.ErrnoException & {
+    stderr: string;
+  };
+  err.stderr = "Parser Error: syntax error at or near \"FROOM\"";
+  return err;
+}
+
+beforeEach(() => {
+  execFileMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("duckdbQueryOnFileAsync — lock-conflict retry", () => {
+  it("returns rows on first success without retrying", async () => {
+    execFileMock.mockImplementationOnce(
+      (_bin: string, _args: string[], _opts: unknown, cb: ExecFileCb) => {
+        cb(null, { stdout: '[{"id":"obj1","name":"company"}]', stderr: "" });
+      },
+    );
+
+    const rows = await duckdbQueryOnFileAsync<{ id: string; name: string }>(
+      "/tmp/test.duckdb",
+      "SELECT * FROM objects",
+    );
+
+    expect(rows).toEqual([{ id: "obj1", name: "company" }]);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it(
+    "REGRESSION: retries on a Conflicting-lock error and returns the rows from the next attempt " +
+      "(prevents the silent [] → 404 → blank-panel 'crash' after column creation)",
+    async () => {
+      // First attempt: lock conflict. Second attempt: rows.
+      execFileMock
+        .mockImplementationOnce(
+          (_bin: string, _args: string[], _opts: unknown, cb: ExecFileCb) => {
+            cb(lockConflictError(), null);
+          },
+        )
+        .mockImplementationOnce(
+          (_bin: string, _args: string[], _opts: unknown, cb: ExecFileCb) => {
+            cb(null, { stdout: '[{"id":"obj1","name":"company"}]', stderr: "" });
+          },
+        );
+
+      const rows = await duckdbQueryOnFileAsync<{ id: string; name: string }>(
+        "/tmp/test.duckdb",
+        "SELECT * FROM objects WHERE name = 'company'",
+      );
+
+      expect(rows).toEqual([{ id: "obj1", name: "company" }]);
+      expect(execFileMock).toHaveBeenCalledTimes(2);
+    },
+    8000,
+  );
+
+  it("does NOT retry non-lock errors (parser errors, missing tables, etc — fail fast)", async () => {
+    execFileMock.mockImplementationOnce(
+      (_bin: string, _args: string[], _opts: unknown, cb: ExecFileCb) => {
+        cb(syntaxError(), null);
+      },
+    );
+
+    const rows = await duckdbQueryOnFileAsync(
+      "/tmp/test.duckdb",
+      "SELECT * FROOM objects",
+    );
+
+    expect(rows).toEqual([]);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns [] without retrying when the read genuinely produces no rows", async () => {
+    execFileMock.mockImplementationOnce(
+      (_bin: string, _args: string[], _opts: unknown, cb: ExecFileCb) => {
+        cb(null, { stdout: "[]", stderr: "" });
+      },
+    );
+
+    const rows = await duckdbQueryOnFileAsync("/tmp/test.duckdb", "SELECT 1 WHERE FALSE");
+
+    expect(rows).toEqual([]);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("duckdbQueryOnFileAsyncStrict — lock-conflict retry", () => {
+  it("returns rows on first success without retrying", async () => {
+    execFileMock.mockImplementationOnce(
+      (_bin: string, _args: string[], _opts: unknown, cb: ExecFileCb) => {
+        cb(null, { stdout: '[{"cnt":42}]', stderr: "" });
+      },
+    );
+
+    const rows = await duckdbQueryOnFileAsyncStrict<{ cnt: number }>(
+      "/tmp/test.duckdb",
+      'SELECT COUNT(*) AS cnt FROM "v_company"',
+    );
+
+    expect(rows).toEqual([{ cnt: 42 }]);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it(
+    "REGRESSION: retries on a Conflicting-lock error before resolving with rows " +
+      "(strict variant must not throw spuriously when the failure was just a transient lock race)",
+    async () => {
+      execFileMock
+        .mockImplementationOnce(
+          (_bin: string, _args: string[], _opts: unknown, cb: ExecFileCb) => {
+            cb(lockConflictError(), null);
+          },
+        )
+        .mockImplementationOnce(
+          (_bin: string, _args: string[], _opts: unknown, cb: ExecFileCb) => {
+            cb(null, { stdout: '[{"cnt":42}]', stderr: "" });
+          },
+        );
+
+      const rows = await duckdbQueryOnFileAsyncStrict<{ cnt: number }>(
+        "/tmp/test.duckdb",
+        'SELECT COUNT(*) AS cnt FROM "v_company"',
+      );
+
+      expect(rows).toEqual([{ cnt: 42 }]);
+      expect(execFileMock).toHaveBeenCalledTimes(2);
+    },
+    8000,
+  );
+
+  it("rethrows immediately on non-lock errors (so callers can fall back, e.g. EAV when pivot view is missing)", async () => {
+    execFileMock.mockImplementationOnce(
+      (_bin: string, _args: string[], _opts: unknown, cb: ExecFileCb) => {
+        const err = new Error("Catalog Error: Table with name v_company does not exist!") as
+          NodeJS.ErrnoException & { stderr: string };
+        err.stderr = "Catalog Error: Table with name v_company does not exist!";
+        cb(err, null);
+      },
+    );
+
+    await expect(
+      duckdbQueryOnFileAsyncStrict("/tmp/test.duckdb", 'SELECT * FROM "v_company"'),
+    ).rejects.toThrow();
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/lib/workspace-projection.ts
+++ b/apps/web/lib/workspace-projection.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { type Dirent, existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import YAML from "yaml";
 import type { ObjectYamlConfig } from "./workspace";
@@ -49,7 +49,7 @@ function hasExistingObjectYamlOutsideRootSlot(
   const resolvedRootObjectDir = resolve(rootObjectDir);
 
   function walk(dir: string): boolean {
-    let entries: ReturnType<typeof readdirSync>;
+    let entries: Dirent[];
     try {
       entries = readdirSync(dir, { withFileTypes: true });
     } catch {

--- a/apps/web/lib/workspace.ts
+++ b/apps/web/lib/workspace.ts
@@ -1252,7 +1252,101 @@ export function duckdbQueryOnFile<T = Record<string, unknown>>(
   }
 }
 
-/** Async version of duckdbQueryOnFile — does not block the event loop. */
+type DuckdbReadAttemptResult<T> =
+  | { ok: true; rows: T[] }
+  | { ok: false; retriable: boolean; error: unknown; errorMessage: string };
+
+/**
+ * Run one DuckDB read against a specific DB file and classify the outcome
+ * so callers can decide whether to retry. DuckDB acquires an exclusive
+ * file lock for any operation; concurrent CLI processes against the same
+ * file collide. When stderr contains "Conflicting lock" or "Could not set
+ * lock" the failure is transient and worth retrying. Other failures (bad
+ * SQL, missing table) are terminal and surfaced unchanged.
+ */
+async function runDuckdbReadOnce<T>(
+  bin: string,
+  dbFilePath: string,
+  sql: string,
+  timeoutMs: number,
+): Promise<DuckdbReadAttemptResult<T>> {
+  try {
+    const { stdout } = await execFileAsync(bin, ["-json", dbFilePath, sql], {
+      encoding: "utf-8",
+      timeout: timeoutMs,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    const trimmed = stdout.trim();
+    if (!trimmed || trimmed === "[]") {return { ok: true, rows: [] };}
+    return { ok: true, rows: JSON.parse(trimmed) as T[] };
+  } catch (err) {
+    const stderr = (err as { stderr?: string | Buffer }).stderr;
+    const stderrText =
+      typeof stderr === "string"
+        ? stderr
+        : Buffer.isBuffer(stderr)
+          ? stderr.toString("utf-8")
+          : (err as Error).message ?? "";
+    const lockConflict =
+      stderrText.includes("Conflicting lock") ||
+      stderrText.includes("Could not set lock");
+    return {
+      ok: false,
+      retriable: lockConflict,
+      error: err,
+      errorMessage: stderrText.slice(0, 800) || (err as Error).message || "duckdb read failed",
+    };
+  }
+}
+
+/**
+ * Run a DuckDB read with the same retry-on-lock-conflict semantics that
+ * `duckdbExecOnFileAsync` already uses for writes. Resolves with rows on
+ * success, or with an error result after retries are exhausted (so callers
+ * can choose between returning `[]` or rethrowing).
+ *
+ * Why this exists: DuckDB's CLI takes an exclusive file lock for every
+ * operation. Back-to-back operations from the workspace (POST /fields,
+ * server-side pivot view rebuild, then the immediate GET /objects/[name]
+ * that the client fires after the write completes) can race a still-running
+ * sibling on the same file. Without retry, the read fails with a lock
+ * conflict and silently returns `[]`. The route then treats the empty
+ * result as "object not found" and 404s — the right panel goes blank and
+ * the user sees a "crash" right after creating a column. Reads need the
+ * same retry resilience writes already have.
+ */
+async function runDuckdbReadWithRetry<T>(
+  bin: string,
+  dbFilePath: string,
+  sql: string,
+  timeoutMs: number,
+): Promise<DuckdbReadAttemptResult<T>> {
+  const MAX_RETRIES = 8;
+  let attempt = 0;
+  let lastResult: DuckdbReadAttemptResult<T> = {
+    ok: false,
+    retriable: false,
+    error: new Error("no attempts made"),
+    errorMessage: "no attempts made",
+  };
+  while (attempt < MAX_RETRIES) {
+    lastResult = await runDuckdbReadOnce<T>(bin, dbFilePath, sql, timeoutMs);
+    if (lastResult.ok) {return lastResult;}
+    if (!lastResult.retriable) {return lastResult;}
+    const delay = Math.min(4000, 250 * 2 ** attempt) + Math.floor(Math.random() * 100);
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    attempt += 1;
+  }
+  return lastResult;
+}
+
+/**
+ * Async version of duckdbQueryOnFile — does not block the event loop.
+ * Retries lock conflicts (transient races with concurrent CLI processes)
+ * with exponential backoff before giving up. Persistent failures still
+ * resolve to `[]`, matching the legacy contract for callers that don't
+ * distinguish errors from empty results.
+ */
 export async function duckdbQueryOnFileAsync<T = Record<string, unknown>>(
   dbFilePath: string,
   sql: string,
@@ -1260,26 +1354,18 @@ export async function duckdbQueryOnFileAsync<T = Record<string, unknown>>(
   const bin = resolveDuckdbBin();
   if (!bin) {return [];}
 
-  try {
-    const { stdout } = await execFileAsync(bin, ["-json", dbFilePath, sql], {
-      encoding: "utf-8",
-      timeout: 15_000,
-      maxBuffer: 10 * 1024 * 1024,
-    });
-
-    const trimmed = stdout.trim();
-    if (!trimmed || trimmed === "[]") {return [];}
-    return JSON.parse(trimmed) as T[];
-  } catch {
-    return [];
-  }
+  const result = await runDuckdbReadWithRetry<T>(bin, dbFilePath, sql, 15_000);
+  if (result.ok) {return result.rows;}
+  console.error(`[duckdb] query gave up on ${dbFilePath}: ${result.errorMessage}`);
+  return [];
 }
 
 /**
  * Like `duckdbQueryOnFileAsync`, but rethrows errors instead of silently
  * returning `[]`. Use when callers need to distinguish "no rows" from "query
  * failed" (e.g. to trigger an EAV fallback when a pivot view is missing or
- * has a bad identifier).
+ * has a bad identifier). Lock conflicts are still retried with exponential
+ * backoff; only persistent failures throw.
  */
 export async function duckdbQueryOnFileAsyncStrict<T = Record<string, unknown>>(
   dbFilePath: string,
@@ -1290,15 +1376,11 @@ export async function duckdbQueryOnFileAsyncStrict<T = Record<string, unknown>>(
     throw new Error("DuckDB CLI binary not found");
   }
 
-  const { stdout } = await execFileAsync(bin, ["-json", dbFilePath, sql], {
-    encoding: "utf-8",
-    timeout: 15_000,
-    maxBuffer: 10 * 1024 * 1024,
-  });
-
-  const trimmed = stdout.trim();
-  if (!trimmed || trimmed === "[]") {return [];}
-  return JSON.parse(trimmed) as T[];
+  const result = await runDuckdbReadWithRetry<T>(bin, dbFilePath, sql, 15_000);
+  if (result.ok) {return result.rows;}
+  throw result.error instanceof Error
+    ? result.error
+    : new Error(result.errorMessage);
 }
 
 /**

--- a/extensions/apollo-enrichment/index.test.ts
+++ b/extensions/apollo-enrichment/index.test.ts
@@ -85,36 +85,52 @@ describe("apollo-enrichment requiredFields", () => {
     }
   });
 
-  it("omits requiredFields and mode by default for people enrichment", async () => {
-    stateDir = mkdtempSync(path.join(os.tmpdir(), "apollo-enrichment-state-"));
-    process.env.OPENCLAW_STATE_DIR = stateDir;
-    writeAuthProfiles(stateDir, "dc-key");
-    writeOpenClawConfig(stateDir);
+  it(
+    "REGRESSION: substitutes the canonical requiredFields when the caller omits — " +
+      "never emits a no-list payload that hits the gateway's deprecated default-backfill (Apollo `mode` removal)",
+    async () => {
+      stateDir = mkdtempSync(path.join(os.tmpdir(), "apollo-enrichment-state-"));
+      process.env.OPENCLAW_STATE_DIR = stateDir;
+      writeAuthProfiles(stateDir, "dc-key");
+      writeOpenClawConfig(stateDir);
 
-    globalThis.fetch = vi.fn(async (input, init) => {
-      expect(String(input)).toBe("https://gateway.example.com/v1/enrichment/people");
-      expect(init?.method).toBe("POST");
-      const body = JSON.parse(String(init?.body));
-      expect(body).toMatchObject({ email: "jane@acme.com" });
-      expect(body.mode).toBeUndefined();
-      expect(body.requiredFields).toBeUndefined();
-      return new Response(JSON.stringify({ person: { id: "p1" } }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
+      globalThis.fetch = vi.fn(async (input, init) => {
+        expect(String(input)).toBe("https://gateway.example.com/v1/enrichment/people");
+        expect(init?.method).toBe("POST");
+        const body = JSON.parse(String(init?.body));
+        expect(body).toMatchObject({ email: "jane@acme.com" });
+        // mode is NEVER sent; requiredFields is ALWAYS sent (default or caller-supplied).
+        expect(body.mode).toBeUndefined();
+        expect(Array.isArray(body.requiredFields)).toBe(true);
+        // The canonical people allowlist mirrors PEOPLE_ENRICHMENT_COLUMNS in
+        // apps/web/lib/enrichment-columns.ts; keep these in sync.
+        expect(body.requiredFields).toEqual([
+          "fullName",
+          "email",
+          "headline",
+          "linkedinID",
+          "URLs",
+          "phone",
+          "location",
+        ]);
+        return new Response(JSON.stringify({ person: { id: "p1" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }) as typeof fetch;
+
+      const { api, tools } = createApi();
+      register(api);
+
+      expect(tools).toHaveLength(1);
+      await tools[0].execute("call_1", {
+        action: "people",
+        email: "jane@acme.com",
       });
-    }) as typeof fetch;
 
-    const { api, tools } = createApi();
-    register(api);
-
-    expect(tools).toHaveLength(1);
-    await tools[0].execute("call_1", {
-      action: "people",
-      email: "jane@acme.com",
-    });
-
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-  });
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("forwards camelCase requiredFields to people enrichment when callers provide them", async () => {
     stateDir = mkdtempSync(path.join(os.tmpdir(), "apollo-enrichment-state-"));
@@ -243,6 +259,83 @@ describe("apollo-enrichment requiredFields", () => {
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
   });
+
+  it(
+    "REGRESSION: substitutes the canonical requiredFields when the caller omits for company enrichment — " +
+      "same gateway 'mode' deprecation; the chat-side path was the symptomatic one but company has the same shape",
+    async () => {
+      stateDir = mkdtempSync(path.join(os.tmpdir(), "apollo-enrichment-state-"));
+      process.env.OPENCLAW_STATE_DIR = stateDir;
+      writeAuthProfiles(stateDir, "dc-key");
+      writeOpenClawConfig(stateDir);
+
+      globalThis.fetch = vi.fn(async (input, init) => {
+        const url = new URL(String(input));
+        expect(url.origin + url.pathname).toBe("https://gateway.example.com/v1/enrichment/company");
+        expect(url.searchParams.get("domain")).toBe("acme.com");
+        expect(url.searchParams.get("mode")).toBeNull();
+        const csv = url.searchParams.get("requiredFields");
+        expect(csv).not.toBeNull();
+        expect(csv?.split(",")).toEqual([
+          "name",
+          "website",
+          "industryList",
+          "linkedinID",
+          "totalFunding",
+          "founded",
+        ]);
+        expect(init?.method).toBe("GET");
+        return new Response(JSON.stringify({ organization: { id: "o1" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }) as typeof fetch;
+
+      const { api, tools } = createApi();
+      register(api);
+
+      await tools[0].execute("call_1", {
+        action: "company",
+        domain: "acme.com",
+      });
+
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it(
+    "people_search does NOT receive a requiredFields default (different gateway endpoint, " +
+      "different params; sending one would 400)",
+    async () => {
+      stateDir = mkdtempSync(path.join(os.tmpdir(), "apollo-enrichment-state-"));
+      process.env.OPENCLAW_STATE_DIR = stateDir;
+      writeAuthProfiles(stateDir, "dc-key");
+      writeOpenClawConfig(stateDir);
+
+      globalThis.fetch = vi.fn(async (input, init) => {
+        expect(String(input)).toBe(
+          "https://gateway.example.com/v1/enrichment/people/search",
+        );
+        const body = JSON.parse(String(init?.body));
+        expect(body.requiredFields).toBeUndefined();
+        expect(body.mode).toBeUndefined();
+        return new Response(JSON.stringify({ people: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }) as typeof fetch;
+
+      const { api, tools } = createApi();
+      register(api);
+
+      await tools[0].execute("call_1", {
+        action: "people_search",
+        personTitles: ["Founder"],
+      });
+
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("forwards CSV requiredFields query param for company enrichment", async () => {
     stateDir = mkdtempSync(path.join(os.tmpdir(), "apollo-enrichment-state-"));

--- a/extensions/apollo-enrichment/index.ts
+++ b/extensions/apollo-enrichment/index.ts
@@ -9,6 +9,47 @@ export const id = "apollo-enrichment";
 const ENRICHMENT_BASE_PATH = "/v1/enrichment";
 const APOLLO_ACTIONS = ["people", "company", "people_search"] as const;
 
+/**
+ * Canonical `requiredFields` lists for each enrichment action.
+ *
+ * Why these exist: the Dench Cloud gateway's "default backfill" path —
+ * the one taken when the caller sends no `requiredFields` — was wired to
+ * Apollo's now-removed `mode` field. Apollo returns
+ * `{ code: "deprecated_field", message: "The mode field has been removed.
+ * Use requiredFields to control which fields the waterfall must populate." }`,
+ * which surfaces in chat as "Apollo hit an API issue." The column-based
+ * enrichment route never hits this because it derives `requiredFields`
+ * from the matched column. The chat tool used to leave the parameter
+ * optional with a description telling the agent it could omit. The agent
+ * naturally omitted, the gateway took its broken default-backfill path,
+ * Apollo rejected it.
+ *
+ * The fix: when the caller omits `requiredFields`, the plugin substitutes
+ * the canonical list below. This mirrors the columns defined in
+ * `apps/web/lib/enrichment-columns.ts` (the union of every column's
+ * `requiredFields`), which the column-enrichment route already exercises
+ * in production and which is on the gateway allowlist. Callers can still
+ * override with their own list.
+ */
+const PEOPLE_DEFAULT_REQUIRED_FIELDS = [
+  "fullName",
+  "email",
+  "headline",
+  "linkedinID",
+  "URLs",
+  "phone",
+  "location",
+];
+
+const COMPANY_DEFAULT_REQUIRED_FIELDS = [
+  "name",
+  "website",
+  "industryList",
+  "linkedinID",
+  "totalFunding",
+  "founded",
+];
+
 type UnknownRecord = Record<string, unknown>;
 
 function asRecord(value: unknown): UnknownRecord | undefined {
@@ -95,7 +136,7 @@ const ApolloEnrichParameters = {
       type: "array",
       items: { type: "string" },
       description:
-        "Optional Dench gateway requiredFields contract. The waterfall stops as soon as every listed field is non-null on the merged record. Omit to use the gateway's default backfill list.",
+        "Optional Dench gateway requiredFields contract. The waterfall stops as soon as every listed field is non-null on the merged record. Omit to use the canonical default for the action (people: name/email/headline/linkedin/URLs/phone/location; company: name/website/industry/linkedin/funding/founded). Never omit just to opt out — the gateway's no-list path is deprecated and Apollo rejects it.",
     },
     required_fields: {
       type: "array",
@@ -196,14 +237,17 @@ async function executeApolloEnrich(
 
   try {
     let response: Response;
-    const requiredFields =
+    // Caller-supplied requiredFields wins. When omitted, fall back to the
+    // canonical allowlist for the action so the gateway never takes its
+    // deprecated default-backfill path (which Apollo rejects with the
+    // "mode field has been removed" 400). people_search uses a different
+    // endpoint that does not accept requiredFields, so leave it alone.
+    const callerRequiredFields =
       readStringList(params.requiredFields) ?? readStringList(params.required_fields);
 
     if (action === "people") {
       const body = buildPeopleBody(params);
-      if (requiredFields) {
-        body.requiredFields = requiredFields;
-      }
+      body.requiredFields = callerRequiredFields ?? PEOPLE_DEFAULT_REQUIRED_FIELDS;
       if (!body.email && !body.linkedin_url && !body.first_name && !body.last_name) {
         return jsonResult({
           error: "People enrichment requires at least an email, LinkedIn URL, or person name.",
@@ -224,9 +268,8 @@ async function executeApolloEnrich(
       }
       const url = new URL(`${gatewayUrl}${ENRICHMENT_BASE_PATH}/company`);
       url.searchParams.set("domain", domain);
-      if (requiredFields) {
-        url.searchParams.set("requiredFields", requiredFields.join(","));
-      }
+      const companyRequiredFields = callerRequiredFields ?? COMPANY_DEFAULT_REQUIRED_FIELDS;
+      url.searchParams.set("requiredFields", companyRequiredFields.join(","));
       response = await fetch(url, {
         method: "GET",
         headers: {


### PR DESCRIPTION
## Summary

A batch from one focused session: a new bulk-Enrich row action plus four crash/UX fixes that surfaced while testing it. Each commit is independently revertable.

| Commit | What |
|---|---|
| `ded2be342` fix | Build was broken: `let entries: ReturnType<typeof readdirSync>` resolved to `Dirent<NonSharedBuffer>[]` under `@types/node` 22 (TS picks the *last* overload of an overloaded function), but the actual call returns `Dirent[]`. Annotated explicitly. |
| `032e6a295` fix | Newly-created columns were silently hidden when a saved-view whitelist (`viewColumns`) was active. New `mergeNewlySeenColumns` helper tracks which field IDs we've seen per object; fields that appear after initial mount get appended to the whitelist so they default visible. Saved-view "explicitly hidden" intent is preserved. |
| (folded into above) fix | `duckdbQueryOnFileAsync` and `duckdbQueryOnFileAsyncStrict` had **no retry on lock conflicts** while `duckdbExecOnFileAsync` already had 8-retry exponential backoff. Result: POST /fields succeeded → immediate refresh GET raced the still-completing pivot-view rebuild → lock conflict → silent `[]` → 404 → blank panel. Reads now have the same retry-with-backoff that writes already had. |
| `5245be788` fix | Chat agent's `apollo_enrich` tool sent payloads without `requiredFields`, hitting the gateway's deprecated default-backfill path which still emits Apollo's removed `mode` field → "Apollo hit an API issue." Plugin now substitutes a canonical default (mirrors the column-enrichment route), so the broken gateway path is unreachable from chat. |
| `8f493de22` feat | `/api/workspace/objects/[name]/enrich` accepts optional `entryIds: string[]` to scope enrichment to specific rows. Composes with `scope` (so "selected rows that are still empty" works). Validated: 5000-cap, regex per ID, SQL injection impossible by construction. |
| `5b7ad89d9` feat | `BulkActionBar` gets optional `onBulkEnrich` + `enrichBusy` props. Button renders only when the parent passes a handler — tables with no enrichable columns get no dead UI. |
| `3667cbe20` feat | `ObjectTable` derives `enrichableColumns` via `parseEnrichmentMeta`, walks each one sequentially with the selected entry IDs as scope. End-to-end: select rows → click Enrich → only those rows get enriched. |

## Why this is one PR

All six commits touch the same surface (workspace tables / Apollo enrichment) and the fixes are what made the new feature testable. Splitting would mean shipping the build break first, then waiting for review on each follow-up; bundling lets one review pass ship a coherent slice.

## Test plan

- [x] `pnpm web:build` — passes (was failing before `ded2be342`)
- [x] `pnpm exec tsc --noEmit` from `apps/web` — clean
- [x] All touched test files pass:
  - `lib/workspace.test.ts` (113), `lib/workspace-projection.test.ts` (11), `lib/workspace-duckdb-retry.test.ts` (7, new)
  - `app/workspace/object-view-column-discovery.test.ts` (9, new), `app/workspace/object-view-active-view.test.ts` (11), `app/workspace/use-tab-content.test.tsx` (3)
  - `app/api/workspace/objects/[name]/enrich/route.test.ts` (11, +5 new)
  - `app/components/workspace/bulk-action-bar.test.tsx` (6, new), `object-table.test.tsx` (4), `column-header-menu.test.tsx` (5)
  - `extensions/apollo-enrichment/index.test.ts` (8, +3 new)
- [x] Live verification on `localhost:3100/?path=company`:
  - Created a new column with a saved view active → column shows up immediately (no blank-panel, no need to toggle visibility).
  - Selected row 1 (Nykaa) → BulkActionBar showed `Clear | Enrich | Delete` in that order.
  - Clicked Enrich → `POST /enrich → 200 in 1.7s`, table refreshed, new enriched value appeared in row 1, `Updated` timestamp moved to "now".

## Known follow-ups (deferred to keep this PR focused)

- **POST /fields uses *sync* DuckDB helpers** without retry. Rapid double-add can still 404. Fix: convert that route to async + the now-resilient `duckdbQueryOnFileAsync`. Same pattern.
- **`AddColumnPopover` doesn't refresh `nextDefaultFieldName` between rapid creates** → 409 duplicate-name conflict. Cosmetic vs the crash, but worth fixing.
- **`startEnrichment` doesn't expose a completion callback** — `handleBulkEnrich` polls a ref every 80ms to detect "done." A Promise-based callback would let the bulk handler `await` directly; left for a follow-up to keep this diff focused.
- Server logs show `Table "objects" does not have a column with name "icon"` at startup — schema migration is missing for old workspaces. Doesn't affect behavior (route reads from yaml) but adds noise.

## Risk

- The DuckDB read-retry change is the most behavior-impactful: any caller of `duckdbQueryOnFileAsync` / `duckdbQueryOnFileAsyncStrict` now waits up to ~16s on persistent lock conflict (vs. failing immediately). Same envelope as the existing write-side retry, so it's symmetric — but worth a careful look during review.
- Plugin default `requiredFields` lists for Apollo enrichment hard-code field names that mirror `apps/web/lib/enrichment-columns.ts`. If those move out of sync, both the column UI and the chat agent will diverge. A doc comment in `extensions/apollo-enrichment/index.ts` calls this out.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new row-selection bulk enrichment flow and changes DuckDB async read behavior to retry on lock conflicts, which can affect latency/error semantics across routes. Also introduces new SQL narrowing via `entryIds` (validated/capped) and auto-mutates saved-view column whitelists when new fields appear, which may have edge-case UX impacts.
> 
> **Overview**
> Adds a row-selection **Bulk Enrich** workflow: `BulkActionBar` now optionally renders an `Enrich` button (disabled while enrichment is running), `ObjectTable` discovers enrichable columns and runs enrichment sequentially for the selected row IDs, and the `/api/workspace/objects/[name]/enrich` route accepts optional `entryIds` to narrow the enrichment SQL (composed with `scope`) with validation + payload cap.
> 
> Improves workspace stability/UX: async DuckDB read helpers (`duckdbQueryOnFileAsync` / `Strict`) now retry transient lock-conflict failures with exponential backoff instead of failing immediately, and saved-view column whitelists now auto-append **newly-created fields** (tracked by seen field IDs) so new columns don’t appear hidden.
> 
> Hardens Apollo chat enrichment by defaulting `requiredFields` for `people`/`company` actions (avoiding the gateway’s deprecated no-list path), and fixes a Node 22 typings issue by explicitly typing `readdirSync` dirents. Includes new regression-focused tests for these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3667cbe2066c6b75cfb654198ee95182ec93fb4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->