### PR TITLE
Feat/enrichment fix

### DIFF
--- a/apps/web/app/components/integrations/dench-integrations-section.tsx
+++ b/apps/web/app/components/integrations/dench-integrations-section.tsx
@@ -174,6 +174,8 @@ type DenchIntegrationsSectionProps = {
   savingId?: DenchIntegrationId | null;
   repairing?: boolean;
   notice?: IntegrationActionNotice | null;
+  /** Hide these integrations from this list (e.g. apollo rendered next to waterfall UI elsewhere). */
+  excludeIntegrationIds?: readonly DenchIntegrationId[];
   onToggle?: (integration: DenchIntegrationState, enabled: boolean) => void;
   onRetry?: () => void;
   onRepair?: () => void;
@@ -219,6 +221,14 @@ export function DenchIntegrationsSection(props: DenchIntegrationsSectionProps = 
   const resolvedNotice = controlled ? props.notice ?? null : notice;
 
   const integrations = useMemo(() => resolvedData?.integrations ?? [], [resolvedData]);
+  const excludedIds = useMemo(
+    () => new Set(props.excludeIntegrationIds ?? []),
+    [props.excludeIntegrationIds],
+  );
+  const visibleIntegrations = useMemo(
+    () => integrations.filter((integration) => !excludedIds.has(integration.id)),
+    [integrations, excludedIds],
+  );
   const needsRepair = useMemo(
     () =>
       integrations.some(
@@ -387,7 +397,7 @@ export function DenchIntegrationsSection(props: DenchIntegrationsSectionProps = 
       )}
 
       <div className="space-y-1">
-        {integrations.map((integration) => (
+        {visibleIntegrations.map((integration) => (
           <IntegrationCard
             key={integration.id}
             integration={integration}

--- a/apps/web/app/components/settings/cloud-settings-panel.test.tsx
+++ b/apps/web/app/components/settings/cloud-settings-panel.test.tsx
@@ -10,23 +10,29 @@ vi.mock("../integrations/dench-integrations-section", () => ({
   DenchIntegrationsSection: ({
     data,
     onToggle,
+    excludeIntegrationIds,
   }: {
     data?: IntegrationsState | null;
     onToggle?: (integration: DenchIntegrationState, enabled: boolean) => void;
-  }) => (
-    <div>
-      <div>Mock Integrations</div>
-      {data?.integrations.map((integration) => (
-        <button
-          key={integration.id}
-          type="button"
-          onClick={() => onToggle?.(integration, !integration.enabled)}
-        >
-          {integration.label}:{integration.enabled ? "on" : "off"}:{integration.locked ? "locked" : "open"}
-        </button>
-      ))}
-    </div>
-  ),
+    excludeIntegrationIds?: readonly string[];
+  }) => {
+    const excluded = new Set(excludeIntegrationIds ?? []);
+    const visible = data?.integrations.filter((i) => !excluded.has(i.id)) ?? [];
+    return (
+      <div>
+        <div>Mock Integrations</div>
+        {visible.map((integration) => (
+          <button
+            key={integration.id}
+            type="button"
+            onClick={() => onToggle?.(integration, !integration.enabled)}
+          >
+            {integration.label}:{integration.enabled ? "on" : "off"}:{integration.locked ? "locked" : "open"}
+          </button>
+        ))}
+      </div>
+    );
+  },
 }));
 
 const baseState = {
@@ -309,7 +315,8 @@ describe("CloudSettingsPanel", () => {
     await waitFor(() => {
       expect(screen.getByText("Dench Enrichment")).toBeInTheDocument();
     });
-    expect(screen.getByText("Waterfall providers")).toBeInTheDocument();
+    expect(screen.getByText("Enrich people and company data with multiple providers.")).toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: "Toggle Dench Enrichments" })).toBeInTheDocument();
 
     expect(screen.getByTitle("Dench")).toBeInTheDocument();
     expect(screen.getByTitle("Aviato")).toBeInTheDocument();

--- a/apps/web/app/components/settings/cloud-settings-panel.tsx
+++ b/apps/web/app/components/settings/cloud-settings-panel.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronDown, Loader2 } from "lucide-react";
 import { ChatModelSelector, type ChatModelSelectorOption } from "../chat-model-selector";
 import { Button } from "../ui/button";
+import { Switch } from "../ui/switch";
 import { DenchIntegrationsSection } from "../integrations/dench-integrations-section";
 import { McpServersSection } from "./mcp-servers-section";
 import type { DenchIntegrationId, DenchIntegrationState, IntegrationsState } from "@/lib/integrations";
@@ -152,18 +153,54 @@ function NoticeBanner({ notice }: { notice: ActionNotice }) {
   );
 }
 
-function EnrichmentWaterfallCard() {
+function EnrichmentWaterfallCard({
+  enrichmentIntegration,
+  onToggleEnrichment,
+}: {
+  enrichmentIntegration: DenchIntegrationState | null;
+  onToggleEnrichment: (integration: DenchIntegrationState, enabled: boolean) => void;
+}) {
+  const enrichmentLabel = "Dench Enrichments";
+
   return (
     <div
       className="rounded-xl border px-4 py-4"
       style={{ borderColor: "var(--color-border)", background: "var(--color-surface)" }}
     >
-      <div className="space-y-1">
-        <div className="text-sm font-medium" style={{ color: "var(--color-text)" }}>
-          Dench Enrichment
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0 space-y-1">
+          <div className="text-sm font-medium" style={{ color: "var(--color-text)" }}>
+            Dench Enrichment
+          </div>
+          <div className="max-w-[42rem] text-xs leading-5" style={{ color: "var(--color-text-muted)" }}>
+            Waterfall providers
+          </div>
         </div>
-        <div className="max-w-[42rem] text-xs leading-5" style={{ color: "var(--color-text-muted)" }}>
-          Waterfall providers
+        <div className="flex shrink-0 items-center gap-2">
+          {enrichmentIntegration?.lockBadge ? (
+            <span
+              className="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium"
+              style={{
+                background: "var(--color-surface-hover)",
+                color: "var(--color-text)",
+              }}
+            >
+              {enrichmentIntegration.lockBadge}
+            </span>
+          ) : null}
+          <Switch
+            aria-label={`Toggle ${enrichmentLabel}`}
+            checked={enrichmentIntegration?.enabled ?? false}
+            disabled={
+              !enrichmentIntegration
+              || enrichmentIntegration.locked
+            }
+            onCheckedChange={(checked) => {
+              if (enrichmentIntegration) {
+                onToggleEnrichment(enrichmentIntegration, checked);
+              }
+            }}
+          />
         </div>
       </div>
       <div className="mt-4 flex flex-wrap items-center gap-3">
@@ -895,12 +932,18 @@ export function CloudSettingsPanel() {
           error={integrationsError}
           savingId={null}
           repairing={repairingIntegrations}
+          excludeIntegrationIds={["apollo"]}
           onToggle={handleDraftIntegrationToggle}
           onRetry={() => void fetchIntegrations()}
           onRepair={() => void handleRepairIntegrations()}
         />
       </div>
-      <EnrichmentWaterfallCard />
+      <EnrichmentWaterfallCard
+        enrichmentIntegration={
+          draftIntegrationsState?.integrations.find((i) => i.id === "apollo") ?? null
+        }
+        onToggleEnrichment={handleDraftIntegrationToggle}
+      />
       <McpServersSection />
       <div className="flex items-center justify-end gap-2 pt-2">
         <Button

--- a/apps/web/app/components/settings/cloud-settings-panel.tsx
+++ b/apps/web/app/components/settings/cloud-settings-panel.tsx
@@ -173,7 +173,7 @@ function EnrichmentWaterfallCard({
             Dench Enrichment
           </div>
           <div className="max-w-[42rem] text-xs leading-5" style={{ color: "var(--color-text-muted)" }}>
-            Waterfall providers
+            Enrich people and company data with multiple providers.
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-2">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how the `apollo` integration is displayed and toggled in the Cloud settings UI, which could affect users’ ability to enable/disable enrichment if the new filtering or switch wiring is incorrect.
> 
> **Overview**
> Updates the settings UI to treat *Dench Enrichments* (`apollo`) as a dedicated “enrichment waterfall” card with its own `Switch` (including lock badge/disabled behavior), instead of only being toggled from the generic integrations list.
> 
> Adds `excludeIntegrationIds` to `DenchIntegrationsSection` so callers can hide specific integrations from the list; `CloudSettingsPanel` uses this to exclude `apollo` and sources the waterfall card’s state from the same draft integrations state. Tests were updated to honor the new prop and assert the new card copy and switch presence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc67a72003baf7e0f3d3b6b2068b8f78c0738d86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->