### PR TITLE
Rebuild skill templates with hand-authored workflows

### DIFF
--- a/apps/web/app/components/templates/skill-template-gallery.tsx
+++ b/apps/web/app/components/templates/skill-template-gallery.tsx
@@ -72,10 +72,14 @@ function templateMatches(template: SkillTemplate, query: string): boolean {
     template.category,
     template.outcome,
     template.autonomy,
+    template.userUseCase,
     ...template.personas,
     ...template.triggerModes,
     ...template.requiredApps.map((app) => app.name),
-    ...template.interviewTopics,
+    ...template.interviewQuestions.map((question) => question.prompt),
+    ...template.interviewQuestions.flatMap((question) =>
+      question.options?.map((option) => `${option.label} ${option.description ?? ""}`) ?? [],
+    ),
   ]
     .join(" ")
     .toLowerCase()

--- a/apps/web/lib/skill-templates.test.ts
+++ b/apps/web/lib/skill-templates.test.ts
@@ -47,15 +47,18 @@ describe("skill templates", () => {
     expect(prompt).toContain("SKILL.md");
     expect(prompt).toContain("Do not create or edit any files until");
     expect(prompt).toContain("manual trigger and cron/scheduled agent messages");
-    expect(prompt).toContain("send rules");
+    expect(prompt).toContain("explicit send rules");
+    expect(prompt).toContain("Which buyer personas should DenchClaw");
+    expect(prompt).toContain("Who this skill is for");
     expect(prompt).toContain("idempotency checks");
     expect(prompt).toContain("Required external setup");
   });
 
-  it("marks every template with UI metadata", () => {
+  it("marks every template with hand-authored UI and prompt metadata", () => {
     const categories = new Set(SKILL_TEMPLATE_CATEGORIES);
     const personas = new Set(SKILL_TEMPLATE_PERSONAS);
     const ids = new Set<string>();
+    const instructionFingerprints = new Set<string>();
 
     for (const template of SKILL_TEMPLATES) {
       expect(ids.has(template.id)).toBe(false);
@@ -63,6 +66,8 @@ describe("skill templates", () => {
       expect(categories.has(template.category)).toBe(true);
       expect(template.outcome).toBeTruthy();
       expect(template.summary).toBeTruthy();
+      expect(template.userUseCase).toBeTruthy();
+      expect(template.userUseCase.length).toBeGreaterThan(80);
       expect(template.autonomy).toBeTruthy();
       expect(template.personas.length).toBeGreaterThan(0);
       for (const persona of template.personas) {
@@ -73,14 +78,39 @@ describe("skill templates", () => {
         expect(app.name).not.toBe("Apollo");
       }
       expect(template.triggerModes.length).toBeGreaterThan(0);
-      expect(template.interviewTopics.length).toBeGreaterThan(3);
-      expect(template.skillInstructions.length).toBeGreaterThan(3);
+      expect(template.interviewQuestions.length).toBeGreaterThanOrEqual(4);
+      expect(template.interviewQuestions.length).toBeLessThanOrEqual(5);
+      for (const question of template.interviewQuestions) {
+        expect(question.id).toMatch(/^[a-z0-9-]+$/);
+        expect(question.prompt.length).toBeGreaterThan(24);
+        expect(typeof question.required).toBe("boolean");
+        if (question.options) {
+          expect(question.options.length).toBeGreaterThan(1);
+          for (const option of question.options) {
+            expect(option.id).toMatch(/^[a-z0-9-]+$/);
+            expect(option.label).toBeTruthy();
+          }
+        }
+      }
+      expect(template.skillInstructions.length).toBeGreaterThanOrEqual(6);
+      const allTemplateText = [
+        template.userUseCase,
+        ...template.interviewQuestions.map((question) => question.prompt),
+        ...template.skillInstructions,
+      ].join("\n");
+      expect(allTemplateText).not.toContain("The exact ");
+      expect(allTemplateText).not.toContain("for this workflow");
+      expect(allTemplateText).not.toContain("A clear trigger description");
+      expect(allTemplateText).not.toContain("Step-by-step instructions to achieve this outcome");
+      const fingerprint = template.skillInstructions.join("|");
+      expect(instructionFingerprints.has(fingerprint)).toBe(false);
+      instructionFingerprints.add(fingerprint);
     }
 
     expect(ids.size).toBe(SKILL_TEMPLATES.length);
   });
 
-  it("keeps each template definition in its own tiny file", () => {
+  it("keeps each template definition in its own file", () => {
     for (const template of SKILL_TEMPLATES) {
       const templateFile = fileURLToPath(
         new URL(`./skill-templates/${template.id}.ts`, import.meta.url),

--- a/apps/web/lib/skill-templates.ts
+++ b/apps/web/lib/skill-templates.ts
@@ -53,7 +53,9 @@ export {
   type SkillTemplateAutonomy,
   type SkillTemplateCategory,
   type SkillTemplateId,
+  type SkillTemplateInterviewQuestion,
   type SkillTemplatePersona,
+  type SkillTemplateQuestionOption,
   type SkillTemplateTriggerMode,
 } from "./skill-templates/types";
 

--- a/apps/web/lib/skill-templates/account-health-monitor.ts
+++ b/apps/web/lib/skill-templates/account-health-monitor.ts
@@ -1,13 +1,89 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const accountHealthMonitor = createSkillTemplate({
+export const accountHealthMonitor = defineSkillTemplate({
   id: "account-health-monitor",
   title: "Account Health Monitor",
   summary: "Monitor accounts for risk, expansion signals, and missing next steps.",
   category: "Grow Customers",
   outcome: "Scores account health from CRM, email, meeting, and relationship signals, then alerts owners with recommended actions.",
+  userUseCase: "Use this when a founder or customer success owner wants a manual or scheduled monitor that turns scattered account activity into a reliable health view. The skill should synthesize CRM activity, enrichment, email, meetings, HubSpot, Slack, Notion, files, and web context into risk, expansion, relationship, and next-step signals.",
   personas: ["Customer Success", "Founder"],
   requiredApps: [externalApps.hubspot, externalApps.gmail, externalApps.slack],
   triggerModes: ["scheduled", "manual"],
-  focusAreas: ["account segments", "health signals", "risk thresholds", "owner alerts"],
+  autonomy: "Updates CRM",
+  interviewQuestions: [
+    {
+      id: "account-scope",
+      prompt: "Which accounts should the health monitor cover?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "all-customers", label: "All customers" },
+        { id: "strategic-accounts", label: "Strategic accounts" },
+        { id: "paid-customers", label: "Paid customers" },
+        { id: "implementation", label: "Implementation accounts" },
+        { id: "at-risk", label: "Known at-risk accounts" },
+      ],
+      freeformHint: "Include segment, lifecycle stage, ARR threshold, owner, or exclusion rules.",
+    },
+    {
+      id: "health-signals",
+      prompt: "Which signals should affect account health?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "engagement", label: "Engagement" },
+        { id: "support-issues", label: "Support/issues" },
+        { id: "executive-relationship", label: "Executive relationship" },
+        { id: "usage-adoption", label: "Usage/adoption" },
+        { id: "commercial-risk", label: "Commercial risk" },
+        { id: "expansion-signal", label: "Expansion signal" },
+      ],
+    },
+    {
+      id: "scoring-model",
+      prompt: "How should account health be reported?",
+      required: true,
+      options: [
+        { id: "red-yellow-green", label: "Red/yellow/green" },
+        { id: "numeric-score", label: "Numeric score" },
+        { id: "ranked-risk-list", label: "Ranked risk list" },
+        { id: "narrative-only", label: "Narrative only" },
+      ],
+    },
+    {
+      id: "alert-thresholds",
+      prompt: "When should the skill alert an account owner?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "health-drops", label: "Health drops" },
+        { id: "no-next-step", label: "No next step" },
+        { id: "exec-silent", label: "Executive silent" },
+        { id: "renewal-near", label: "Renewal near" },
+        { id: "expansion-opportunity", label: "Expansion opportunity" },
+      ],
+    },
+    {
+      id: "crm-write-policy",
+      prompt: "What CRM updates may the monitor make?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "health-note", label: "Add health note" },
+        { id: "health-field", label: "Update health field" },
+        { id: "owner-task", label: "Create owner task" },
+        { id: "no-write", label: "Read-only digest" },
+      ],
+    },
+  ],
+  skillInstructions: [
+    "Use CRM, enrichment, web search, and files as the default source set; optionally incorporate Gmail, Calendar, HubSpot, Notion, and Slack when connected for recent activity and relationship context.",
+    "Support manual review runs and cron/scheduled health checks only; do not design around real-time triggers or webhook events.",
+    "Make scheduled runs idempotent by recording the account, run window, health outcome, alert reason, and created task IDs so unresolved alerts are not duplicated.",
+    "Apply the agreed scoring model consistently and include evidence, source links, confidence, and missing-data caveats for every health change.",
+    "Respect the CRM write policy: additive notes and attributed score updates are preferred; never overwrite owner-entered fields or lifecycle stages without explicit permission.",
+    "Alert account owners only when thresholds are met, with a short diagnosis, why it matters, the recommended next action, and whether the alert is urgent or informational.",
+    "Produce audience-specific outputs: owner action lists, founder-level portfolio summaries, CRM notes, and optional Slack or email digests in a direct founder-ops tone.",
+  ],
 });

--- a/apps/web/lib/skill-templates/board-meeting-prep.ts
+++ b/apps/web/lib/skill-templates/board-meeting-prep.ts
@@ -1,13 +1,85 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const boardMeetingPrep = createSkillTemplate({
+export const boardMeetingPrep = defineSkillTemplate({
   id: "board-meeting-prep",
   title: "Board Meeting Prep",
   summary: "Assemble board prep packets, open questions, risks, and follow-up actions.",
   category: "Run Founder Ops",
   outcome: "Gathers metrics, narrative updates, decisions needed, risks, and prior commitments into a board-ready brief.",
+  userUseCase:
+    "Use this when a founder or operator needs a repeatable way to assemble board prep from files, Notion, CRM, metrics, inbox context, meeting history, and prior commitments. The skill should create board-ready materials while keeping private founder notes separate from board-safe output.",
   personas: ["Founder", "Operator"],
   requiredApps: [externalApps.googleCalendar, externalApps.gmail, externalApps.notion],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["meeting date", "required sections", "metrics source", "sensitive topics"],
+  autonomy: "Updates CRM",
+  interviewQuestions: [
+    {
+      id: "meeting-context",
+      prompt: "What board meeting should this prep target?",
+      required: true,
+      freeformHint: "Include meeting date, board members, observers, format, and prep deadline.",
+    },
+    {
+      id: "packet-sections",
+      prompt: "Which sections should the board packet include?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "metrics", label: "Metrics" },
+        { id: "wins", label: "Wins" },
+        { id: "risks", label: "Risks" },
+        { id: "decisions-needed", label: "Decisions needed" },
+        { id: "hiring", label: "Hiring" },
+        { id: "fundraising", label: "Fundraising" },
+        { id: "customer-pipeline", label: "Customer/pipeline" },
+      ],
+    },
+    {
+      id: "source-priority",
+      prompt: "Which sources should be treated as authoritative?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "files", label: "Files" },
+        { id: "notion", label: "Notion" },
+        { id: "crm", label: "Dench CRM" },
+        { id: "hubspot", label: "HubSpot" },
+        { id: "gmail-calendar", label: "Gmail/Calendar" },
+        { id: "slack", label: "Slack" },
+      ],
+    },
+    {
+      id: "audience-versions",
+      prompt: "Which audience-specific versions should be created?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "founder-private", label: "Founder private" },
+        { id: "board-packet", label: "Board packet" },
+        { id: "exec-team", label: "Exec team" },
+        { id: "follow-up-list", label: "Follow-up list" },
+      ],
+    },
+    {
+      id: "write-policy",
+      prompt: "What may be written back after prep?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "no-write", label: "No writes" },
+        { id: "customer-risk-notes", label: "Customer risk notes" },
+        { id: "owner-tasks", label: "Owner tasks" },
+        { id: "board-followups", label: "Board follow-ups" },
+      ],
+    },
+  ],
+  skillInstructions: [
+    "Use Dench files, CRM, enrichment, and web search as default context; use Gmail, Calendar, Notion, HubSpot, and Slack for prior commitments, meeting logistics, source docs, and sensitive context when connected.",
+    "Support manual packet prep and scheduled prep reminders only; do not rely on calendar webhooks or automatic document callbacks.",
+    "Tie scheduled outputs to the board meeting date and packet version, updating the same draft or checklist instead of creating duplicates.",
+    "Keep private founder prep, exec-team action lists, and board-safe packets separate so sensitive working notes do not leak into external materials.",
+    "Respect the write policy: add sourced notes or tasks only when allowed, avoid overwriting CRM fields, and keep board-sensitive commentary out of customer-visible records.",
+    "Alert owners for missing metrics, unresolved prior board commitments, unclear decision owners, or customer/revenue risks that need executive input before the meeting.",
+    "Use a board-ready tone: clear, candid, numbers-aware, and explicit about decisions, tradeoffs, risks, and asks.",
+  ],
 });

--- a/apps/web/lib/skill-templates/candidate-research-brief.ts
+++ b/apps/web/lib/skill-templates/candidate-research-brief.ts
@@ -1,13 +1,75 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const candidateResearchBrief = createSkillTemplate({
+export const candidateResearchBrief = defineSkillTemplate({
   id: "candidate-research-brief",
   title: "Candidate Research Brief",
   summary: "Research candidates before outreach, interviews, or hiring debriefs.",
   category: "Hire People",
   outcome: "Creates candidate briefs with background, evidence, fit hypotheses, risks, and interview questions.",
+  userUseCase:
+    "Use this when a recruiter or founder needs a fair, cited candidate brief for outreach, interview prep, or debriefs. The skill should evaluate role-relevant evidence from candidate records, resumes, portfolios, public professional sources, and connected apps while avoiding protected-class and privacy-sensitive analysis.",
   personas: ["Recruiter", "Founder"],
   requiredApps: [externalApps.linkedin, externalApps.github],
   triggerModes: ["manual"],
-  focusAreas: ["role requirements", "source links", "privacy rules", "brief format"],
+  autonomy: "Creates drafts",
+  interviewQuestions: [
+    {
+      id: "candidate",
+      prompt: "Which candidate should be researched?",
+      required: true,
+      freeformHint:
+        "Provide candidate name, CRM record, LinkedIn URL, resume, portfolio, GitHub profile, or uploaded files.",
+    },
+    {
+      id: "role",
+      prompt: "What role, level, and hiring criteria should the brief evaluate against?",
+      required: true,
+      freeformHint:
+        "Paste the job description, scorecard, must-haves, nice-to-haves, and interview stage.",
+    },
+    {
+      id: "allowed-sources",
+      prompt: "Which candidate sources may be used?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "crm", label: "Candidate record" },
+        { id: "files", label: "Resume/files" },
+        { id: "web", label: "Public web" },
+        { id: "linkedin", label: "LinkedIn" },
+        { id: "github", label: "GitHub/portfolio" },
+      ],
+    },
+    {
+      id: "brief-purpose",
+      prompt: "What should the brief be used for?",
+      required: true,
+      options: [
+        { id: "outreach", label: "Outreach" },
+        { id: "interview-prep", label: "Interview prep" },
+        { id: "debrief", label: "Debrief" },
+        { id: "sourcing-fit", label: "Sourcing fit" },
+      ],
+    },
+    {
+      id: "output-format",
+      prompt: "What output format should the candidate brief use?",
+      required: true,
+      options: [
+        { id: "manual-brief", label: "Manual brief" },
+        { id: "scorecard-prep", label: "Scorecard prep" },
+        { id: "email-draft", label: "Outreach draft" },
+        { id: "notion-note", label: "Notion note" },
+      ],
+      freeformHint: "Include destination, audience, and whether outreach hooks should be included.",
+    },
+  ],
+  skillInstructions: [
+    "Use only job-relevant, candidate-provided, public, or authorized internal information from Dench CRM, enrichment, files, and connected apps.",
+    "Do not infer, mention, score, or use protected-class or sensitive attributes such as age, race, religion, health, family status, gender identity, national origin, disability, veteran status, or photos.",
+    "Cite role-relevant claims with source references such as resume lines, portfolio pages, public work, CRM notes, or interview feedback.",
+    "Separate evidence from hypotheses and phrase fit as role-related observations or questions to validate.",
+    "Prefer primary candidate materials, work samples, public professional profiles, and authorized internal notes over low-quality web results.",
+    "Format the output as Candidate Snapshot, Role-Relevant Evidence, Fit Hypotheses, Risks/Unknowns, Suggested Interview Questions, Outreach Hooks if requested, and Sources.",
+  ],
 });

--- a/apps/web/lib/skill-templates/company-deep-researcher.ts
+++ b/apps/web/lib/skill-templates/company-deep-researcher.ts
@@ -1,13 +1,82 @@
-import { createSkillTemplate } from "./create-template";
+import { defineSkillTemplate } from "./create-template";
 
-export const companyDeepResearcher = createSkillTemplate({
+export const companyDeepResearcher = defineSkillTemplate({
   id: "company-deep-researcher",
   title: "Company Deep Researcher",
   summary: "Create a sourced company dossier for sales, hiring, investing, or strategy.",
   category: "Research Anything",
   outcome: "Builds a sourced company brief with business model, team, market, recent news, risks, and recommended actions.",
+  userUseCase: "Use this when a user needs a cited company brief that can support a sales account plan, investor diligence, recruiting context, partnership evaluation, or strategic research. The skill should combine Dench-native CRM, enrichment, web search, and files first, then use connected Gmail, Calendar, Notion, Slack, or LinkedIn context only when relevant and authorized.",
   personas: ["Founder", "Sales", "Investor/BD", "Knowledge Worker"],
   requiredApps: [],
   triggerModes: ["manual"],
-  focusAreas: ["research purpose", "sections needed", "source rules", "output format"],
+  autonomy: "Creates drafts",
+  interviewQuestions: [
+    {
+      id: "research-goal",
+      prompt: "What decision should this company brief support?",
+      required: true,
+      options: [
+        { id: "sales", label: "Sales plan" },
+        { id: "investment", label: "Investment diligence" },
+        { id: "hiring", label: "Hiring context" },
+        { id: "partnership", label: "Partnership evaluation" },
+        { id: "strategy", label: "Strategy research" },
+      ],
+      freeformHint: "Name the audience, decision, and depth needed.",
+    },
+    {
+      id: "target-company",
+      prompt: "Which company should be researched?",
+      required: true,
+      freeformHint: "Provide a company name, domain, CRM record, profile URL, or source file.",
+    },
+    {
+      id: "source-priority",
+      prompt: "Which sources should be prioritized?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "crm", label: "CRM notes" },
+        { id: "enrichment", label: "Enrichment" },
+        { id: "web", label: "Web research" },
+        { id: "files", label: "Files" },
+        { id: "connected-context", label: "Connected apps" },
+      ],
+    },
+    {
+      id: "brief-sections",
+      prompt: "Which sections should the brief include?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "overview", label: "Overview" },
+        { id: "team", label: "Team" },
+        { id: "market", label: "Market" },
+        { id: "news", label: "Recent news" },
+        { id: "risks", label: "Risks" },
+        { id: "actions", label: "Actions" },
+      ],
+    },
+    {
+      id: "output-format",
+      prompt: "Where should the final brief be saved or delivered?",
+      required: true,
+      options: [
+        { id: "dench-note", label: "Dench note" },
+        { id: "markdown", label: "Markdown" },
+        { id: "gmail-draft", label: "Gmail draft" },
+        { id: "notion-page", label: "Notion page" },
+      ],
+      freeformHint: "Include desired length, destination, and citation style.",
+    },
+  ],
+  skillInstructions: [
+    "Use Dench CRM records, native enrichment, web search, and user-provided files as the baseline source set; use connected apps only when they add relevant authorized context.",
+    "Cite every material factual claim, including company size, funding, leadership, customers, pricing, news, market position, and risks.",
+    "Prefer primary and high-quality sources such as company websites, filings, official blogs, reputable news, customer evidence, and supplied files.",
+    "Do not invent facts; if sources conflict, cite both sides, explain the conflict, and mark the field unresolved.",
+    "Structure the brief around the user's decision with executive summary, evidence-backed sections, risks or unknowns, recommendations, and sources.",
+    "Keep private CRM, email, Slack, and file excerpts scoped to the requested business purpose and visible audience.",
+  ],
 });

--- a/apps/web/lib/skill-templates/competitor-monitor.ts
+++ b/apps/web/lib/skill-templates/competitor-monitor.ts
@@ -1,13 +1,81 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const competitorMonitor = createSkillTemplate({
+export const competitorMonitor = defineSkillTemplate({
   id: "competitor-monitor",
   title: "Competitor Monitor",
   summary: "Monitor competitor launches, pricing changes, messaging, and market moves.",
   category: "Research Anything",
   outcome: "Tracks named competitors, summarizes meaningful changes, and posts implications with suggested responses.",
+  userUseCase:
+    "Use this when a founder, GTM team, CS lead, or operator needs a repeatable monitor for named competitors, adjacent categories, or strategic threats. The skill should watch for product, pricing, customer, hiring, funding, and messaging changes, then separate verified facts from implications so the team can decide whether to respond.",
   personas: ["Founder", "Sales", "Customer Success"],
   requiredApps: [externalApps.slack],
   triggerModes: ["scheduled", "manual"],
-  focusAreas: ["competitor list", "signal types", "digest cadence", "noise filters"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "competitors",
+      prompt: "Which competitors, categories, or strategic threats should be monitored?",
+      required: true,
+      freeformHint: "List company names, websites, CRM accounts, or category keywords.",
+    },
+    {
+      id: "signals",
+      prompt: "Which competitor signals matter most?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "product", label: "Product launches" },
+        { id: "pricing", label: "Pricing changes" },
+        { id: "customers", label: "Customer wins" },
+        { id: "funding", label: "Funding or M&A" },
+        { id: "hiring", label: "Hiring patterns" },
+        { id: "messaging", label: "Messaging shifts" },
+      ],
+    },
+    {
+      id: "source-scope",
+      prompt: "Which sources should the monitor check?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "web", label: "Web and news" },
+        { id: "company-sites", label: "Company sites" },
+        { id: "crm", label: "Dench CRM" },
+        { id: "files", label: "Battlecards/files" },
+        { id: "slack-notion", label: "Slack/Notion" },
+      ],
+    },
+    {
+      id: "cadence",
+      prompt: "How should competitor monitoring run?",
+      required: true,
+      options: [
+        { id: "manual", label: "Manual research" },
+        { id: "daily-cron", label: "Daily digest" },
+        { id: "weekly-cron", label: "Weekly digest" },
+      ],
+    },
+    {
+      id: "output",
+      prompt: "Where should the monitor publish results and what action guidance should it include?",
+      required: true,
+      options: [
+        { id: "dench-note", label: "Dench note" },
+        { id: "slack-digest", label: "Slack digest" },
+        { id: "notion", label: "Notion page" },
+        { id: "gmail-draft", label: "Gmail draft" },
+      ],
+      freeformHint: "Include audience, max length, and whether to include sales/CS response recommendations.",
+    },
+  ],
+  skillInstructions: [
+    "Monitor only the requested competitors, categories, and signal types unless the user explicitly expands scope.",
+    "Use primary sources, company sites, reputable news, CRM context, and supplied files before lower-quality commentary.",
+    "Cite each signal with source title, URL or file reference, publisher, and observed date.",
+    "Deduplicate repeated coverage of the same event and suppress unchanged signals in scheduled digests.",
+    "Separate verified changes from interpretation, and label confidence for each implication or recommended response.",
+    "Format output with top changes, why they matter, recommended response, watchlist, and sources.",
+    "For scheduled runs, publish only net-new or materially changed findings since the prior run.",
+  ],
 });

--- a/apps/web/lib/skill-templates/conference-lead-researcher.ts
+++ b/apps/web/lib/skill-templates/conference-lead-researcher.ts
@@ -1,13 +1,74 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const conferenceLeadResearcher = createSkillTemplate({
+export const conferenceLeadResearcher = defineSkillTemplate({
   id: "conference-lead-researcher",
   title: "Conference Lead Researcher",
   summary: "Research attendees, speakers, or sponsors before an event and build a hit list.",
   category: "Find Leads",
   outcome: "Turns an event or attendee list into a prioritized meeting and outreach plan with CRM-ready context.",
+  userUseCase:
+    "Use this before or after an event when a founder, seller, or BD owner has a conference page, attendee file, sponsor list, or speaker lineup and wants a prioritized lead plan. The skill should connect event participation to CRM context, warm paths, and concrete meeting or follow-up actions.",
   personas: ["Founder", "Sales", "Investor/BD"],
   requiredApps: [externalApps.gmail, externalApps.googleCalendar],
   triggerModes: ["manual"],
-  focusAreas: ["event source", "target persona", "meeting value", "output format"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "conference-source",
+      prompt: "Which event should be researched, and what source should I use?",
+      required: true,
+      freeformHint:
+        "Share the event name, website, sponsor page, attendee list, exhibitor list, speaker page, or uploaded file.",
+    },
+    {
+      id: "participant-types",
+      prompt: "Which participant types should become leads?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "sponsors", label: "Sponsors" },
+        { id: "exhibitors", label: "Exhibitors" },
+        { id: "speakers", label: "Speakers" },
+        { id: "attendees", label: "Attendees" },
+        { id: "partners", label: "Partners" },
+      ],
+    },
+    {
+      id: "lead-fit",
+      prompt: "What makes an event participant worth prioritizing?",
+      required: true,
+      freeformHint:
+        "Describe target persona, company profile, buying trigger, partnership fit, or investor relevance.",
+    },
+    {
+      id: "event-goal",
+      prompt: "What should the skill optimize the event list for?",
+      required: true,
+      options: [
+        { id: "book-before-event", label: "Book meetings before" },
+        { id: "prioritize-booth-visits", label: "Prioritize booth visits" },
+        { id: "post-event-follow-up", label: "Post-event follow-up" },
+        { id: "partnership-targets", label: "Partnership targets" },
+      ],
+    },
+    {
+      id: "crm-context-policy",
+      prompt: "How should existing CRM relationships affect prioritization?",
+      required: false,
+      options: [
+        { id: "prioritize-warm", label: "Prioritize warm accounts" },
+        { id: "exclude-customers", label: "Exclude customers" },
+        { id: "include-opportunities", label: "Include opportunities" },
+        { id: "net-new-only", label: "Net-new only" },
+      ],
+    },
+  ],
+  skillInstructions: [
+    "Collect participant companies and people from event pages, uploaded lists, files, CRM context, and web search.",
+    "Classify each lead by participant role, event relevance, account fit, and likely reason for attending.",
+    "Enrich companies and people with domains, titles, headquarters, company size, CRM status, and recent public signals.",
+    "Prioritize leads according to the event goal, separating pre-event, on-site, and post-event actions when useful.",
+    "Highlight warm paths such as existing contacts, CRM notes, shared accounts, prior interactions, or scheduled meetings.",
+    "Return a conference-ready lead list with meeting rationale, conversation starters, recommended outreach timing, and source evidence.",
+  ],
 });

--- a/apps/web/lib/skill-templates/create-template.ts
+++ b/apps/web/lib/skill-templates/create-template.ts
@@ -1,10 +1,6 @@
 import type {
   SkillTemplateApp,
-  SkillTemplateCategory,
   SkillTemplateDefinition,
-  SkillTemplateId,
-  SkillTemplatePersona,
-  SkillTemplateTriggerMode,
 } from "./types";
 
 export const externalApps = {
@@ -17,53 +13,8 @@ export const externalApps = {
   linkedin: { slug: "linkedin", name: "LinkedIn" },
 } satisfies Record<string, SkillTemplateApp>;
 
-export type TemplateSeed = {
-  id: SkillTemplateId;
-  title: string;
-  summary: string;
-  category: SkillTemplateCategory;
-  outcome: string;
-  personas: readonly SkillTemplatePersona[];
-  requiredApps: readonly SkillTemplateApp[];
-  triggerModes: readonly SkillTemplateTriggerMode[];
-  focusAreas: readonly string[];
-};
-
-const categoryInterviewTopics: Record<SkillTemplateCategory, readonly string[]> = {
-  "Find Leads": ["where inputs should come from", "scoring and dedupe rules"],
-  "Follow Up": ["message tone and approval policy", "stop conditions and reply detection"],
-  "Keep CRM Clean": ["fields to update or protect", "confidence thresholds and audit notes"],
-  "Prep Meetings": ["brief timing and destination", "meeting types and sensitive context"],
-  "Research Anything": ["source rules and citation expectations", "output format and save destination"],
-  "Hire People": ["role criteria and privacy guardrails", "pipeline update rules"],
-  "Grow Customers": ["account segments and risk signals", "owner alerts and CRM updates"],
-  "Run Founder Ops": ["cadence, audience, and delivery channel", "decisions, asks, and follow-up actions"],
-};
-
-const categoryInstructions: Record<SkillTemplateCategory, readonly string[]> = {
-  "Find Leads": ["rank outputs with evidence, fit, timing, and confidence", "write CRM records additively with source URLs"],
-  "Follow Up": ["use prior context before writing any message", "enforce caps, quiet hours, dedupe, and stop rules"],
-  "Keep CRM Clean": ["preserve user-authored fields unless overwrite rules are explicit", "record confidence, source, and timestamp for every change"],
-  "Prep Meetings": ["summarize context, objectives, risks, and recommended questions", "flag missing or low-confidence context clearly"],
-  "Research Anything": ["separate verified facts from hypotheses", "end with recommendations and next research tasks"],
-  "Hire People": ["avoid protected-class inference and cite professional evidence", "keep candidate communications stage-aware and respectful"],
-  "Grow Customers": ["separate churn risk, expansion opportunity, and missing data", "alert owners only when action is warranted"],
-  "Run Founder Ops": ["keep outputs concise, decision-oriented, and reusable", "make scheduled runs idempotent for the relevant period"],
-};
-
-export function createSkillTemplate(seed: TemplateSeed): SkillTemplateDefinition {
-  return {
-    ...seed,
-    autonomy: "Can automate",
-    interviewTopics: [
-      ...seed.focusAreas.map((area) => "The exact " + area + " for this workflow."),
-      ...categoryInterviewTopics[seed.category].map((topic) => "The " + topic + " to apply."),
-    ].slice(0, 5),
-    skillInstructions: [
-      "A clear trigger description for when future agents should use " + seed.title + ".",
-      "Step-by-step instructions to achieve this outcome: " + seed.outcome,
-      ...categoryInstructions[seed.category],
-      "Manual invocation guidance plus an exact cron/scheduled message when scheduled runs are enabled.",
-    ],
-  };
+export function defineSkillTemplate(
+  template: SkillTemplateDefinition,
+): SkillTemplateDefinition {
+  return template;
 }

--- a/apps/web/lib/skill-templates/crm-contact-enricher.ts
+++ b/apps/web/lib/skill-templates/crm-contact-enricher.ts
@@ -1,13 +1,82 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const crmContactEnricher = createSkillTemplate({
+export const crmContactEnricher = defineSkillTemplate({
   id: "crm-contact-enricher",
   title: "CRM Contact Enricher",
   summary: "Fill missing contact and company fields with attributed enrichment.",
   category: "Keep CRM Clean",
   outcome: "Finds incomplete records, enriches missing fields from native data and external CRM context, and writes confidence-scored updates.",
+  userUseCase: "Use this when Dench CRM or HubSpot contacts are missing firmographic, role, company, source, owner, lifecycle, or relationship fields. The skill should run manually for a named list or on a schedule for incomplete records, enrich from Dench-native data first, and write only attributed, confidence-scored CRM updates.",
   personas: ["RevOps", "Sales"],
   requiredApps: [externalApps.hubspot],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["record segments", "required fields", "confidence threshold", "overwrite rules"],
+  autonomy: "Updates CRM",
+  interviewQuestions: [
+    {
+      id: "record-scope",
+      prompt: "Which CRM records should this enrich?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "all-incomplete-contacts", label: "All incomplete contacts" },
+        { id: "owned-contacts", label: "Contacts I own" },
+        { id: "recently-created", label: "Recently created" },
+        { id: "target-accounts", label: "Target accounts" },
+        { id: "named-list", label: "Named list" },
+      ],
+      freeformHint: "Name the Dench view, HubSpot list, owner, lifecycle stage, or saved segment.",
+    },
+    {
+      id: "fields-to-enrich",
+      prompt: "Which fields should be enriched or backfilled?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "person-fields", label: "Person fields", description: "title, seniority, location, profile URL, email confidence" },
+        { id: "company-fields", label: "Company fields", description: "industry, size, website, HQ, funding, description" },
+        { id: "routing-fields", label: "Routing fields", description: "owner, lifecycle, lead status, persona, territory" },
+        { id: "relationship-context", label: "Relationship context", description: "last touch, source, warm intro, notes" },
+      ],
+    },
+    {
+      id: "confidence-policy",
+      prompt: "What confidence threshold should be required before writing enriched fields?",
+      required: true,
+      options: [
+        { id: "high-only", label: "High only", description: "Write only very high-confidence values" },
+        { id: "medium-review", label: "Medium with review", description: "Write strong matches and queue uncertain values" },
+        { id: "draft-only", label: "Draft only", description: "Never write automatically" },
+      ],
+    },
+    {
+      id: "overwrite-policy",
+      prompt: "How should existing CRM values be handled?",
+      required: true,
+      options: [
+        { id: "never-overwrite", label: "Never overwrite" },
+        { id: "overwrite-stale-attributed", label: "Overwrite stale machine-sourced values" },
+        { id: "ask-before-overwrite", label: "Ask before overwriting" },
+      ],
+    },
+    {
+      id: "run-cadence",
+      prompt: "How should this enrichment skill run?",
+      required: true,
+      options: [
+        { id: "manual-only", label: "Manual only" },
+        { id: "daily-cron", label: "Daily scheduled scan" },
+        { id: "weekly-cron", label: "Weekly cleanup" },
+      ],
+      freeformHint: "Include cron time, timezone, and where a completion summary should go.",
+    },
+  ],
+  skillInstructions: [
+    "Support only manual runs and cron/scheduled agent messages; do not assume contact-created webhooks or real-time CRM callbacks.",
+    "Use Dench CRM as the system of record, with Dench-native enrichment first and HubSpot, Gmail, or Calendar context only when connected and relevant.",
+    "For every proposed or written CRM value, store source attribution, observed date, confidence score, and a short evidence note.",
+    "Never overwrite user-authored CRM fields unless the configured overwrite policy explicitly allows it; otherwise create a review queue of conflicts.",
+    "Write enriched values only when they meet the configured confidence threshold; below-threshold findings should remain suggestions.",
+    "Make scheduled runs idempotent by skipping records enriched successfully within the configured lookback window.",
+    "End each run with records scanned, fields updated, conflicts skipped, low-confidence suggestions, and any HubSpot sync issues.",
+  ],
 });

--- a/apps/web/lib/skill-templates/customer-voice-miner.ts
+++ b/apps/web/lib/skill-templates/customer-voice-miner.ts
@@ -1,13 +1,81 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const customerVoiceMiner = createSkillTemplate({
+export const customerVoiceMiner = defineSkillTemplate({
   id: "customer-voice-miner",
   title: "Customer Voice Miner",
   summary: "Mine calls, notes, tickets, and messages for themes in customer language.",
   category: "Research Anything",
   outcome: "Extracts recurring pains, objections, feature requests, quotes, and messaging insights from customer-facing context.",
+  userUseCase: "Use this when product, founder, CS, or GTM teams need customer truth from CRM notes, transcripts, support notes, reviews, Slack threads, Notion docs, Gmail, or uploaded research. The skill should turn messy qualitative material into cited themes, quotes, objections, product gaps, and messaging recommendations without exposing unnecessary private details.",
   personas: ["Founder", "Customer Success", "Sales"],
   requiredApps: [externalApps.slack, externalApps.notion],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["source set", "themes to mine", "quote rules", "destination"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "source-material",
+      prompt: "Where should customer voice be mined from?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "crm", label: "CRM notes" },
+        { id: "files", label: "Uploaded files" },
+        { id: "gmail", label: "Gmail" },
+        { id: "slack", label: "Slack" },
+        { id: "notion", label: "Notion" },
+        { id: "web", label: "Public reviews" },
+      ],
+    },
+    {
+      id: "customer-segment",
+      prompt: "Which customer segment, account set, lifecycle stage, or date range should be analyzed?",
+      required: true,
+      freeformHint: "Name the CRM segment, accounts, product line, market, or source date range.",
+    },
+    {
+      id: "themes",
+      prompt: "Which themes should the analysis extract?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "pain", label: "Pain points" },
+        { id: "objections", label: "Objections" },
+        { id: "features", label: "Feature requests" },
+        { id: "value", label: "Value drivers" },
+        { id: "churn", label: "Churn risk" },
+        { id: "language", label: "Exact language" },
+      ],
+    },
+    {
+      id: "cadence",
+      prompt: "Should this be a manual analysis or a recurring customer voice digest?",
+      required: true,
+      options: [
+        { id: "manual", label: "Manual analysis" },
+        { id: "weekly", label: "Weekly digest" },
+        { id: "monthly", label: "Monthly digest" },
+      ],
+    },
+    {
+      id: "output-format",
+      prompt: "What output format should the report use?",
+      required: true,
+      options: [
+        { id: "brief", label: "Executive brief" },
+        { id: "theme-table", label: "Theme table" },
+        { id: "backlog", label: "Product backlog" },
+        { id: "messaging", label: "Messaging doc" },
+      ],
+      freeformHint: "Include destination, audience, and whether quotes may include account names.",
+    },
+  ],
+  skillInstructions: [
+    "Use only customer data available to the requesting user through Dench CRM, local files, and connected apps.",
+    "Cite each theme with source references, dates, account or segment context, and representative quotes where permitted.",
+    "Redact sensitive personal data unless necessary for the requested business purpose and avoid exposing private email or Slack content beyond relevant excerpts.",
+    "Group similar feedback into themes, quantify frequency when possible, and avoid overstating conclusions from small samples.",
+    "Preserve exact customer language for quoted evidence while clearly separating quotes from paraphrased analysis.",
+    "Prioritize recent, direct, high-context sources such as call transcripts, customer emails, CRM notes, support notes, and uploaded research files.",
+    "Format the output as Summary, Theme Table, Representative Quotes, Segment Differences, Recommendations, Open Questions, and Sources.",
+  ],
 });

--- a/apps/web/lib/skill-templates/duplicate-record-cleaner.ts
+++ b/apps/web/lib/skill-templates/duplicate-record-cleaner.ts
@@ -1,13 +1,84 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const duplicateRecordCleaner = createSkillTemplate({
+export const duplicateRecordCleaner = defineSkillTemplate({
   id: "duplicate-record-cleaner",
   title: "Duplicate Record Cleaner",
   summary: "Find likely duplicate people or companies and prepare safe merge guidance.",
   category: "Keep CRM Clean",
   outcome: "Detects duplicate records, ranks merge confidence, proposes canonical records, and queues safe cleanup actions.",
+  userUseCase:
+    "Use this when Dench CRM or HubSpot contains duplicate people, companies, or deals that break attribution, ownership, and reporting. The skill should identify duplicate clusters, recommend canonical records, preserve history, and only merge or update when confidence and overwrite rules are explicit.",
   personas: ["RevOps", "Sales"],
   requiredApps: [externalApps.hubspot],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["duplicate signals", "canonical rules", "merge threshold", "audit log"],
+  autonomy: "Updates CRM",
+  interviewQuestions: [
+    {
+      id: "duplicate-scope",
+      prompt: "Which record types should be checked for duplicates?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "contacts", label: "Contacts" },
+        { id: "companies", label: "Companies" },
+        { id: "deals", label: "Deals" },
+        { id: "all-crm-records", label: "All CRM records" },
+      ],
+    },
+    {
+      id: "matching-signals",
+      prompt: "Which signals should count toward a duplicate match?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "exact-email-domain", label: "Exact email/domain" },
+        { id: "name-company", label: "Name + company" },
+        { id: "hubspot-ids", label: "HubSpot IDs" },
+        { id: "gmail-calendar-history", label: "Activity history" },
+        { id: "dench-enrichment", label: "Dench enrichment" },
+      ],
+    },
+    {
+      id: "canonical-policy",
+      prompt: "How should the canonical record be chosen?",
+      required: true,
+      options: [
+        { id: "most-complete", label: "Most complete" },
+        { id: "oldest-attributed", label: "Oldest attributed" },
+        { id: "active-owner", label: "Active owner/deal" },
+        { id: "hubspot-primary", label: "HubSpot primary" },
+      ],
+    },
+    {
+      id: "merge-threshold",
+      prompt: "What confidence is required before cleanup can happen?",
+      required: true,
+      options: [
+        { id: "review-all", label: "Review all" },
+        { id: "merge-95", label: "Auto-merge 95%+" },
+        { id: "merge-90-simple", label: "Auto-merge simple 90%+" },
+      ],
+    },
+    {
+      id: "audit-destination",
+      prompt: "Where should duplicate reports and audit logs go?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "dench-crm-note", label: "Dench CRM note" },
+        { id: "hubspot-note", label: "HubSpot note" },
+        { id: "notion-table", label: "Notion table" },
+        { id: "digest-only", label: "Digest only" },
+      ],
+    },
+  ],
+  skillInstructions: [
+    "Support only manual duplicate checks and cron/scheduled duplicate hygiene runs.",
+    "Compare Dench CRM records with HubSpot records when connected, keeping Dench attribution and external IDs intact.",
+    "Score each duplicate cluster with match reasons, conflicting fields, canonical recommendation, and merge confidence.",
+    "Do not merge or overwrite records below the configured confidence threshold; route them to review with evidence.",
+    "Preserve field provenance by carrying source attribution, original record IDs, timestamps, owners, and activity history into the canonical record or audit note.",
+    "Never overwrite user-authored fields during automatic cleanup unless the canonical and overwrite policies explicitly permit it.",
+    "Produce an audit summary with clusters reviewed, safe merges completed, conflicts blocked, and records requiring manual review.",
+  ],
 });

--- a/apps/web/lib/skill-templates/executive-daily-brief.ts
+++ b/apps/web/lib/skill-templates/executive-daily-brief.ts
@@ -1,13 +1,88 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const executiveDailyBrief = createSkillTemplate({
+export const executiveDailyBrief = defineSkillTemplate({
   id: "executive-daily-brief",
   title: "Executive Daily Brief",
   summary: "Start each day with priorities, meetings, follow-ups, and lurking risks.",
   category: "Prep Meetings",
   outcome: "Reviews calendar, inbox, Slack, CRM, and workspace context to produce a focused daily plan.",
+  userUseCase: "Use this when a founder, operator, or knowledge worker wants a morning command center instead of checking Calendar, Gmail, Slack, CRM, and Notion separately. The skill should run manually or on a morning cron, identify what needs attention today, and produce a calm executive brief with priorities, risks, prep needs, and follow-ups.",
   personas: ["Founder", "Operator", "Knowledge Worker"],
   requiredApps: [externalApps.googleCalendar, externalApps.gmail, externalApps.slack],
   triggerModes: ["scheduled", "manual"],
-  focusAreas: ["delivery time", "priority sources", "urgency rules", "task policy"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "brief-audience",
+      prompt: "Who will use this daily brief and what perspective should it optimize for?",
+      required: true,
+      options: [
+        { id: "founder", label: "Founder" },
+        { id: "sales-leader", label: "Sales leader" },
+        { id: "operator", label: "Operator" },
+        { id: "knowledge-worker", label: "Knowledge worker" },
+      ],
+    },
+    {
+      id: "priority-sources",
+      prompt: "Which sources should determine priorities?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "calendar", label: "Calendar" },
+        { id: "gmail", label: "Gmail" },
+        { id: "dench-crm", label: "Dench CRM" },
+        { id: "hubspot", label: "HubSpot" },
+        { id: "notion", label: "Notion" },
+        { id: "slack", label: "Slack" },
+      ],
+    },
+    {
+      id: "brief-sections",
+      prompt: "Which sections should the brief include?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "todays-meetings", label: "Today's meetings" },
+        { id: "urgent-follow-ups", label: "Urgent follow-ups" },
+        { id: "crm-risks", label: "CRM and pipeline risks" },
+        { id: "waiting-on-me", label: "Waiting on me" },
+        { id: "top-priorities", label: "Top priorities" },
+        { id: "prep-links", label: "Prep links" },
+      ],
+    },
+    {
+      id: "delivery-schedule",
+      prompt: "When should the daily brief arrive and should quiet days be skipped?",
+      required: true,
+      options: [
+        { id: "weekday-morning", label: "Weekday morning" },
+        { id: "daily-morning", label: "Every morning" },
+        { id: "manual-only", label: "Manual only" },
+      ],
+      freeformHint: "Include exact local time, timezone, and whether to skip days with no meetings.",
+    },
+    {
+      id: "destination-format",
+      prompt: "Where should the daily brief be delivered?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "gmail", label: "Gmail" },
+        { id: "notion", label: "Notion" },
+        { id: "dench-chat", label: "Dench chat" },
+        { id: "slack", label: "Slack" },
+      ],
+      freeformHint: "Include recipients, page or channel destinations, and desired brief length.",
+    },
+  ],
+  skillInstructions: [
+    "Support manual runs and cron-scheduled morning briefs only; do not assume passive app listeners.",
+    "Use Calendar as the daily structure, then rank Gmail, Dench CRM, HubSpot, Notion, and Slack signals by urgency, importance, and meeting relevance.",
+    "Include source attribution for deal, customer, investor, hiring, and relationship context that influences priority.",
+    "Do not send emails, update CRM, or modify tasks unless explicitly configured; default to a read-only brief with suggested actions.",
+    "Call out low-confidence or conflicting data instead of presenting it as fact, especially for pipeline risk or relationship status.",
+    "Deliver one scannable brief with top priorities, meetings, prep needs, follow-ups, and risks in the configured destination.",
+    "Make scheduled runs idempotent by generating at most one brief per recipient per scheduled window unless manually invoked.",
+  ],
 });

--- a/apps/web/lib/skill-templates/funding-signal-prospector.ts
+++ b/apps/web/lib/skill-templates/funding-signal-prospector.ts
@@ -1,13 +1,82 @@
-import { createSkillTemplate } from "./create-template";
+import { defineSkillTemplate } from "./create-template";
 
-export const fundingSignalProspector = createSkillTemplate({
+export const fundingSignalProspector = defineSkillTemplate({
   id: "funding-signal-prospector",
   title: "Funding Signal Prospector",
   summary: "Find newly funded companies that match your ICP and likely need help now.",
   category: "Find Leads",
   outcome: "Monitors funding signals, filters against ICP rules, enriches contacts, and creates time-sensitive CRM opportunities.",
+  userUseCase: "Use this when a founder or seller wants a repeatable prospecting workflow around recent funding events. The skill should find companies that match a target market, verify funding from credible sources, infer why the event creates urgency, and turn the signal into CRM-ready account research and outreach angles.",
   personas: ["Founder", "Sales"],
   requiredApps: [],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["funding stages", "trigger thesis", "freshness window", "CRM handoff"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "funding-stage",
+      prompt: "Which funding stages should count as a prospecting signal?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "pre-seed-seed", label: "Pre-seed/seed" },
+        { id: "series-a-b", label: "Series A/B" },
+        { id: "series-c-plus", label: "Series C+" },
+        { id: "growth-pe", label: "Growth/PE" },
+        { id: "debt-ma", label: "Debt or M&A" },
+      ],
+    },
+    {
+      id: "freshness-window",
+      prompt: "How fresh should the funding event be?",
+      required: true,
+      options: [
+        { id: "30-days", label: "30 days" },
+        { id: "90-days", label: "90 days" },
+        { id: "6-months", label: "6 months" },
+        { id: "12-months", label: "12 months" },
+      ],
+    },
+    {
+      id: "company-filters",
+      prompt: "Which company profiles should be included after the funding filter?",
+      required: true,
+      freeformHint: "Describe industries, geographies, employee ranges, business models, or customer segments.",
+    },
+    {
+      id: "spend-trigger",
+      prompt: "What post-funding motion makes these companies worth contacting?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "sales-hiring", label: "Sales hiring" },
+        { id: "marketing-expansion", label: "Marketing expansion" },
+        { id: "engineering-growth", label: "Engineering growth" },
+        { id: "international-expansion", label: "International expansion" },
+        { id: "compliance-buildout", label: "Compliance buildout" },
+        { id: "new-product", label: "New product" },
+      ],
+    },
+    {
+      id: "crm-handoff",
+      prompt: "What should be written to CRM for each funded prospect?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "account-note", label: "Sourced account note" },
+        { id: "priority-score", label: "Priority score" },
+        { id: "contact-research", label: "Contact research" },
+        { id: "owner-task", label: "Owner task" },
+        { id: "draft-message", label: "Draft message" },
+      ],
+    },
+  ],
+  skillInstructions: [
+    "Search public web sources and Dench-native enrichment for funding events that match the selected stage and freshness window.",
+    "Verify funding amount, date, stage, investors, and company identity from credible sources before including a company.",
+    "Filter funded companies through the requested ICP, exclusions, and CRM duplicate checks before ranking them.",
+    "Explain the likely post-funding spend trigger for each account and tie it to observable evidence.",
+    "Enrich each qualified account with domain, size, headquarters, relevant leaders, and source URLs.",
+    "Write only additive CRM notes, scores, tasks, or drafts with source attribution and confidence; do not overwrite user-authored fields.",
+    "For scheduled runs, suppress funding events already processed in earlier runs unless a materially new signal appears.",
+  ],
 });

--- a/apps/web/lib/skill-templates/fundraising-target-builder.ts
+++ b/apps/web/lib/skill-templates/fundraising-target-builder.ts
@@ -1,13 +1,83 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const fundraisingTargetBuilder = createSkillTemplate({
+export const fundraisingTargetBuilder = defineSkillTemplate({
   id: "fundraising-target-builder",
   title: "Fundraising Target Builder",
   summary: "Build and maintain a prioritized investor target list for a fundraise.",
   category: "Run Founder Ops",
   outcome: "Maps investor fit, enriches partners, finds warm paths, ranks targets, and creates investor CRM records.",
+  userUseCase: "Use when a founder is preparing or maintaining a fundraise target list and wants DenchClaw to find, enrich, rank, and track relevant investors. The skill should identify fund-stage fit, partner ownership, portfolio conflicts, warm paths, and the next action that moves each investor forward.",
   personas: ["Founder", "Investor/BD"],
   requiredApps: [externalApps.gmail, externalApps.notion],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["round details", "investor filters", "warm paths", "ranking criteria"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "round-context",
+      prompt: "What fundraising context should guide the target list?",
+      required: true,
+      freeformHint: "Include round type, target raise, stage, geography, timing, traction, check size, and any investor exclusions.",
+    },
+    {
+      id: "investor-fit-criteria",
+      prompt: "Which investor fit criteria matter most?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "stage-fit", label: "Stage fit" },
+        { id: "sector-fit", label: "Sector fit" },
+        { id: "geo-fit", label: "Geo fit" },
+        { id: "check-size", label: "Check size" },
+        { id: "portfolio-synergy", label: "Portfolio synergy" },
+        { id: "can-lead", label: "Can lead" },
+      ],
+    },
+    {
+      id: "warm-path-sources",
+      prompt: "Where should the skill look for warm introduction paths?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "dench-crm", label: "Dench CRM" },
+        { id: "gmail", label: "Gmail" },
+        { id: "calendar", label: "Calendar" },
+        { id: "notion-files", label: "Notion/files" },
+        { id: "manual-network", label: "Manual network notes" },
+      ],
+    },
+    {
+      id: "crm-write-policy",
+      prompt: "How should investor targets be written to CRM?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "create-records", label: "Create records" },
+        { id: "add-research-notes", label: "Add research notes" },
+        { id: "create-intro-tasks", label: "Create intro tasks" },
+        { id: "rank-only", label: "Rank only" },
+        { id: "review-before-write", label: "Review before write" },
+      ],
+    },
+    {
+      id: "outputs",
+      prompt: "Which fundraising outputs should be prepared?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "founder-shortlist", label: "Founder shortlist" },
+        { id: "crm-import-plan", label: "CRM import plan" },
+        { id: "intro-drafts", label: "Intro request drafts" },
+        { id: "investor-memos", label: "Investor memos" },
+      ],
+    },
+  ],
+  skillInstructions: [
+    "Use Dench CRM, native enrichment, web search, and files to build investor evidence; optionally use Gmail, Calendar, HubSpot, Notion, and Slack for prior interactions, warm paths, and notes.",
+    "Support only manual list-building runs and cron-scheduled refreshes; do not assume investor news or CRM update webhooks.",
+    "Deduplicate investors, firms, partners, domains, prior targets, and active fundraising opportunities before creating records or tasks.",
+    "Score each investor with stage fit, sector fit, check-size fit, portfolio relevance, warm-path strength, and timing rationale.",
+    "Follow the CRM write policy: create or update investor records only when allowed, use additive sourced research notes, and avoid overwriting owner-entered stages, rankings, or relationship fields.",
+    "Alert the founder when a high-fit investor has a strong warm path, recent relevant activity, or a time-sensitive reason to engage.",
+    "Produce a founder-ranked shortlist, operator CRM write plan, intro-request drafts, and investor-specific research memos.",
+  ],
 });

--- a/apps/web/lib/skill-templates/hiring-manager-weekly-digest.ts
+++ b/apps/web/lib/skill-templates/hiring-manager-weekly-digest.ts
@@ -1,13 +1,80 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const hiringManagerWeeklyDigest = createSkillTemplate({
+export const hiringManagerWeeklyDigest = defineSkillTemplate({
   id: "hiring-manager-weekly-digest",
   title: "Hiring Manager Weekly Digest",
   summary: "Send hiring managers a weekly summary of pipeline health and decisions needed.",
   category: "Hire People",
   outcome: "Summarizes candidates, interviews, feedback gaps, risks, and decisions required by each hiring manager.",
+  userUseCase: "Send hiring managers a weekly operating brief that turns candidate records, interviews, feedback gaps, and process blockers into the few decisions they need to make.",
   personas: ["Recruiter", "Founder", "Operator"],
   requiredApps: [externalApps.googleCalendar, externalApps.slack, externalApps.notion],
   triggerModes: ["scheduled", "manual"],
-  focusAreas: ["roles covered", "weekly sections", "escalation rules", "delivery channel"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "audience-scope",
+      prompt: "Which hiring manager, team, or roles should the digest cover?",
+      required: true,
+      freeformHint: "Specify manager, role names, departments, CRM views, or candidate pipelines.",
+    },
+    {
+      id: "digest-sections",
+      prompt: "Which sections should the weekly digest include?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "pipeline", label: "Pipeline snapshot" },
+        { id: "interviews", label: "Upcoming interviews" },
+        { id: "feedback", label: "Overdue feedback" },
+        { id: "blockers", label: "Blockers" },
+        { id: "priority-candidates", label: "Priority candidates" },
+      ],
+    },
+    {
+      id: "source-systems",
+      prompt: "Which sources should be checked before writing the digest?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "crm", label: "Candidate CRM" },
+        { id: "calendar", label: "Calendar" },
+        { id: "gmail", label: "Gmail" },
+        { id: "slack", label: "Slack" },
+        { id: "notion", label: "Notion" },
+        { id: "files", label: "Files" },
+      ],
+    },
+    {
+      id: "delivery-policy",
+      prompt: "When and where should the digest be delivered?",
+      required: true,
+      options: [
+        { id: "weekly-slack", label: "Weekly Slack" },
+        { id: "weekly-gmail", label: "Weekly Gmail draft" },
+        { id: "notion-page", label: "Notion page" },
+        { id: "manual-only", label: "Manual only" },
+      ],
+      freeformHint: "Include weekday, time, timezone, recipients, and privacy level.",
+    },
+    {
+      id: "candidate-privacy",
+      prompt: "How much candidate detail is appropriate for this audience?",
+      required: true,
+      options: [
+        { id: "names-ok", label: "Names ok" },
+        { id: "role-stage-only", label: "Role and stage only" },
+        { id: "private-links", label: "Private links" },
+      ],
+    },
+  ],
+  skillInstructions: [
+    "Include only hiring information the audience is authorized to see, and minimize candidate personal data in broad digests.",
+    "Use role-related and process-related signals only: stage, next step, feedback status, interview schedule, scorecard completion, and authorized notes.",
+    "Do not mention, infer, rank, or summarize candidates using protected-class or sensitive attributes.",
+    "Cite private digest claims with Dench records, Calendar events, Gmail threads, files, Slack threads, or Notion pages.",
+    "Prioritize blockers that require hiring-manager attention in the next week, not every low-level pipeline detail.",
+    "For weekly cron digests, compare against the prior week and highlight stage movement, newly stale candidates, and resolved blockers.",
+    "Format the digest as executive summary, pipeline snapshot, priority decisions, overdue feedback, upcoming interviews, blockers, and recommended actions.",
+  ],
 });

--- a/apps/web/lib/skill-templates/hiring-signal-prospector.ts
+++ b/apps/web/lib/skill-templates/hiring-signal-prospector.ts
@@ -1,6 +1,6 @@
-import { createSkillTemplate } from "./create-template";
+import { defineSkillTemplate } from "./create-template";
 
-export const hiringSignalProspector = createSkillTemplate({
+export const hiringSignalProspector = defineSkillTemplate({
   id: "hiring-signal-prospector",
   title: "Hiring Signal Prospector",
   summary: "Spot companies hiring for roles that reveal urgency for your product.",
@@ -9,5 +9,74 @@ export const hiringSignalProspector = createSkillTemplate({
   personas: ["Founder", "Sales"],
   requiredApps: [],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["job titles", "hiring thresholds", "decision-maker roles", "signal evidence"],
+  autonomy: "Can automate",
+  userUseCase: "Use this when hiring activity is a buying-intent signal: companies adding sales reps, RevOps, security, support, finance, or other roles that reveal a new operational pain. The skill should find companies hiring for the right jobs, interpret what that implies, identify likely buyers, and turn the signal into CRM-ready prospecting action.",
+  interviewQuestions: [
+    {
+      id: "hiring-roles",
+      prompt: "Which open roles or departments should signal demand?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "sales", label: "Sales roles" },
+        { id: "revops", label: "RevOps roles" },
+        { id: "security", label: "Security roles" },
+        { id: "support", label: "Support roles" },
+        { id: "engineering", label: "Engineering roles" },
+      ],
+      freeformHint: "Include exact titles, seniority, departments, or phrases from job descriptions.",
+    },
+    {
+      id: "intent-meaning",
+      prompt: "What should those hiring signals imply about business need?",
+      required: true,
+      options: [
+        { id: "new-team", label: "Building a new team" },
+        { id: "scale-capacity", label: "Scaling capacity" },
+        { id: "manual-work", label: "Replacing manual work" },
+        { id: "compliance", label: "Compliance push" },
+        { id: "market-expansion", label: "Market expansion" },
+      ],
+    },
+    {
+      id: "company-scope",
+      prompt: "Which company types, regions, or size ranges should be searched?",
+      required: true,
+      freeformHint: "Example: Series B-C SaaS in North America with 100-1000 employees.",
+    },
+    {
+      id: "signal-strength",
+      prompt: "Which hiring patterns should receive higher priority?",
+      required: false,
+      allowMultiple: true,
+      options: [
+        { id: "multiple-openings", label: "Multiple similar roles" },
+        { id: "new-leader", label: "New leadership role" },
+        { id: "tool-mentions", label: "Tool mentions" },
+        { id: "urgent-language", label: "Urgent language" },
+        { id: "new-market", label: "New market role" },
+      ],
+    },
+    {
+      id: "contact-strategy",
+      prompt: "Who should be contacted when a strong hiring signal is found?",
+      required: true,
+      options: [
+        { id: "hiring-manager", label: "Hiring manager" },
+        { id: "department-exec", label: "Department exec" },
+        { id: "ops-leader", label: "Ops leader" },
+        { id: "founder", label: "Founder" },
+        { id: "finance", label: "Finance approver" },
+      ],
+    },
+  ],
+  skillInstructions: [
+    "Search public job postings, company career pages, enrichment data, and CRM context for hiring signals that match the requested roles.",
+    "Group related openings by company to detect team-level growth rather than isolated one-off roles.",
+    "Interpret job descriptions for buying intent, tool mentions, department priorities, urgency, and timing cues.",
+    "Prioritize companies where hiring activity maps directly to the user's product thesis and target buyer.",
+    "Exclude companies already owned by active CRM opportunities unless the user explicitly wants them reviewed.",
+    "Return each prospect with relevant job links, signal interpretation, likely buyer, recommended contact path, and CRM-safe source notes.",
+    "For scheduled runs, dedupe against prior findings and only surface new or materially changed hiring signals since the last run.",
+  ],
 });

--- a/apps/web/lib/skill-templates/icp-outreach-builder.ts
+++ b/apps/web/lib/skill-templates/icp-outreach-builder.ts
@@ -1,13 +1,71 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const icpOutreachBuilder = createSkillTemplate({
+export const icpOutreachBuilder = defineSkillTemplate({
   id: "icp-outreach-builder",
   title: "ICP Outreach Builder",
   summary: "Build a guardrailed outbound skill from an ICP, offer, and send policy.",
   category: "Find Leads",
   outcome: "Researches ICP-matched leads, writes personalized messages, follows the configured send policy, and logs activity to CRM.",
+  userUseCase: "Use when a founder or seller knows the customer profile and offer but needs DenchClaw to turn that into a repeatable prospecting skill. The workflow should find accounts and people with Dench-native CRM, enrichment, and web research, draft outreach grounded in evidence, and only send when explicit rules exist.",
   personas: ["Founder", "Sales"],
   requiredApps: [externalApps.gmail, externalApps.hubspot],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["ICP and buyer persona", "offer and CTA", "send rules", "follow-up cadence"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "icp-definition",
+      prompt: "What ICP should this outreach skill target?",
+      required: true,
+      freeformHint: "Include industry, geography, size, buyer pain, maturity, and exclusions.",
+    },
+    {
+      id: "buyer-personas",
+      prompt: "Which buyer personas should DenchClaw research at each account?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "founder", label: "Founder/CEO" },
+        { id: "sales-leader", label: "Sales leader" },
+        { id: "revops", label: "RevOps" },
+        { id: "marketing", label: "Marketing" },
+        { id: "custom", label: "Custom role" },
+      ],
+      freeformHint: "List exact titles, seniority, and backup personas.",
+    },
+    {
+      id: "offer-and-cta",
+      prompt: "What offer, pain, and CTA should the outreach connect to?",
+      required: true,
+      freeformHint: "Describe the product, promise, proof, call to action, and phrases to avoid.",
+    },
+    {
+      id: "personalization-evidence",
+      prompt: "Which evidence should drive personalization?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "company-news", label: "Company news" },
+        { id: "hiring", label: "Hiring" },
+        { id: "funding", label: "Funding" },
+        { id: "crm-history", label: "CRM history" },
+        { id: "website-positioning", label: "Website positioning" },
+        { id: "tech-stack", label: "Tech stack" },
+      ],
+    },
+    {
+      id: "send-policy",
+      prompt: "What are the send, follow-up, quiet-hour, and stop rules?",
+      required: true,
+      freeformHint: "Include draft vs auto-send, daily caps, allowlists, follow-up spacing, reply detection, meeting booked, do-not-contact, and CRM stage stops.",
+    },
+  ],
+  skillInstructions: [
+    "Translate the ICP into concrete account, contact, exclusion, and evidence rules before searching.",
+    "Use Dench CRM, native enrichment, Apollo-style native data, web search, HubSpot context, and Gmail history to find and prioritize accounts; never require Apollo as an external app.",
+    "For each lead, capture account fit, buyer-persona rationale, source links, personalization evidence, and confidence.",
+    "Write outreach that is concise, specific, and tied to observable evidence; do not fabricate familiarity, private details, or unsupported claims.",
+    "Default to drafts unless the user approves explicit send rules; enforce caps, quiet hours, dedupe, stop conditions, and CRM do-not-contact fields before sending.",
+    "For scheduled runs, make each campaign idempotent by checking prior Dench runs, Gmail history, and CRM notes before creating new drafts or sends.",
+    "Create the final SKILL.md with manual invocation examples, an exact scheduled message if enabled, CRM write fields, send policy, and a run summary format.",
+  ],
 });

--- a/apps/web/lib/skill-templates/interview-follow-up-agent.ts
+++ b/apps/web/lib/skill-templates/interview-follow-up-agent.ts
@@ -1,13 +1,73 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const interviewFollowUpAgent = createSkillTemplate({
+export const interviewFollowUpAgent = defineSkillTemplate({
   id: "interview-follow-up-agent",
   title: "Interview Follow-up Agent",
   summary: "Send timely candidate follow-ups and keep interview loops moving.",
   category: "Hire People",
   outcome: "Detects completed interviews, sends next-step messages, nudges interviewers, and updates candidate status.",
+  userUseCase: "Use this after interviews to draft candidate updates, nudge interviewers for feedback, and keep hiring loops moving without exposing private notes or using protected-class information.",
   personas: ["Recruiter", "Founder"],
   requiredApps: [externalApps.gmail, externalApps.googleCalendar],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["interview stages", "message policy", "internal nudges", "pipeline updates"],
+  autonomy: "Creates drafts",
+  interviewQuestions: [
+    {
+      id: "follow-up-type",
+      prompt: "What kind of interview follow-up should be created?",
+      required: true,
+      options: [
+        { id: "candidate-next-step", label: "Candidate next step" },
+        { id: "feedback-reminder", label: "Feedback reminder" },
+        { id: "debrief-summary", label: "Debrief summary" },
+        { id: "rejection-draft", label: "Rejection draft" },
+        { id: "offer-coordination", label: "Offer coordination" },
+      ],
+    },
+    {
+      id: "candidate-role-stage",
+      prompt: "Which candidate, role, and interview stage does this concern?",
+      required: true,
+      freeformHint: "Reference the candidate record, role, interview date, participants, and stage.",
+    },
+    {
+      id: "source-context",
+      prompt: "Which sources should be checked before drafting?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "candidate-record", label: "Candidate record" },
+        { id: "calendar", label: "Calendar event" },
+        { id: "gmail", label: "Gmail thread" },
+        { id: "scorecards", label: "Scorecards/files" },
+        { id: "notion-slack", label: "Notion/Slack notes" },
+      ],
+    },
+    {
+      id: "message-policy",
+      prompt: "What approval and tone rules should candidate-facing drafts follow?",
+      required: true,
+      freeformHint: "Include sender, signature, review requirement, timing SLA, and wording to avoid.",
+    },
+    {
+      id: "status-policy",
+      prompt: "What candidate status, task, or reminder updates may the skill create?",
+      required: true,
+      options: [
+        { id: "draft-only", label: "Draft only" },
+        { id: "create-tasks", label: "Create tasks" },
+        { id: "add-notes", label: "Add notes" },
+        { id: "suggest-status", label: "Suggest status" },
+      ],
+    },
+  ],
+  skillInstructions: [
+    "Use Calendar events, Gmail threads, candidate records, scorecards, and authorized notes to understand interview context before drafting.",
+    "Create drafts and reminders by default; do not send messages or change candidate status unless the user has explicitly configured that policy.",
+    "Do not mention or rely on protected-class or sensitive personal information in candidate-facing drafts, reminders, or summaries.",
+    "Keep rejection and feedback-adjacent language respectful, role-related, concise, and free of internal deliberation.",
+    "For feedback reminders, include the specific interview, requested scorecard, due date, and hiring impact without shaming the interviewer.",
+    "For scheduled runs, scan only the configured lookback window and skip interviews already followed up, replied to, or marked complete.",
+    "Output context checked, recommended action, draft message or reminder, missing inputs, and any CRM/task updates created or proposed.",
+  ],
 });

--- a/apps/web/lib/skill-templates/investor-meeting-prep.ts
+++ b/apps/web/lib/skill-templates/investor-meeting-prep.ts
@@ -1,13 +1,88 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const investorMeetingPrep = createSkillTemplate({
+export const investorMeetingPrep = defineSkillTemplate({
   id: "investor-meeting-prep",
   title: "Investor Meeting Prep",
   summary: "Research investors and assemble a sharp brief before fundraising meetings.",
   category: "Prep Meetings",
   outcome: "Researches investor background, portfolio, thesis, prior interactions, likely objections, and tailored talking points.",
+  userUseCase: "Prepare for investor, advisor, or fundraising meetings with a brief that connects calendar attendees, prior relationship history, portfolio fit, company narrative, and likely objections. It should help a founder walk into the meeting knowing what to emphasize, what not to claim, and what follow-up ask to make.",
   personas: ["Founder", "Investor/BD"],
   requiredApps: [externalApps.googleCalendar, externalApps.gmail, externalApps.notion],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["investor goal", "company narrative", "portfolio fit", "follow-up rules"],
+  autonomy: "Creates drafts",
+  interviewQuestions: [
+    {
+      id: "investor-meeting-goal",
+      prompt: "What is the goal of these investor meetings?",
+      required: true,
+      options: [
+        { id: "first-intro", label: "First intro" },
+        { id: "fundraising-pitch", label: "Fundraising pitch" },
+        { id: "follow-up-diligence", label: "Follow-up or diligence" },
+        { id: "advisor-board", label: "Advisor or board context" },
+        { id: "investor-update", label: "Investor update" },
+      ],
+    },
+    {
+      id: "research-scope",
+      prompt: "What should the investor brief research?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "firm-thesis", label: "Firm thesis" },
+        { id: "portfolio-fit", label: "Portfolio fit" },
+        { id: "partner-background", label: "Partner background" },
+        { id: "prior-interactions", label: "Prior interactions" },
+        { id: "likely-objections", label: "Likely objections" },
+        { id: "warm-intros", label: "Warm intros" },
+      ],
+    },
+    {
+      id: "source-of-truth",
+      prompt: "Where should company narrative and metrics come from?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "notion", label: "Notion" },
+        { id: "dench-crm", label: "Dench CRM" },
+        { id: "hubspot", label: "HubSpot" },
+        { id: "gmail", label: "Gmail" },
+        { id: "manual-context", label: "Manual context" },
+      ],
+      freeformHint: "Name the docs or CRM fields that contain approved positioning and metrics.",
+    },
+    {
+      id: "prep-timing",
+      prompt: "When should investor prep be generated?",
+      required: true,
+      options: [
+        { id: "day-before", label: "Day before" },
+        { id: "morning-of", label: "Morning of" },
+        { id: "one-hour-before", label: "1 hour before" },
+        { id: "manual-only", label: "Manual only" },
+      ],
+    },
+    {
+      id: "brief-destination",
+      prompt: "Where should the prep brief go?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "notion-page", label: "Notion page" },
+        { id: "gmail-draft", label: "Gmail draft" },
+        { id: "dench-chat", label: "Dench chat" },
+        { id: "calendar-note", label: "Calendar note" },
+      ],
+    },
+  ],
+  skillInstructions: [
+    "Support manual prep for a selected investor or meeting and scheduled prep for qualifying calendar events only.",
+    "Use calendar attendees as the anchor, then combine Dench CRM relationship history, Gmail threads, HubSpot stages, Notion narrative sources, and Dench enrichment.",
+    "Attribute investor facts, portfolio claims, prior interactions, CRM status, and company metrics to their sources with freshness and confidence.",
+    "Never invent fundraising metrics, commitments, terms, or investor interest; use only approved Notion, CRM, file, or user-provided context.",
+    "Deliver a brief with investor background, relationship history, portfolio fit, likely objections, tailored talking points, and follow-up suggestions.",
+    "Default to read-only prep; if writing notes, use additive CRM or Notion entries with source attribution and no overwrites.",
+    "For scheduled runs, skip events already briefed unless attendee, CRM, Gmail, or Notion context materially changed.",
+  ],
 });

--- a/apps/web/lib/skill-templates/investor-update-builder.ts
+++ b/apps/web/lib/skill-templates/investor-update-builder.ts
@@ -1,13 +1,91 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const investorUpdateBuilder = createSkillTemplate({
+export const investorUpdateBuilder = defineSkillTemplate({
   id: "investor-update-builder",
   title: "Investor Update Builder",
   summary: "Draft crisp investor updates from company context, asks, and metrics.",
   category: "Run Founder Ops",
   outcome: "Gathers wins, metrics, asks, risks, and narrative context into a polished investor update draft or send-ready email.",
+  userUseCase:
+    "Use when a founder needs a credible investor update assembled from metrics, customer progress, risks, asks, and prior investor context. It should create audience-specific drafts from trusted sources while keeping sensitive working notes private.",
   personas: ["Founder", "Investor/BD"],
   requiredApps: [externalApps.gmail, externalApps.notion, externalApps.hubspot],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["audience", "sections", "source docs", "send policy"],
+  autonomy: "Creates drafts",
+  interviewQuestions: [
+    {
+      id: "update-audience",
+      prompt: "Who is this investor update for?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "current-investors", label: "Current investors" },
+        { id: "prospective-investors", label: "Prospective investors" },
+        { id: "advisors", label: "Advisors" },
+        { id: "board", label: "Board" },
+        { id: "internal-only", label: "Internal only" },
+      ],
+    },
+    {
+      id: "update-sections",
+      prompt: "Which sections should the update include?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "headline", label: "Headline" },
+        { id: "metrics", label: "Metrics" },
+        { id: "wins", label: "Wins" },
+        { id: "challenges", label: "Challenges" },
+        { id: "asks", label: "Asks" },
+        { id: "customer-proof", label: "Customer proof" },
+        { id: "runway", label: "Runway" },
+      ],
+    },
+    {
+      id: "source-priority",
+      prompt: "Which sources should the skill use for facts and metrics?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "files", label: "Files" },
+        { id: "notion", label: "Notion" },
+        { id: "crm", label: "Dench CRM" },
+        { id: "hubspot", label: "HubSpot" },
+        { id: "gmail-calendar", label: "Gmail/Calendar" },
+        { id: "manual-context", label: "Manual context" },
+      ],
+    },
+    {
+      id: "send-policy",
+      prompt: "How should the skill handle sending?",
+      required: true,
+      options: [
+        { id: "draft-only", label: "Draft only" },
+        { id: "approval-required", label: "Approval required" },
+        { id: "send-ready-copy", label: "Send-ready copy" },
+        { id: "manual-export", label: "Manual export" },
+      ],
+    },
+    {
+      id: "crm-write-policy",
+      prompt: "What investor CRM updates should be allowed?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "log-update", label: "Log update" },
+        { id: "create-followups", label: "Create follow-ups" },
+        { id: "tag-audience", label: "Tag audience" },
+        { id: "no-write", label: "No writes" },
+      ],
+    },
+  ],
+  skillInstructions: [
+    "Use files, Notion, Dench CRM, HubSpot, Gmail, Calendar, and manual context only as configured sources for metrics, wins, risks, asks, and prior investor commitments.",
+    "Separate facts from narrative; cite the source for every metric, customer proof point, runway claim, hiring update, and investor ask that influences the draft.",
+    "Create audience-specific versions such as private founder notes, current-investor update, prospective-investor version, board-safe version, and follow-up task list.",
+    "Follow the send and CRM write policies exactly: default to drafts, log updates only when approved, use additive notes with attribution, and never overwrite investor relationship fields without permission.",
+    "Alert the founder when required metrics are missing, asks are vague, sensitive claims lack support, or an investor-specific follow-up should be handled separately.",
+    "For scheduled preparation, key drafts, source windows, logged updates, and follow-up tasks to the update period so repeated runs update the same artifact instead of creating duplicates.",
+    "Use a founder voice that is clear, candid, optimistic without hype, specific about asks, and honest about risks and unknowns.",
+  ],
 });

--- a/apps/web/lib/skill-templates/linkedin-style-outreach.ts
+++ b/apps/web/lib/skill-templates/linkedin-style-outreach.ts
@@ -1,13 +1,78 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const linkedinStyleOutreach = createSkillTemplate({
+export const linkedinStyleOutreach = defineSkillTemplate({
   id: "linkedin-style-outreach",
   title: "LinkedIn-style Outreach",
   summary: "Create concise social-style outreach and follow-ups with strict automation rules.",
   category: "Follow Up",
   outcome: "Researches prospects, writes short LinkedIn-style messages, manages follow-up sequencing, and logs outreach state.",
+  userUseCase: "Use this when a founder, seller, recruiter, or BD owner has people or accounts to contact and wants concise LinkedIn-style outreach that feels researched without being creepy. The skill should turn CRM lists, uploaded files, saved searches, or manual names into short messages, follow-up plans, and logged outreach state.",
   personas: ["Founder", "Sales", "Recruiter"],
   requiredApps: [externalApps.linkedin],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["audience source", "channel constraints", "message style", "automation caps"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "audience-source",
+      prompt: "Where should the outreach audience come from?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "crm-list", label: "CRM list" },
+        { id: "uploaded-file", label: "Uploaded file" },
+        { id: "manual-names", label: "Manual names" },
+        { id: "search-criteria", label: "Search criteria" },
+      ],
+      freeformHint: "Include list names, filters, file names, or exact prospect criteria.",
+    },
+    {
+      id: "outreach-goal",
+      prompt: "What should the message try to accomplish?",
+      required: true,
+      options: [
+        { id: "book-meeting", label: "Book a meeting" },
+        { id: "start-conversation", label: "Start a conversation" },
+        { id: "recruit-candidate", label: "Recruit candidate" },
+        { id: "partner-intro", label: "Partner intro" },
+        { id: "investor-bd", label: "Investor or BD" },
+      ],
+    },
+    {
+      id: "message-style",
+      prompt: "What style should the outreach use?",
+      required: true,
+      options: [
+        { id: "very-short", label: "Very short" },
+        { id: "warm-specific", label: "Warm and specific" },
+        { id: "direct-business", label: "Direct business" },
+        { id: "curious-peer", label: "Curious peer" },
+      ],
+      freeformHint: "Mention phrases to use or avoid.",
+    },
+    {
+      id: "send-policy",
+      prompt: "Should DenchClaw draft messages only, or send when rules are met?",
+      required: true,
+      options: [
+        { id: "draft-only", label: "Draft only" },
+        { id: "send-after-review", label: "Send after review" },
+        { id: "auto-send-allowlist", label: "Auto-send allowlist" },
+      ],
+      freeformHint: "If auto-sending is allowed, specify allowed lists, daily caps, quiet hours, and exclusions.",
+    },
+    {
+      id: "follow-up-guardrails",
+      prompt: "What follow-up limits and stop conditions should apply?",
+      required: true,
+      freeformHint: "Include max follow-ups, spacing, reply or connection-accepted detection, CRM stage changes, and do-not-contact rules.",
+    },
+  ],
+  skillInstructions: [
+    "Accept prospects from Dench CRM records, enrichment results, uploaded files, pasted names, or manual search criteria; use LinkedIn only when connected and useful for profile context.",
+    "For each prospect, research lightweight public and CRM context that supports a specific opening line: role, company, recent change, mutual context, hiring/funding/news signal, or stated interest.",
+    "Write concise LinkedIn-style messages with one clear CTA, no fabricated familiarity, no over-personalized claims, and no sensitive personal data unless the user explicitly provided it.",
+    "Respect the selected send policy: draft by default; send only when the prospect matches explicit allowlists, daily caps, duplicate checks, quiet hours, and channel constraints.",
+    "For scheduled runs, use idempotency checks against CRM notes, prior Dench runs, and connected app history so the same prospect is not messaged twice for the same campaign.",
+    "Stop outreach when a reply, accepted connection plus response, meeting booked, disqualifying CRM stage, do-not-contact flag, blocked signal, or owner override is detected.",
+  ],
 });

--- a/apps/web/lib/skill-templates/lookalike-customer-finder.ts
+++ b/apps/web/lib/skill-templates/lookalike-customer-finder.ts
@@ -1,13 +1,75 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const lookalikeCustomerFinder = createSkillTemplate({
+export const lookalikeCustomerFinder = defineSkillTemplate({
   id: "lookalike-customer-finder",
   title: "Lookalike Customer Finder",
   summary: "Use best customers as seeds to find companies that look and behave like them.",
   category: "Find Leads",
   outcome: "Analyzes customer seeds, extracts fit patterns, discovers lookalike accounts, and creates a ranked prospect list.",
+  userUseCase: "Use this when a founder, sales team, or RevOps owner has a set of great customers and wants DenchClaw to discover net-new accounts with similar firmographics, buying triggers, and use-case patterns. The skill should compare Dench CRM and HubSpot customer context, native enrichment, files, and web research to produce a defensible prospect list rather than a loose 'companies like these' dump.",
   personas: ["Founder", "Sales", "RevOps"],
   requiredApps: [externalApps.hubspot],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["seed customers", "match signals", "output size", "dedupe policy"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "seed-customers",
+      prompt: "Which customers should be used as the lookalike seed set?",
+      required: true,
+      freeformHint: "Paste company names/domains or reference a CRM segment, HubSpot list, saved view, or uploaded file.",
+    },
+    {
+      id: "success-traits",
+      prompt: "What makes these customers worth copying?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "high-acv", label: "High ACV" },
+        { id: "fast-sales-cycle", label: "Fast sales cycle" },
+        { id: "strong-retention", label: "Strong retention" },
+        { id: "expansion", label: "Expansion potential" },
+        { id: "strategic-logo", label: "Strategic logo" },
+      ],
+    },
+    {
+      id: "similarity-dimensions",
+      prompt: "Which similarity dimensions matter most?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "industry", label: "Industry" },
+        { id: "company-size", label: "Company size" },
+        { id: "growth-rate", label: "Growth rate" },
+        { id: "tech-stack", label: "Tech stack" },
+        { id: "buyer-team", label: "Buyer team" },
+        { id: "use-case", label: "Use case" },
+      ],
+    },
+    {
+      id: "blocked-matches",
+      prompt: "Which companies or categories should be excluded from the lookalike list?",
+      required: false,
+      freeformHint: "Example: current customers, competitors, non-US companies, accounts already in active opportunities.",
+    },
+    {
+      id: "result-goal",
+      prompt: "What should the final list optimize for?",
+      required: true,
+      options: [
+        { id: "closest-similarity", label: "Closest similarity" },
+        { id: "largest-market", label: "Largest market" },
+        { id: "fastest-outreach", label: "Fastest outreach" },
+        { id: "highest-intent", label: "Highest intent" },
+      ],
+    },
+  ],
+  skillInstructions: [
+    "Normalize seed customers from Dench CRM, HubSpot, uploaded files, or user-provided text, including company domains and customer status.",
+    "Derive shared traits across the seed set: firmographics, market category, buyer team, use case, buying trigger, retention or expansion signals, and observable operating patterns.",
+    "Search for non-customer accounts that match the selected similarity dimensions using Dench-native enrichment and web research.",
+    "Exclude current customers, blocked categories, duplicates, competitors, and accounts already in active opportunities unless explicitly included.",
+    "Rank each lookalike by similarity strength and explain which seed-customer traits it matches.",
+    "Return account recommendations with evidence, confidence, source links, CRM status, and suggested prospecting angle.",
+    "For scheduled refreshes, report only new or materially improved lookalikes since the prior run and avoid recreating records already written to CRM.",
+  ],
 });

--- a/apps/web/lib/skill-templates/lost-customer-winback.ts
+++ b/apps/web/lib/skill-templates/lost-customer-winback.ts
@@ -1,13 +1,81 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const lostCustomerWinback = createSkillTemplate({
+export const lostCustomerWinback = defineSkillTemplate({
   id: "lost-customer-winback",
   title: "Lost Customer Winback",
   summary: "Identify lost customers worth re-engaging and craft high-signal winback plays.",
   category: "Grow Customers",
   outcome: "Segments churned or closed-lost accounts, finds reactivation triggers, sends winback messages, and logs outcomes.",
+  userUseCase: "Use when a founder, CS lead, or sales owner wants to identify churned, dormant, or closed-lost customers worth re-engaging because something has changed: product improvements, new leadership, renewed pain, growth, or a still-warm relationship.",
   personas: ["Founder", "Customer Success", "Sales"],
   requiredApps: [externalApps.gmail, externalApps.hubspot],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["qualified lost accounts", "churn reasons", "new proof points", "contact rules"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "lost-customer-scope",
+      prompt: "Which lost accounts should this skill consider for winback?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "churned-customers", label: "Churned customers" },
+        { id: "closed-lost-opps", label: "Closed-lost opportunities" },
+        { id: "dormant-trials", label: "Dormant trials" },
+        { id: "inactive-free-users", label: "Inactive free users" },
+      ],
+      freeformHint: "Include lifecycle stages, date windows, exclusions, or minimum contract value.",
+    },
+    {
+      id: "winback-triggers",
+      prompt: "What makes a lost account worth re-engaging now?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "product-change", label: "Product change" },
+        { id: "new-leadership", label: "New leadership" },
+        { id: "funding-growth", label: "Funding or growth" },
+        { id: "renewed-need", label: "Renewed pain signal" },
+        { id: "warm-relationship", label: "Warm relationship" },
+      ],
+    },
+    {
+      id: "churn-context",
+      prompt: "Which churn, loss, or inactivity reasons should the agent respect before suggesting outreach?",
+      required: true,
+      freeformHint: "Mention pricing objections, missing features, bad fit, implementation issues, competitors, support history, or accounts that should never be contacted.",
+    },
+    {
+      id: "owner-approval",
+      prompt: "Who should approve or receive winback actions before any customer-facing message goes out?",
+      required: true,
+      options: [
+        { id: "account-owner", label: "Account owner" },
+        { id: "cs-owner", label: "CS owner" },
+        { id: "founder", label: "Founder" },
+        { id: "manual-review", label: "Review queue" },
+      ],
+    },
+    {
+      id: "output-policy",
+      prompt: "What should the skill create for each qualified winback account?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "owner-brief", label: "Owner brief" },
+        { id: "email-draft", label: "Email draft" },
+        { id: "crm-task", label: "CRM task" },
+        { id: "founder-digest", label: "Founder digest" },
+      ],
+      freeformHint: "Include send caps, quiet hours, approval rules, and CRM write permissions.",
+    },
+  ],
+  skillInstructions: [
+    "Use Dench CRM churn history, closed-lost notes, enrichment, web search, files, and connected Gmail or HubSpot context to understand why each account left before recommending re-engagement.",
+    "Prioritize accounts only when there is a credible reactivation reason tied to a product change, customer change, company signal, relationship warmth, or new offer.",
+    "Make scheduled runs idempotent by checking prior winback notes, tasks, draft messages, and recent outreach before creating anything new.",
+    "Follow the CRM write policy exactly: prefer additive notes with source links, timestamps, confidence, and rationale; never overwrite user-authored loss reasons or stages unless explicitly allowed.",
+    "Draft winback messages that acknowledge context lightly, avoid generic 'checking in' copy, and connect the account's old reason for leaving to a specific new reason to talk.",
+    "Alert the configured owner with the account, reactivation reason, risk caveats, and suggested next step before any customer-facing send unless explicit send rules allow automation.",
+    "Return audience-specific outputs: owner action briefs, founder-level pipeline impact summary, CRM-safe notes, and customer-facing drafts.",
+  ],
 });

--- a/apps/web/lib/skill-templates/market-map-builder.ts
+++ b/apps/web/lib/skill-templates/market-map-builder.ts
@@ -1,13 +1,83 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const marketMapBuilder = createSkillTemplate({
+export const marketMapBuilder = defineSkillTemplate({
   id: "market-map-builder",
   title: "Market Map Builder",
   summary: "Map a market into segments, players, signals, and open opportunities.",
   category: "Research Anything",
   outcome: "Builds and updates a market map with categories, companies, trends, funding, customer segments, and strategic takeaways.",
+  userUseCase: "Use this when a founder, investor, BD lead, or strategy operator needs a cited map of a market, category, or problem space. The skill should discover companies, segment them cleanly, capture evidence, and expose whitespace without forcing uncertain companies into tidy boxes.",
   personas: ["Founder", "Investor/BD", "Knowledge Worker"],
   requiredApps: [externalApps.notion],
   triggerModes: ["manual"],
-  focusAreas: ["market boundaries", "segmentation", "signals", "save location"],
+  autonomy: "Updates CRM",
+  interviewQuestions: [
+    {
+      id: "market-scope",
+      prompt: "What market, category, or problem space should be mapped?",
+      required: true,
+      freeformHint: "Describe the market, keywords, geographies, customer segments, or source documents.",
+    },
+    {
+      id: "map-goal",
+      prompt: "What decision should this market map support?",
+      required: true,
+      options: [
+        { id: "sales", label: "Find target accounts" },
+        { id: "strategy", label: "Understand landscape" },
+        { id: "partnerships", label: "Find partners" },
+        { id: "investment", label: "Evaluate targets" },
+        { id: "hiring", label: "Talent landscape" },
+      ],
+    },
+    {
+      id: "company-criteria",
+      prompt: "Which company attributes should be captured?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "size", label: "Size and stage" },
+        { id: "geo", label: "Geography" },
+        { id: "buyers", label: "Target buyers" },
+        { id: "funding", label: "Funding or ownership" },
+        { id: "positioning", label: "Positioning" },
+        { id: "signals", label: "Growth signals" },
+      ],
+    },
+    {
+      id: "source-policy",
+      prompt: "Which sources should be used and trusted most?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "web", label: "Public web" },
+        { id: "enrichment", label: "Native enrichment" },
+        { id: "crm", label: "Dench CRM" },
+        { id: "files", label: "Uploaded files" },
+        { id: "linkedin", label: "LinkedIn" },
+        { id: "notion-slack", label: "Notion or Slack" },
+      ],
+    },
+    {
+      id: "output-format",
+      prompt: "How should the map be delivered?",
+      required: true,
+      options: [
+        { id: "brief", label: "Research brief" },
+        { id: "table", label: "Structured table" },
+        { id: "notion-database", label: "Notion database" },
+        { id: "crm-list", label: "CRM list" },
+      ],
+      freeformHint: "Specify columns, grouping logic, ranking criteria, and destination.",
+    },
+  ],
+  skillInstructions: [
+    "Define the market boundaries before collecting companies, including what is intentionally out of scope.",
+    "Build the map from Dench CRM, native enrichment, web search, and supplied files; use connected Notion, Slack, Gmail, Calendar, or LinkedIn only when they add relevant context.",
+    "Cite each included company and material attribute with primary or reputable sources.",
+    "Assign companies to clear categories and explain ambiguous classifications instead of forcing weak fits.",
+    "Include confidence levels for company fit, market category, and important inferred attributes.",
+    "Deliver Market Definition, Category Taxonomy, Company Table, Segment Insights, Whitespace, Risks/Unknowns, and Sources.",
+    "If saving to CRM or Notion, write additive records with source attribution and avoid overwriting user-authored notes.",
+  ],
 });

--- a/apps/web/lib/skill-templates/meeting-prep-brief.ts
+++ b/apps/web/lib/skill-templates/meeting-prep-brief.ts
@@ -1,6 +1,6 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const meetingPrepBrief = createSkillTemplate({
+export const meetingPrepBrief = defineSkillTemplate({
   id: "meeting-prep-brief",
   title: "Meeting Prep Brief",
   summary: "Prepare concise briefs before sales, customer, partner, or recruiting calls.",
@@ -9,5 +9,77 @@ export const meetingPrepBrief = createSkillTemplate({
   personas: ["Founder", "Sales", "Customer Success", "Investor/BD"],
   requiredApps: [externalApps.googleCalendar, externalApps.gmail],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["meeting types", "research depth", "brief timing", "sensitive topics"],
+  autonomy: "Can automate",
+  userUseCase: "Use this before important external meetings so DenchClaw turns calendar, inbox, CRM, enrichment, and notes into a concise brief with context, risks, open asks, and suggested agenda.",
+  interviewQuestions: [
+    {
+      id: "meeting-types",
+      prompt: "Which meeting types should receive prep briefs?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "sales", label: "Sales" },
+        { id: "customer", label: "Customer" },
+        { id: "partner", label: "Partner" },
+        { id: "recruiting", label: "Recruiting" },
+        { id: "investor", label: "Investor" },
+      ],
+    },
+    {
+      id: "brief-sections",
+      prompt: "What should each brief include?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "attendees", label: "Attendee background" },
+        { id: "crm-history", label: "CRM history" },
+        { id: "recent-email", label: "Recent email" },
+        { id: "open-asks", label: "Open asks" },
+        { id: "risks", label: "Risks" },
+        { id: "agenda", label: "Agenda" },
+      ],
+    },
+    {
+      id: "prep-timing",
+      prompt: "When should briefs be generated before meetings?",
+      required: true,
+      options: [
+        { id: "15-minutes", label: "15 minutes before" },
+        { id: "one-hour", label: "1 hour before" },
+        { id: "morning-of", label: "Morning of" },
+        { id: "manual-only", label: "Manual only" },
+      ],
+      freeformHint: "Include timezone and calendar filters such as external-only or CRM contacts only.",
+    },
+    {
+      id: "destination",
+      prompt: "Where should the prep brief be delivered?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "dench-chat", label: "Dench chat" },
+        { id: "calendar-note", label: "Calendar note" },
+        { id: "gmail-draft", label: "Gmail draft" },
+        { id: "notion", label: "Notion" },
+      ],
+    },
+    {
+      id: "sensitive-policy",
+      prompt: "How should sensitive or low-confidence information be handled?",
+      required: true,
+      options: [
+        { id: "include-labeled", label: "Include with labels" },
+        { id: "private-section", label: "Private section" },
+        { id: "hide-sensitive", label: "Hide sensitive" },
+      ],
+    },
+  ],
+  skillInstructions: [
+    "Support manual prep for a selected meeting and scheduled prep for qualifying upcoming calendar events; do not assume calendar webhooks.",
+    "Use the calendar event as the anchor, then gather CRM, Gmail, HubSpot, Notion, enrichment, and file context relevant to attendees and accounts.",
+    "Produce a scannable brief with meeting goal, attendee context, relationship history, recent activity, open asks, risks, and suggested questions.",
+    "Label uncertain claims with confidence and keep sensitive private context in the configured section or out of the brief.",
+    "Do not write CRM or meeting notes unless configured; when writing, use additive notes with source attribution.",
+    "Make scheduled prep idempotent by skipping meetings already briefed unless important context changed.",
+  ],
 });

--- a/apps/web/lib/skill-templates/news-signal-digest.ts
+++ b/apps/web/lib/skill-templates/news-signal-digest.ts
@@ -1,13 +1,83 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const newsSignalDigest = createSkillTemplate({
+export const newsSignalDigest = defineSkillTemplate({
   id: "news-signal-digest",
   title: "News Signal Digest",
   summary: "Turn noisy news into a short digest of actionable signals.",
   category: "Research Anything",
   outcome: "Watches topics, companies, people, and markets, then posts relevant developments with context and next actions.",
+  userUseCase: "Use this when a founder, seller, investor, recruiter, or operator needs a manual or scheduled news digest that turns noisy public updates into cited account, market, customer, investor, or hiring signals.",
   personas: ["Founder", "Sales", "Investor/BD", "Knowledge Worker"],
   requiredApps: [externalApps.slack],
   triggerModes: ["scheduled", "manual"],
-  focusAreas: ["watch topics", "action threshold", "digest style", "task policy"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "digest-scope",
+      prompt: "What should the news digest cover?",
+      required: true,
+      options: [
+        { id: "accounts", label: "CRM accounts" },
+        { id: "customers", label: "Customers" },
+        { id: "industry", label: "Industry" },
+        { id: "investors", label: "Investors" },
+        { id: "hiring", label: "Hiring market" },
+      ],
+      freeformHint: "Name accounts, keywords, markets, saved CRM segments, or watchlists.",
+    },
+    {
+      id: "signal-types",
+      prompt: "Which news signals should be included?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "funding", label: "Funding or M&A" },
+        { id: "leadership", label: "Leadership changes" },
+        { id: "product", label: "Product launches" },
+        { id: "customer", label: "Customer wins/losses" },
+        { id: "risk", label: "Risk or layoffs" },
+        { id: "hiring", label: "Hiring growth" },
+      ],
+    },
+    {
+      id: "cadence",
+      prompt: "When should the news digest run, and should it be manual or scheduled?",
+      required: true,
+      options: [
+        { id: "manual", label: "Manual digest" },
+        { id: "daily-cron", label: "Daily cron" },
+        { id: "weekly-cron", label: "Weekly cron" },
+      ],
+    },
+    {
+      id: "source-quality",
+      prompt: "How strict should source quality be?",
+      required: true,
+      options: [
+        { id: "primary-only", label: "Primary only" },
+        { id: "trusted-news", label: "Trusted news" },
+        { id: "broad-scan", label: "Broad scan", description: "Include confidence labels" },
+      ],
+    },
+    {
+      id: "output-format",
+      prompt: "Where should the digest go and how should it read?",
+      required: true,
+      options: [
+        { id: "dench-note", label: "Dench note" },
+        { id: "slack", label: "Slack post" },
+        { id: "gmail", label: "Gmail draft" },
+        { id: "notion", label: "Notion page" },
+      ],
+      freeformHint: "Specify audience, max length, ranking rules, and whether to include recommended actions.",
+    },
+  ],
+  skillInstructions: [
+    "Use web search, Dench CRM records, enrichment, and files to identify relevant news; use connected Slack, Gmail, Notion, Calendar, or LinkedIn only when helpful.",
+    "Cite every news item with source name, title, URL or file reference, publication date, and retrieval date when available.",
+    "Rank items by relevance to the chosen scope, recency, credibility, and potential business impact.",
+    "Filter duplicate syndications, stale articles, SEO spam, and unsupported rumors unless rumor monitoring is explicitly requested.",
+    "Separate factual news from inferred implications and label confidence for every recommendation.",
+    "For scheduled digests, include only new or materially updated items since the prior run and say when no meaningful signal was found.",
+  ],
 });

--- a/apps/web/lib/skill-templates/no-show-recovery.ts
+++ b/apps/web/lib/skill-templates/no-show-recovery.ts
@@ -1,13 +1,82 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const noShowRecovery = createSkillTemplate({
+export const noShowRecovery = defineSkillTemplate({
   id: "no-show-recovery",
   title: "No-show Recovery",
   summary: "Recover missed meetings with fast, polite rescheduling and CRM notes.",
   category: "Follow Up",
   outcome: "Identifies no-shows, sends rescheduling notes, updates CRM/calendar context, and stops when a new meeting is booked.",
+  userUseCase:
+    "Use this when a prospect, customer, candidate, partner, or investor misses a scheduled meeting and the owner needs a fast, polite recovery path. The skill reviews calendar and CRM context, drafts a no-blame reschedule message, updates the record, and stops once the person replies or books a new time.",
   personas: ["Founder", "Sales", "Customer Success", "Recruiter"],
   requiredApps: [externalApps.gmail, externalApps.googleCalendar],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["meeting types", "follow-up timing", "reschedule options", "retry limits"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "meeting-source",
+      prompt: "How should DenchClaw identify no-shows?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "calendar-review", label: "Calendar review" },
+        { id: "crm-meeting-outcomes", label: "CRM outcomes" },
+        { id: "manual-trigger", label: "Manual trigger" },
+        { id: "uploaded-log", label: "Uploaded log" },
+      ],
+      freeformHint: "Include calendar names, CRM outcome values, or how you will invoke it manually.",
+    },
+    {
+      id: "meeting-types",
+      prompt: "Which meeting types should this recover?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "sales-discovery", label: "Sales discovery" },
+        { id: "demo", label: "Demo" },
+        { id: "customer-success", label: "Customer success" },
+        { id: "candidate-interview", label: "Candidate interview" },
+        { id: "investor-bd", label: "Investor or BD" },
+      ],
+    },
+    {
+      id: "first-touch-timing",
+      prompt: "When should the first no-show message be drafted or sent?",
+      required: true,
+      options: [
+        { id: "15-minutes", label: "15 minutes" },
+        { id: "1-hour", label: "1 hour" },
+        { id: "same-day", label: "Same day" },
+        { id: "next-business-day", label: "Next business day" },
+      ],
+      freeformHint: "Include quiet hours and whether timing differs by meeting type.",
+    },
+    {
+      id: "reschedule-cta",
+      prompt: "What rescheduling CTA should the recovery note use?",
+      required: true,
+      options: [
+        { id: "booking-link", label: "Booking link" },
+        { id: "offer-times", label: "Offer times" },
+        { id: "ask-for-times", label: "Ask for times" },
+        { id: "owner-review", label: "Owner review first" },
+      ],
+      freeformHint: "Provide booking links, calendar constraints, or preferred time windows.",
+    },
+    {
+      id: "retry-stop-rules",
+      prompt: "What retry limits, reply detection, and stop conditions should apply?",
+      required: true,
+      freeformHint: "Include max attempts, spacing, quiet hours, booked meeting detection, apology/reply handling, CRM outcome updates, and when to mark closed/no-response.",
+    },
+  ],
+  skillInstructions: [
+    "Identify likely no-shows from Calendar history, CRM meeting outcomes, uploaded logs, or manual input; verify attendance state during each manual or scheduled run instead of relying on webhooks.",
+    "Use meeting title, attendees, CRM record, prior thread, and notes/files to understand context before writing a recovery message.",
+    "Draft or send a fast, polite note that assumes positive intent, avoids blame, and offers the approved rescheduling path with minimal friction.",
+    "Apply different wording for sales, customer, recruiting, founder, and investor/BD meetings so the note fits the relationship and stakes.",
+    "Respect send guardrails including draft-vs-send mode, quiet hours, daily caps, booking-link rules, recipient exclusions, and duplicate prevention for the same missed meeting.",
+    "For scheduled runs, check Calendar, Gmail, and CRM activity before each follow-up so the skill stops once a new meeting is booked, the person replies, the owner intervenes, or the record changes stage.",
+    "Log the no-show, message sent or drafted, next retry date, and final outcome in CRM/calendar notes without overwriting existing user-authored context unless explicitly allowed.",
+  ],
 });

--- a/apps/web/lib/skill-templates/partner-pipeline-builder.ts
+++ b/apps/web/lib/skill-templates/partner-pipeline-builder.ts
@@ -1,13 +1,89 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const partnerPipelineBuilder = createSkillTemplate({
+export const partnerPipelineBuilder = defineSkillTemplate({
   id: "partner-pipeline-builder",
   title: "Partner Pipeline Builder",
   summary: "Build a partner pipeline with fit scoring, relationship paths, and next steps.",
   category: "Run Founder Ops",
   outcome: "Discovers potential partners, scores mutual value, identifies contacts and warm paths, and logs pipeline records.",
+  userUseCase: "Use when a founder, BD owner, or sales lead wants a manual or scheduled workflow to discover, enrich, score, and manage potential partners. The skill should build a pipeline around mutual value, relationship paths, and clear next actions rather than vague partnership wishlists.",
   personas: ["Founder", "Investor/BD", "Sales"],
   requiredApps: [externalApps.gmail, externalApps.hubspot],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["partner type", "mutual value", "relationship paths", "stage fields"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "partner-type",
+      prompt: "What type of partners should this pipeline focus on?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "channel", label: "Channel" },
+        { id: "integration", label: "Integration" },
+        { id: "agency", label: "Agency" },
+        { id: "strategic", label: "Strategic" },
+        { id: "community", label: "Community" },
+      ],
+    },
+    {
+      id: "mutual-value",
+      prompt: "What mutual value should the skill score for?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "shared-customers", label: "Shared customers" },
+        { id: "distribution", label: "Distribution" },
+        { id: "product-fit", label: "Product fit" },
+        { id: "co-marketing", label: "Co-marketing" },
+        { id: "revenue-potential", label: "Revenue potential" },
+      ],
+    },
+    {
+      id: "relationship-paths",
+      prompt: "Where should the skill look for relationship paths?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "crm", label: "Dench CRM" },
+        { id: "gmail", label: "Gmail" },
+        { id: "calendar", label: "Calendar" },
+        { id: "slack", label: "Slack" },
+        { id: "files-notion", label: "Files or Notion" },
+      ],
+    },
+    {
+      id: "crm-write-policy",
+      prompt: "How should partner pipeline records be handled?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "create-records", label: "Create records" },
+        { id: "add-notes", label: "Add notes" },
+        { id: "create-tasks", label: "Create tasks" },
+        { id: "suggest-stage", label: "Suggest stage" },
+        { id: "review-only", label: "Review only" },
+      ],
+    },
+    {
+      id: "audience-output",
+      prompt: "Which output views should be generated?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "founder-shortlist", label: "Founder shortlist" },
+        { id: "bd-action-list", label: "BD action list" },
+        { id: "crm-import", label: "CRM import" },
+        { id: "partner-brief", label: "Partner brief" },
+      ],
+    },
+  ],
+  skillInstructions: [
+    "Use Dench CRM, native enrichment, web search, and files to identify partner candidates and evidence; optionally use Gmail, Calendar, HubSpot, Notion, and Slack for prior relationship and account context.",
+    "Support manual builds and cron/scheduled refreshes only; do not assume partner form submissions, CRM webhooks, or event listeners.",
+    "Make runs idempotent by deduping companies, domains, contacts, existing partner records, and previously dismissed targets before creating notes or tasks.",
+    "Follow the CRM write policy: additive partner notes, source attribution, confidence, and owner tasks are preferred; do not overwrite stages, owners, or custom fields unless explicitly allowed.",
+    "Alert owners when a partner has a strong warm path, material mutual value, overlapping customer signal, or a next step that should not wait for the next digest.",
+    "Produce audience-specific outputs: founder strategic shortlist, BD owner action queue, CRM import or update plan, and partner-facing brief or intro draft.",
+    "Use a founder-ops tone: pragmatic, commercially grounded, concise, and skeptical of partnerships without a clear next step or measurable upside.",
+  ],
 });

--- a/apps/web/lib/skill-templates/pipeline-hygiene-digest.ts
+++ b/apps/web/lib/skill-templates/pipeline-hygiene-digest.ts
@@ -1,13 +1,83 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const pipelineHygieneDigest = createSkillTemplate({
+export const pipelineHygieneDigest = defineSkillTemplate({
   id: "pipeline-hygiene-digest",
   title: "Pipeline Hygiene Digest",
   summary: "Send a digest of stale deals, missing next steps, and risky CRM gaps.",
   category: "Keep CRM Clean",
   outcome: "Audits pipeline records, surfaces the highest-impact hygiene issues, and posts action-oriented cleanup recommendations.",
+  userUseCase: "Use this before forecast reviews or on a recurring schedule to audit Dench CRM and HubSpot pipeline data for stale deals, missing next steps, bad close dates, weak attribution, and owner-specific cleanup work.",
   personas: ["Founder", "Sales", "RevOps"],
   requiredApps: [externalApps.hubspot, externalApps.slack],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["pipeline stages", "stale thresholds", "digest destination", "write permissions"],
+  autonomy: "Updates CRM",
+  interviewQuestions: [
+    {
+      id: "pipeline-scope",
+      prompt: "Which pipeline records should be audited?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "all-open-pipeline", label: "All open pipeline" },
+        { id: "owned-deals", label: "Deals I own" },
+        { id: "forecast-period", label: "Current forecast" },
+        { id: "late-stage", label: "Late stage" },
+        { id: "named-view", label: "Named CRM view" },
+      ],
+      freeformHint: "Name the Dench CRM view, HubSpot pipeline, owners, stages, or forecast period.",
+    },
+    {
+      id: "hygiene-checks",
+      prompt: "Which hygiene problems should the digest flag?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "stale-next-step", label: "Stale next step" },
+        { id: "bad-close-date", label: "Bad close date" },
+        { id: "missing-core-fields", label: "Missing fields" },
+        { id: "no-recent-activity", label: "No recent activity" },
+        { id: "missing-attribution", label: "Missing attribution" },
+        { id: "handoff-risk", label: "Handoff risk" },
+      ],
+    },
+    {
+      id: "stale-thresholds",
+      prompt: "What stale thresholds should apply by stage?",
+      required: true,
+      freeformHint: "Example: discovery 14 days, proposal 7 days, negotiation 3 days, missing next step always flagged.",
+    },
+    {
+      id: "write-policy",
+      prompt: "Should the skill only report issues, or write safe cleanup artifacts too?",
+      required: true,
+      options: [
+        { id: "digest-only", label: "Digest only" },
+        { id: "write-safe-fields", label: "Write hygiene fields" },
+        { id: "create-tasks", label: "Create owner tasks" },
+        { id: "review-before-write", label: "Review before write" },
+      ],
+    },
+    {
+      id: "delivery",
+      prompt: "When and where should the hygiene digest be delivered?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "slack", label: "Slack" },
+        { id: "gmail", label: "Gmail" },
+        { id: "dench-summary", label: "Dench summary" },
+        { id: "manual-only", label: "Manual only" },
+      ],
+      freeformHint: "Include cron cadence, timezone, recipients, and whether owners need separate sections.",
+    },
+  ],
+  skillInstructions: [
+    "Support manual audits and cron/scheduled digest runs only; do not rely on CRM deal-change webhooks.",
+    "Audit Dench CRM first and reconcile HubSpot fields when connected, preserving external record IDs and source attribution.",
+    "Flag each issue with severity, owner, affected field, evidence, recommended fix, and confidence.",
+    "Only write safe hygiene fields or owner tasks when configured; never overwrite amount, stage, owner, close date, or user-authored forecast notes without explicit approval.",
+    "Use configured stale thresholds by stage, and keep missing next step, missing attribution, and no recent activity as separate explainable findings.",
+    "Make scheduled digests idempotent by suppressing unchanged findings already reported within the configured window.",
+    "Deliver a concise digest with executive summary, owner sections, top risks, blocked writes, and low-confidence findings.",
+  ],
 });

--- a/apps/web/lib/skill-templates/post-meeting-follow-through.ts
+++ b/apps/web/lib/skill-templates/post-meeting-follow-through.ts
@@ -1,13 +1,88 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const postMeetingFollowThrough = createSkillTemplate({
+export const postMeetingFollowThrough = defineSkillTemplate({
   id: "post-meeting-follow-through",
   title: "Post-meeting Follow-through",
   summary: "Turn meeting notes into follow-ups, CRM updates, and owner-specific tasks.",
   category: "Prep Meetings",
   outcome: "Summarizes meeting outcomes, drafts or sends next-step emails, updates CRM, and creates scheduled reminders.",
+  userUseCase:
+    "Use this after meetings to turn Calendar events, Gmail threads, notes, Dench CRM records, HubSpot context, and Notion notes into follow-up drafts, CRM updates, tasks, and reminders. It should run manually after a selected meeting or on a cron schedule for recently completed meetings.",
   personas: ["Founder", "Sales", "Customer Success", "Recruiter"],
   requiredApps: [externalApps.googleCalendar, externalApps.gmail, externalApps.hubspot],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["meeting types", "notes source", "follow-up SLA", "CRM updates"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "meeting-scope",
+      prompt: "Which completed meetings should trigger follow-through?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "sales-calls", label: "Sales calls" },
+        { id: "customer-calls", label: "Customer calls" },
+        { id: "investor-meetings", label: "Investor meetings" },
+        { id: "recruiting-interviews", label: "Recruiting interviews" },
+        { id: "all-external", label: "All external meetings" },
+      ],
+    },
+    {
+      id: "notes-source",
+      prompt: "Where should meeting notes or outcomes come from?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "calendar-description", label: "Calendar description" },
+        { id: "gmail-thread", label: "Gmail thread" },
+        { id: "notion-notes", label: "Notion notes" },
+        { id: "dench-chat", label: "Dench chat" },
+        { id: "manual-summary", label: "Manual summary" },
+      ],
+    },
+    {
+      id: "followup-actions",
+      prompt: "What should the skill create after meetings?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "gmail-draft", label: "Gmail follow-up draft" },
+        { id: "crm-note", label: "CRM note" },
+        { id: "crm-task", label: "CRM task" },
+        { id: "hubspot-update", label: "HubSpot update" },
+        { id: "notion-action-items", label: "Notion action items" },
+      ],
+    },
+    {
+      id: "write-confidence",
+      prompt: "What confidence is required before writing CRM updates?",
+      required: true,
+      options: [
+        { id: "draft-review", label: "Draft for review" },
+        { id: "write-85", label: "Write 85%+ confidence" },
+        { id: "write-95", label: "Write 95%+ confidence" },
+      ],
+    },
+    {
+      id: "timing-destination",
+      prompt: "When and where should follow-through be delivered?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "immediately-after", label: "Immediately after" },
+        { id: "end-of-day", label: "End of day" },
+        { id: "next-morning", label: "Next morning" },
+        { id: "manual-only", label: "Manual only" },
+      ],
+      freeformHint: "Include cron cadence, timezone, destination, and expected follow-up SLA.",
+    },
+  ],
+  skillInstructions: [
+    "Support manual post-meeting runs and cron/scheduled scans of recently completed Calendar events only.",
+    "Use Calendar event details to identify attendees, then gather Gmail, Dench CRM, HubSpot, Notion, and manual notes as available.",
+    "Create follow-up drafts, CRM notes, tasks, and Notion actions only according to the configured action policy.",
+    "For CRM writes, use additive notes with source attribution, meeting date, attendees, confidence score, and linked source records.",
+    "Never overwrite existing CRM fields, deal stages, owners, or next steps unless the user explicitly configures that overwrite policy.",
+    "If meeting outcomes are ambiguous or below the confidence threshold, produce a review draft instead of writing updates automatically.",
+    "Deliver follow-through at the configured timing and destination, and make scheduled runs idempotent by skipping meetings already processed.",
+  ],
 });

--- a/apps/web/lib/skill-templates/prompt.ts
+++ b/apps/web/lib/skill-templates/prompt.ts
@@ -1,7 +1,29 @@
-import type { SkillTemplateDefinition } from "./types";
+import type {
+  SkillTemplateDefinition,
+  SkillTemplateInterviewQuestion,
+} from "./types";
 
 function bulletList(items: readonly string[]): string {
   return items.map((item) => `- ${item}`).join("\n");
+}
+
+function formatQuestion(question: SkillTemplateInterviewQuestion, index: number): string {
+  const required = question.required ? "required" : "optional";
+  const mode = question.allowMultiple ? "multi-select" : "single-answer";
+  const optionText = question.options?.length
+    ? ` Choices: ${question.options
+        .map((option) =>
+          option.description
+            ? `${option.label} (${option.id}) - ${option.description}`
+            : `${option.label} (${option.id})`,
+        )
+        .join("; ")}.`
+    : "";
+  const freeform = question.freeformHint
+    ? ` Freeform guidance: ${question.freeformHint}.`
+    : "";
+
+  return `${index + 1}. ${question.prompt} [id: ${question.id}; ${required}; ${mode}].${optionText}${freeform}`;
 }
 
 export function buildSkillTemplatePromptText(template: SkillTemplateDefinition): string {
@@ -20,6 +42,9 @@ This should become a durable DenchClaw skill, not a one-off chat. DenchClaw is m
 This template is mainly for these personas: ${personas}.
 
 Required external setup for this template: ${requiredApps}.
+
+Who this skill is for and when it should help:
+${template.userUseCase}
 
 The desired outcome is:
 ${template.outcome}
@@ -44,9 +69,11 @@ When the next question has clear choices, ask it with a Dench question card inst
 Set "allowMultiple": true only when more than one option can be selected. Add "optional": true only when skipping is genuinely acceptable. Keep option labels short and include descriptions only when they prevent ambiguity.
 
 Before writing the final SKILL.md, gather these specifics:
-${bulletList(template.interviewTopics)}
+${template.interviewQuestions.map(formatQuestion).join("\n")}
 
-When you have enough context, create a complete SKILL.md for this workflow. Do not assume a skill-creator helper exists; if no helper is available, create the skill directly at skills/<kebab-case-skill-name>/SKILL.md and add references under that folder when useful. The skill should include:
+Ask the questions in that order unless my answer makes a later question unnecessary. If a question lists choices, prefer a dench-question card with the provided IDs and labels so I can answer quickly. Still accept custom freeform detail when my situation does not fit the choices.
+
+When you have enough context, create a complete SKILL.md for this reusable skill. Do not assume a skill-creator helper exists; if no helper is available, create the skill directly at skills/<kebab-case-skill-name>/SKILL.md and add references under that folder when useful. The skill should include:
 ${bulletList(template.skillInstructions)}
 
 Automation policy:

--- a/apps/web/lib/skill-templates/proposal-chaser.ts
+++ b/apps/web/lib/skill-templates/proposal-chaser.ts
@@ -1,13 +1,81 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const proposalChaser = createSkillTemplate({
+export const proposalChaser = defineSkillTemplate({
   id: "proposal-chaser",
   title: "Proposal Chaser",
   summary: "Follow up on sent proposals without sounding desperate or repetitive.",
   category: "Follow Up",
   outcome: "Tracks sent proposals, detects stalled decisions, sends next-step nudges, and keeps forecast notes accurate.",
+  userUseCase: "Use when proposals, quotes, contracts, partnership terms, or fundraising materials have been sent and the owner needs polite follow-through. The skill should understand proposal status from CRM, sent email, files, and HubSpot context, then draft or send stage-appropriate nudges without inventing terms or pressure.",
   personas: ["Founder", "Sales", "Investor/BD"],
   requiredApps: [externalApps.gmail, externalApps.hubspot],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["proposal status source", "decision timeline", "escalation path", "forecast updates"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "proposal-source",
+      prompt: "Where should DenchClaw find proposals to chase?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "crm-deals", label: "CRM deals" },
+        { id: "hubspot-stage", label: "HubSpot stage" },
+        { id: "gmail-sent", label: "Gmail sent mail" },
+        { id: "uploaded-tracker", label: "Uploaded tracker" },
+        { id: "manual-list", label: "Manual list" },
+      ],
+    },
+    {
+      id: "proposal-types",
+      prompt: "What kinds of proposals should this handle?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "sales-proposal", label: "Sales proposal" },
+        { id: "services-sow", label: "Services SOW" },
+        { id: "partnership", label: "Partnership" },
+        { id: "investment-materials", label: "Investment materials" },
+        { id: "contract-redlines", label: "Contract or redlines" },
+      ],
+    },
+    {
+      id: "chase-timing",
+      prompt: "When should DenchClaw follow up after a proposal is sent?",
+      required: true,
+      options: [
+        { id: "2-business-days", label: "2 business days" },
+        { id: "5-business-days", label: "5 business days" },
+        { id: "1-week", label: "1 week" },
+        { id: "custom", label: "Custom" },
+      ],
+      freeformHint: "Include decision dates, procurement timelines, and whether weekends count.",
+    },
+    {
+      id: "escalation-path",
+      prompt: "How should follow-ups escalate if there is no answer?",
+      required: true,
+      options: [
+        { id: "gentle-only", label: "Gentle only" },
+        { id: "add-value", label: "Add useful context" },
+        { id: "ask-for-blocker", label: "Ask about blockers" },
+        { id: "breakup", label: "Close-the-loop note" },
+      ],
+      freeformHint: "Specify max attempts and whether to involve another stakeholder.",
+    },
+    {
+      id: "send-forecast-guardrails",
+      prompt: "What send, quiet-hour, reply-detection, and forecast update rules should apply?",
+      required: true,
+      freeformHint: "Include draft vs auto-send, caps, accepted/rejected proposal signals, stakeholder replies, meetings booked, and forecast fields to update.",
+    },
+  ],
+  skillInstructions: [
+    "Identify open proposals from CRM, HubSpot, sent email, uploaded trackers, or manual input, attaching proposal file, amount, owner, sent date, stakeholders, and next-step promise when available.",
+    "Classify each proposal by stage and urgency: waiting for first response, decision overdue, procurement or legal, verbal yes, stakeholder missing, or likely stalled.",
+    "Draft follow-ups that match the stage: confirm receipt, offer clarification, surface a useful detail, ask about blockers, propose a decision meeting, or send a polite close-the-loop note.",
+    "Do not invent proposal terms, pricing, deadlines, discounts, or legal claims; quote only from CRM fields, user-provided files, or the actual thread.",
+    "Send only under explicit rules with daily caps, quiet hours, recipient allowlists, and duplicate checks; otherwise create drafts and CRM tasks for owner review.",
+    "For scheduled runs, compare against Gmail and CRM activity plus prior Dench notes so the same proposal is not chased twice after a reply, meeting, or owner action.",
+    "Stop or hand off when a reply is detected, proposal is accepted or rejected, a meeting is booked, deal stage changes, procurement/legal owner takes over, contact opts out, or the user marks the opportunity paused.",
+  ],
 });

--- a/apps/web/lib/skill-templates/recruiting-outreach-builder.ts
+++ b/apps/web/lib/skill-templates/recruiting-outreach-builder.ts
@@ -1,13 +1,74 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const recruitingOutreachBuilder = createSkillTemplate({
+export const recruitingOutreachBuilder = defineSkillTemplate({
   id: "recruiting-outreach-builder",
   title: "Recruiting Outreach Builder",
   summary: "Create personalized candidate outreach with role-specific proof and guardrails.",
   category: "Hire People",
   outcome: "Researches candidates, drafts or sends role-specific messages, handles follow-ups, and logs candidate status.",
+  userUseCase: "Use Dench CRM, enrichment, web search, files, and optional LinkedIn/Gmail context to draft role-relevant recruiting outreach that feels researched without crossing privacy lines.",
   personas: ["Recruiter", "Founder"],
   requiredApps: [externalApps.gmail, externalApps.linkedin],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["role pitch", "candidate persona", "send caps", "follow-up cadence"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "candidate-or-segment",
+      prompt: "Who should the outreach target?",
+      required: true,
+      freeformHint: "Provide candidate names, records, LinkedIn URLs, a saved segment, or search criteria.",
+    },
+    {
+      id: "role-context",
+      prompt: "What role and value proposition should the message communicate?",
+      required: true,
+      freeformHint: "Paste role description, team context, must-haves, company pitch, approved compensation notes, and CTA.",
+    },
+    {
+      id: "personalization-sources",
+      prompt: "Which sources may be used for personalization?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "crm", label: "CRM records" },
+        { id: "enrichment", label: "Enrichment" },
+        { id: "files", label: "Resume or files" },
+        { id: "web", label: "Professional web" },
+        { id: "linkedin", label: "LinkedIn" },
+        { id: "gmail", label: "Prior Gmail" },
+      ],
+    },
+    {
+      id: "channel-style",
+      prompt: "Which channel and style should be drafted?",
+      required: true,
+      options: [
+        { id: "email", label: "Email draft" },
+        { id: "linkedin", label: "LinkedIn-style message" },
+        { id: "sequence", label: "Sequence" },
+        { id: "referral", label: "Referral ask" },
+      ],
+      freeformHint: "Specify tone, length, sender, CTA, and number of variants.",
+    },
+    {
+      id: "send-policy",
+      prompt: "Should the skill only draft, or may scheduled runs send to approved candidates?",
+      required: true,
+      options: [
+        { id: "draft-only", label: "Draft only" },
+        { id: "review-required", label: "Review required" },
+        { id: "approved-segment-send", label: "Approved segment send" },
+      ],
+      freeformHint: "Include daily caps, quiet hours, exclusions, and follow-up spacing.",
+    },
+  ],
+  skillInstructions: [
+    "Use only job-relevant, professional, public, candidate-provided, or authorized internal sources for personalization.",
+    "Do not personalize using protected-class or sensitive attributes, photos, family details, private social media, or demographic clues.",
+    "Draft concise outreach around concrete work evidence, role fit, team mission, and a clear CTA rather than generic flattery.",
+    "Cite personalization inputs in internal notes, but keep candidate-facing copy natural and non-creepy.",
+    "Send only under explicit approved-segment rules with caps, quiet hours, duplicate checks, and do-not-contact exclusions; otherwise create drafts.",
+    "For scheduled runs, generate outreach only for approved candidate records and skip anyone contacted recently or missing enough evidence.",
+    "Log draft/send status, evidence sources, next follow-up date, and stop conditions back to candidate records.",
+  ],
 });

--- a/apps/web/lib/skill-templates/relationship-strength-scorer.ts
+++ b/apps/web/lib/skill-templates/relationship-strength-scorer.ts
@@ -1,13 +1,85 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const relationshipStrengthScorer = createSkillTemplate({
+export const relationshipStrengthScorer = defineSkillTemplate({
   id: "relationship-strength-scorer",
   title: "Relationship Strength Scorer",
   summary: "Score relationships from recent emails, meetings, roles, and momentum.",
   category: "Keep CRM Clean",
   outcome: "Updates relationship strength, recency, confidence, and next-action fields across important contacts and accounts.",
+  userUseCase: "Use this when founders, sellers, investor-relations owners, or RevOps teams need Dench CRM relationship strength to reflect actual recent interaction instead of stale gut feel. The skill scores named accounts, investors, partners, customers, or open opportunities from Gmail, Calendar, CRM history, and enrichment context.",
   personas: ["Founder", "Sales", "Investor/BD", "RevOps"],
   requiredApps: [externalApps.gmail, externalApps.googleCalendar],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["scored segments", "signal weights", "score scale", "CRM fields"],
+  autonomy: "Updates CRM",
+  interviewQuestions: [
+    {
+      id: "scoring-scope",
+      prompt: "Which relationships should be scored?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "key-accounts", label: "Key accounts" },
+        { id: "open-opportunities", label: "Open opportunities" },
+        { id: "investors-partners", label: "Investors/partners" },
+        { id: "customer-contacts", label: "Customer contacts" },
+        { id: "named-list", label: "Named list" },
+      ],
+      freeformHint: "Name CRM views, owners, stages, account tiers, or specific companies.",
+    },
+    {
+      id: "signal-sources",
+      prompt: "Which interaction sources should contribute to the score?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "gmail", label: "Gmail", description: "Recency, reply balance, thread depth, unresolved asks." },
+        { id: "calendar", label: "Calendar", description: "Meetings, attendance, cancellations, next touch." },
+        { id: "dench-crm", label: "Dench CRM", description: "Native activities, tags, stage, owner, notes." },
+        { id: "enrichment", label: "Enrichment", description: "Role seniority, company importance, public context." },
+      ],
+    },
+    {
+      id: "score-scale",
+      prompt: "What score scale should the skill write or report?",
+      required: true,
+      options: [
+        { id: "one-to-five", label: "1-5" },
+        { id: "zero-to-one-hundred", label: "0-100" },
+        { id: "weak-warm-strong", label: "Weak/Warm/Strong" },
+        { id: "draft-only", label: "Draft only" },
+      ],
+    },
+    {
+      id: "confidence-policy",
+      prompt: "When should relationship scores update CRM automatically?",
+      required: true,
+      options: [
+        { id: "write-85", label: "85%+ confidence" },
+        { id: "write-90", label: "90%+ confidence" },
+        { id: "review-changes", label: "Review all changes" },
+      ],
+      freeformHint: "Mention fields to protect, who reviews conflicts, and how stale manual scores should be handled.",
+    },
+    {
+      id: "next-action-policy",
+      prompt: "What should happen when an important relationship is weak or stale?",
+      required: true,
+      options: [
+        { id: "crm-task", label: "Create CRM task" },
+        { id: "digest-recommendation", label: "Add to digest" },
+        { id: "gmail-draft", label: "Draft follow-up" },
+        { id: "score-only", label: "Score only" },
+      ],
+      freeformHint: "Include stale thresholds, destination, and daily or weekly schedule if needed.",
+    },
+  ],
+  skillInstructions: [
+    "Support manual scoring for selected records and scheduled scoring for configured CRM segments only.",
+    "Use Dench CRM as the relationship record, with Gmail, Calendar, and enrichment signals as attributed evidence sources.",
+    "Compute scores from recency, reply balance, meeting attendance, stakeholder seniority, account importance, sentiment, and unresolved asks according to the configured weights.",
+    "Write CRM scores only when confidence meets the selected threshold, including evidence, source attribution, calculation timestamp, and score rationale.",
+    "Do not overwrite a user-authored relationship score unless explicitly allowed; otherwise create a proposed score with conflict details.",
+    "For weak or stale high-value relationships, create only the configured next action type and include the manual invocation or cron schedule that produced it.",
+    "Report score changes, blocked overwrites, low-confidence records, and recommended follow-ups after every run.",
+  ],
 });

--- a/apps/web/lib/skill-templates/renewal-risk-digest.ts
+++ b/apps/web/lib/skill-templates/renewal-risk-digest.ts
@@ -1,13 +1,87 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const renewalRiskDigest = createSkillTemplate({
+export const renewalRiskDigest = defineSkillTemplate({
   id: "renewal-risk-digest",
   title: "Renewal Risk Digest",
   summary: "Surface upcoming renewals with risk signals and action plans.",
   category: "Grow Customers",
   outcome: "Reviews accounts approaching renewal, identifies risks and champions, drafts owner actions, and logs readiness notes.",
+  userUseCase: "Use this when a founder, sales leader, or customer success owner wants a scheduled or manual digest of renewals that need attention before the deadline. The skill turns CRM dates, relationship activity, support context, email threads, meetings, and account notes into risk levels and concrete save actions.",
   personas: ["Customer Success", "Sales", "Founder"],
   requiredApps: [externalApps.hubspot, externalApps.gmail, externalApps.slack],
   triggerModes: ["scheduled", "manual"],
-  focusAreas: ["renewal window", "risk signals", "champion signals", "digest cadence"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "renewal-window",
+      prompt: "Which renewal window should the digest monitor?",
+      required: true,
+      options: [
+        { id: "30-days", label: "Next 30 days" },
+        { id: "60-days", label: "Next 60 days" },
+        { id: "90-days", label: "Next 90 days" },
+        { id: "custom", label: "Custom window" },
+      ],
+      freeformHint: "Include renewal-date fields, contract types, and exclusions.",
+    },
+    {
+      id: "risk-signals",
+      prompt: "Which renewal risk signals should be prioritized?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "low-engagement", label: "Low engagement" },
+        { id: "unresolved-issues", label: "Unresolved issues" },
+        { id: "champion-change", label: "Champion change" },
+        { id: "pricing-pressure", label: "Pricing pressure" },
+        { id: "no-mutual-plan", label: "No mutual plan" },
+      ],
+    },
+    {
+      id: "digest-audience",
+      prompt: "Who should receive the renewal digest?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "account-owners", label: "Account owners" },
+        { id: "founder", label: "Founder" },
+        { id: "cs-lead", label: "CS lead" },
+        { id: "sales-lead", label: "Sales lead" },
+      ],
+    },
+    {
+      id: "crm-write-policy",
+      prompt: "What renewal-related CRM writes are allowed?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "readiness-note", label: "Renewal note" },
+        { id: "risk-field", label: "Risk field" },
+        { id: "owner-task", label: "Owner task" },
+        { id: "forecast-suggestion", label: "Forecast suggestion" },
+        { id: "read-only", label: "Read-only" },
+      ],
+    },
+    {
+      id: "owner-alert-rules",
+      prompt: "When should the skill alert an owner outside the regular digest?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "high-risk", label: "High risk" },
+        { id: "deadline-close", label: "Deadline close" },
+        { id: "missing-owner", label: "Missing owner" },
+        { id: "exec-needed", label: "Exec help needed" },
+      ],
+    },
+  ],
+  skillInstructions: [
+    "Read renewal dates, contract fields, account notes, relationship activity, support context, Gmail threads, Calendar meetings, and HubSpot data when connected.",
+    "Score risk with evidence for engagement, champion strength, unresolved issues, commercial pressure, missing mutual plan, and deadline proximity.",
+    "Make scheduled digests idempotent by keying findings to account, renewal period, risk reason, and run date; avoid duplicate owner tasks for unchanged risks.",
+    "Follow the CRM write policy exactly: add sourced readiness notes and tasks by default, include confidence and evidence, and ask before overwriting forecast or owner-authored risk fields.",
+    "Alert owners with account, renewal date, risk level, evidence, recommended save action, and explicit ask for founder or executive support when needed.",
+    "Produce audience-specific outputs: tactical owner action plan, founder revenue-at-risk summary, CS team digest, and CRM-safe renewal note.",
+    "Use a direct, numbers-aware tone that is honest about risk without dramatizing weak signals.",
+  ],
 });

--- a/apps/web/lib/skill-templates/stale-thread-follow-up-agent.ts
+++ b/apps/web/lib/skill-templates/stale-thread-follow-up-agent.ts
@@ -1,13 +1,81 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const staleThreadFollowUpAgent = createSkillTemplate({
+export const staleThreadFollowUpAgent = defineSkillTemplate({
   id: "stale-thread-follow-up-agent",
   title: "Stale Thread Follow-up Agent",
   summary: "Find valuable email threads that went quiet and revive them safely.",
   category: "Follow Up",
   outcome: "Scans stale conversations, ranks which deserve action, drafts or sends tasteful nudges, and updates CRM status.",
+  userUseCase:
+    "Use this when important conversations have gone quiet and you need DenchClaw to find the threads worth reviving, understand the last ask, draft a tasteful next step, and keep CRM state honest.",
   personas: ["Founder", "Sales", "Customer Success"],
   requiredApps: [externalApps.gmail, externalApps.hubspot],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["stale thresholds", "valuable threads", "tone and CTA", "reply detection"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "thread-sources",
+      prompt: "Where should DenchClaw look for stale conversations?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "gmail", label: "Gmail threads" },
+        { id: "crm-activities", label: "CRM activity" },
+        { id: "hubspot-deals", label: "HubSpot deals" },
+        { id: "uploaded-export", label: "Uploaded export" },
+      ],
+    },
+    {
+      id: "stale-definition",
+      prompt: "When should a thread count as stale?",
+      required: true,
+      options: [
+        { id: "3-days", label: "3 days" },
+        { id: "7-days", label: "7 days" },
+        { id: "14-days", label: "14 days" },
+        { id: "custom", label: "Custom" },
+      ],
+      freeformHint: "Say whether the clock starts from your last message, their last message, a proposal sent, a meeting held, or a CRM stage change.",
+    },
+    {
+      id: "valuable-thread-rules",
+      prompt: "Which stale threads are worth following up on?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "open-opportunities", label: "Open opportunities" },
+        { id: "recent-meetings", label: "Recent meetings" },
+        { id: "exec-contacts", label: "Executive contacts" },
+        { id: "customer-risk", label: "Customer risk" },
+        { id: "manual-priority", label: "Manual priority" },
+      ],
+      freeformHint: "Include exclusions like closed-lost, support-only, vendor, personal, or do-not-contact threads.",
+    },
+    {
+      id: "follow-up-tone",
+      prompt: "What kind of nudge should the skill write?",
+      required: true,
+      options: [
+        { id: "light-bump", label: "Light bump" },
+        { id: "useful-context", label: "Add useful context" },
+        { id: "deadline-check", label: "Deadline check" },
+        { id: "breakup-note", label: "Breakup note" },
+      ],
+    },
+    {
+      id: "send-and-stop-rules",
+      prompt: "What send, quiet-hour, reply-detection, and stop-condition rules should apply?",
+      required: true,
+      freeformHint: "Include draft vs send, max nudges per thread, quiet hours, reply detection, meeting booked, CRM stage changes, and do-not-contact handling.",
+    },
+  ],
+  skillInstructions: [
+    "Scan only the selected sources for stale conversations during manual or scheduled runs; do not rely on email webhooks or app callbacks.",
+    "Rank threads by business value using CRM stage, deal amount, account importance, relationship strength, recent meeting context, and owner priority.",
+    "Before drafting, summarize the thread history, last unanswered ask, likely next step, and CRM facts that change the recommendation.",
+    "Draft follow-ups that reference the real prior conversation, avoid guilt or pressure, and choose the lightest useful CTA for the thread state.",
+    "Send only when explicit rules allow it; otherwise create drafts or CRM tasks with the recommended send window.",
+    "For scheduled runs, check Gmail, CRM, HubSpot, and prior Dench notes to avoid duplicate nudges and skip threads already handled by a teammate.",
+    "Stop when a reply is detected, a meeting is booked, the CRM stage closes or disqualifies, the contact opts out, or the owner marks the thread done.",
+  ],
 });

--- a/apps/web/lib/skill-templates/talent-pipeline-hygiene.ts
+++ b/apps/web/lib/skill-templates/talent-pipeline-hygiene.ts
@@ -1,13 +1,80 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const talentPipelineHygiene = createSkillTemplate({
+export const talentPipelineHygiene = defineSkillTemplate({
   id: "talent-pipeline-hygiene",
   title: "Talent Pipeline Hygiene",
   summary: "Find stale candidates, missing feedback, and broken hiring handoffs.",
   category: "Hire People",
   outcome: "Audits candidate pipelines, surfaces stale or incomplete records, and produces owner-specific cleanup actions.",
+  userUseCase:
+    "Use this when recruiting or operations needs a clean view of candidate pipelines: stale stages, missing feedback, duplicate profiles, scheduling gaps, and process risks. The skill should use candidate CRM data, files, Calendar/Gmail context, and optional Slack/Notion notes while avoiding protected-class or privacy-sensitive analysis.",
   personas: ["Recruiter", "Operator"],
   requiredApps: [externalApps.notion, externalApps.slack],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["pipeline source", "stale rules", "digest destination", "write policy"],
+  autonomy: "Updates CRM",
+  interviewQuestions: [
+    {
+      id: "pipeline-scope",
+      prompt: "Which talent pipeline should be audited?",
+      required: true,
+      freeformHint: "Specify roles, departments, hiring stages, recruiters, date range, or saved Dench CRM views.",
+    },
+    {
+      id: "hygiene-checks",
+      prompt: "Which hygiene issues should be flagged?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "stale", label: "Stale candidates" },
+        { id: "missing-data", label: "Missing data" },
+        { id: "feedback", label: "Missing feedback" },
+        { id: "duplicates", label: "Duplicates" },
+        { id: "scheduling", label: "Scheduling gaps" },
+        { id: "compliance", label: "Process risk" },
+      ],
+    },
+    {
+      id: "source-context",
+      prompt: "Which systems should be checked?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "crm", label: "Dench CRM" },
+        { id: "files", label: "Files" },
+        { id: "gmail", label: "Gmail" },
+        { id: "calendar", label: "Calendar" },
+        { id: "slack-notion", label: "Slack/Notion" },
+      ],
+    },
+    {
+      id: "cadence",
+      prompt: "When should the hygiene audit run?",
+      required: true,
+      options: [
+        { id: "manual", label: "Manual audit" },
+        { id: "daily-cron", label: "Daily cron" },
+        { id: "weekly-cron", label: "Weekly cron" },
+      ],
+    },
+    {
+      id: "output-format",
+      prompt: "How should issues and actions be reported?",
+      required: true,
+      options: [
+        { id: "dench-tasks", label: "Dench tasks" },
+        { id: "slack-digest", label: "Slack digest" },
+        { id: "notion-table", label: "Notion table" },
+        { id: "gmail-summary", label: "Gmail summary" },
+      ],
+      freeformHint: "Specify owners, severity levels, and whether to group by role or recruiter.",
+    },
+  ],
+  skillInstructions: [
+    "Audit only authorized candidate and hiring records available through Dench CRM and connected systems.",
+    "Do not surface, infer, or act on protected-class or sensitive attributes; hygiene findings must be process-based and role-related.",
+    "Flag missing or stale operational fields such as owner, stage, next step, last contact, feedback, scheduled interview, or duplicate record.",
+    "Cite each issue with the relevant record, timestamp, Calendar event, Gmail thread, file, Slack thread, or Notion page when available.",
+    "Prioritize issues by candidate impact, hiring urgency, process risk, and age of inactivity.",
+    "For cron audits, report changes since the previous run and avoid repeatedly flagging acknowledged issues unless they become more urgent.",
+  ],
 });

--- a/apps/web/lib/skill-templates/target-account-list-builder.ts
+++ b/apps/web/lib/skill-templates/target-account-list-builder.ts
@@ -1,13 +1,76 @@
-import { createSkillTemplate } from "./create-template";
+import { defineSkillTemplate } from "./create-template";
 
-export const targetAccountListBuilder = createSkillTemplate({
+export const targetAccountListBuilder = defineSkillTemplate({
   id: "target-account-list-builder",
   title: "Target Account List Builder",
   summary: "Turn an ICP into a ranked account list with contacts, evidence, and next actions.",
   category: "Find Leads",
   outcome: "Discovers target companies, enriches contacts, scores fit, and writes a prioritized list into Dench CRM.",
+  userUseCase: "Use this when a founder or seller knows the market they want to attack but needs DenchClaw to turn that ICP into a clean, ranked account list with evidence, exclusions, owners, and CRM-ready next actions.",
   personas: ["Founder", "Sales"],
   requiredApps: [],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["ICP filters and exclusions", "lead sources", "ranking rubric", "CRM output fields"],
+  autonomy: "Updates CRM",
+  interviewQuestions: [
+    {
+      id: "market-scope",
+      prompt: "Which industries, geographies, company sizes, or business models define the account universe?",
+      required: true,
+      freeformHint: "Example: B2B SaaS in North America, 200-2000 employees, selling to revenue teams.",
+    },
+    {
+      id: "qualification-signals",
+      prompt: "Which signals should make an account a strong fit?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "headcount-growth", label: "Headcount growth" },
+        { id: "funding", label: "Recent funding" },
+        { id: "tech-stack", label: "Specific tools" },
+        { id: "new-exec", label: "New executive" },
+        { id: "job-postings", label: "Relevant hiring" },
+        { id: "market-expansion", label: "Market expansion" },
+      ],
+    },
+    {
+      id: "exclusions",
+      prompt: "Which accounts, industries, regions, or CRM stages should be excluded?",
+      required: false,
+      freeformHint: "Example: current customers, open opportunities, agencies, companies under 50 employees.",
+    },
+    {
+      id: "priority-model",
+      prompt: "How should accounts be ranked for sales action?",
+      required: true,
+      options: [
+        { id: "best-fit", label: "Best ICP fit" },
+        { id: "strongest-signal", label: "Strongest signal" },
+        { id: "largest-size", label: "Largest company" },
+        { id: "customer-similarity", label: "Customer similarity" },
+        { id: "fastest-growth", label: "Fastest growth" },
+      ],
+    },
+    {
+      id: "crm-output",
+      prompt: "Which CRM fields and handoff details should the final list include?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "fit-reason", label: "Fit reason" },
+        { id: "signal-evidence", label: "Signal evidence" },
+        { id: "priority-score", label: "Priority score" },
+        { id: "owner", label: "Recommended owner" },
+        { id: "next-action", label: "Next action" },
+      ],
+    },
+  ],
+  skillInstructions: [
+    "Translate the user's ICP into concrete account search filters before gathering companies.",
+    "Use Dench CRM, native enrichment, web search, uploaded files, and workspace context to assemble candidate accounts.",
+    "Deduplicate against existing CRM accounts, customers, active opportunities, previous Dench runs, and user-provided exclusions.",
+    "Enrich each account with domain, industry, size, location, signals, source URLs, and confidence notes.",
+    "Score accounts with the selected priority model and explain the top ranking factors in plain language.",
+    "Write or propose CRM records additively with source attribution, not silent overwrites of user-authored fields.",
+    "Return a sales-ready account table with owners, next actions, blocked records, and any low-confidence matches separated for review.",
+  ],
 });

--- a/apps/web/lib/skill-templates/types.ts
+++ b/apps/web/lib/skill-templates/types.ts
@@ -81,17 +81,33 @@ export type SkillTemplateApp = {
   name: string;
 };
 
+export type SkillTemplateQuestionOption = {
+  id: string;
+  label: string;
+  description?: string;
+};
+
+export type SkillTemplateInterviewQuestion = {
+  id: string;
+  prompt: string;
+  required: boolean;
+  allowMultiple?: boolean;
+  options?: readonly SkillTemplateQuestionOption[];
+  freeformHint?: string;
+};
+
 export type SkillTemplate = {
   id: SkillTemplateId;
   title: string;
   summary: string;
   category: SkillTemplateCategory;
   outcome: string;
+  userUseCase: string;
   personas: readonly SkillTemplatePersona[];
   requiredApps: readonly SkillTemplateApp[];
   triggerModes: readonly SkillTemplateTriggerMode[];
   autonomy: SkillTemplateAutonomy;
-  interviewTopics: readonly string[];
+  interviewQuestions: readonly SkillTemplateInterviewQuestion[];
   skillInstructions: readonly string[];
   buildPrompt: () => string;
 };

--- a/apps/web/lib/skill-templates/warm-lead-nurture.ts
+++ b/apps/web/lib/skill-templates/warm-lead-nurture.ts
@@ -1,13 +1,85 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const warmLeadNurture = createSkillTemplate({
+export const warmLeadNurture = defineSkillTemplate({
   id: "warm-lead-nurture",
   title: "Warm Lead Nurture",
   summary: "Keep promising but not-ready leads warm with useful, low-pressure touches.",
   category: "Follow Up",
   outcome: "Segments warm leads, chooses relevant touchpoints, drafts or sends helpful check-ins, and logs future timing.",
+  userUseCase:
+    "Use this when leads are interested but not ready to buy, meet, invest, partner, or hire yet, and you want DenchClaw to keep them warm with useful, low-pressure touches. The skill should segment leads, find timely reasons to reach out, and maintain nurture state from manual runs or scheduled checks without relying on webhooks.",
   personas: ["Founder", "Sales"],
   requiredApps: [externalApps.gmail, externalApps.hubspot],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["warm lead definition", "nurture themes", "cadence", "conversion signals"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "warm-lead-source",
+      prompt: "Which warm leads should this nurture?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "crm-stage", label: "CRM stage" },
+        { id: "hubspot-list", label: "HubSpot list" },
+        { id: "uploaded-list", label: "Uploaded list" },
+        { id: "manual-selection", label: "Manual selection" },
+        { id: "saved-search", label: "Saved search" },
+      ],
+      freeformHint: "Name the list, stages, tags, owners, file, or saved segment.",
+    },
+    {
+      id: "nurture-reason",
+      prompt: "Why are these leads warm but not ready?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "bad-timing", label: "Bad timing" },
+        { id: "budget-later", label: "Budget later" },
+        { id: "needs-education", label: "Needs education" },
+        { id: "not-priority", label: "Not priority yet" },
+        { id: "relationship-building", label: "Relationship building" },
+      ],
+    },
+    {
+      id: "touchpoint-types",
+      prompt: "What kinds of nurture touches should DenchClaw use?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "helpful-resource", label: "Helpful resource" },
+        { id: "company-trigger", label: "Company trigger" },
+        { id: "product-update", label: "Product update" },
+        { id: "event-invite", label: "Event invite" },
+        { id: "simple-check-in", label: "Simple check-in" },
+      ],
+    },
+    {
+      id: "cadence",
+      prompt: "How often should each lead be touched?",
+      required: true,
+      options: [
+        { id: "monthly", label: "Monthly" },
+        { id: "quarterly", label: "Quarterly" },
+        { id: "signal-based", label: "Signal-based" },
+        { id: "custom", label: "Custom" },
+      ],
+      freeformHint: "Include quiet periods, max total touches, cooldowns, and when to pause.",
+    },
+    {
+      id: "conversion-stop-rules",
+      prompt: "What signals should convert, pause, or stop nurture?",
+      required: true,
+      freeformHint:
+        "Include replies, booked meetings, CRM stage changes, negative intent, unsubscribes, quiet hours, send caps, and owner overrides.",
+    },
+  ],
+  skillInstructions: [
+    "Build the nurture queue from Dench CRM, enriched company/contact data, uploaded files, or connected HubSpot lists, then segment leads by persona, account fit, reason for delay, and last meaningful interaction.",
+    "Use web search and enrichment to find timely but non-invasive context, such as company news, hiring, funding, product launches, role changes, or relevant content hooks.",
+    "Select the lowest-pressure useful touch for each lead, prioritizing relevance over frequency and avoiding generic check-ins when a better trigger exists.",
+    "Draft or send through the approved channel only under explicit send rules, including channel preference, daily caps, quiet hours, exclusions, and duplicate prevention.",
+    "For scheduled nurture, maintain per-lead state so cron runs do not restart the sequence, repeat the same asset, or contact leads inside their cooldown window.",
+    "Detect replies by checking connected inbox or CRM activity during each run; treat substantive replies, booked meetings, stage advancement, opt-outs, and owner pauses as stop or handoff conditions.",
+    "Log each touch, rationale, source links, next eligible date, and confidence notes back to CRM without overwriting user-authored fields unless explicitly allowed.",
+  ],
 });

--- a/apps/web/lib/skill-templates/website-visitor-follow-up.ts
+++ b/apps/web/lib/skill-templates/website-visitor-follow-up.ts
@@ -1,13 +1,80 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const websiteVisitorFollowUp = createSkillTemplate({
+export const websiteVisitorFollowUp = defineSkillTemplate({
   id: "website-visitor-follow-up",
   title: "Website Visitor Follow-up",
   summary: "Turn a pasted or synced visitor list into prioritized follow-up tasks and messages.",
   category: "Find Leads",
   outcome: "Accepts visitor or intent exports, matches accounts, prioritizes warm leads, drafts follow-ups, and logs next actions.",
+  userUseCase: "Turn a manual or scheduled website-visitor export into enriched account follow-up. The skill helps founders and sellers prioritize visitors by intent, match them to CRM records, research likely buyers, and create respectful follow-up actions without pretending DenchClaw has realtime site tracking.",
   personas: ["Founder", "Sales"],
   requiredApps: [externalApps.gmail],
   triggerModes: ["manual", "scheduled"],
-  focusAreas: ["visitor data source", "priority pages", "matching rules", "send policy"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "visitor-source",
+      prompt: "Where will website visitor or intent data come from?",
+      required: true,
+      options: [
+        { id: "uploaded-csv", label: "Uploaded CSV" },
+        { id: "analytics-export", label: "Analytics export" },
+        { id: "campaign-export", label: "Campaign export" },
+        { id: "pasted-list", label: "Pasted list" },
+      ],
+      freeformHint: "Name the export, file shape, and fields available such as domain, page path, visit time, or company name.",
+    },
+    {
+      id: "intent-pages",
+      prompt: "Which pages or behaviors should signal buying interest?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "pricing", label: "Pricing" },
+        { id: "demo", label: "Demo page" },
+        { id: "integrations", label: "Integrations" },
+        { id: "comparison", label: "Comparison page" },
+        { id: "repeat-visits", label: "Repeat visits" },
+      ],
+    },
+    {
+      id: "matching-policy",
+      prompt: "How should visitor records be matched to CRM accounts and contacts?",
+      required: true,
+      options: [
+        { id: "domain", label: "Company domain" },
+        { id: "email-domain", label: "Email domain" },
+        { id: "company-name", label: "Company name" },
+        { id: "export-company-id", label: "Export company ID" },
+      ],
+      freeformHint: "Mention whether fuzzy matches should be reviewed before use.",
+    },
+    {
+      id: "follow-up-output",
+      prompt: "What follow-up should the skill produce?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "hot-account-list", label: "Hot account list" },
+        { id: "buyer-research", label: "Buyer research" },
+        { id: "gmail-drafts", label: "Gmail drafts" },
+        { id: "crm-tasks", label: "CRM tasks" },
+      ],
+    },
+    {
+      id: "send-guardrails",
+      prompt: "What send rules, quiet hours, and stop conditions should apply?",
+      required: true,
+      freeformHint: "Include draft vs send, daily caps, owner approval, reply detection, recent outreach cooldown, and do-not-contact rules.",
+    },
+  ],
+  skillInstructions: [
+    "Use only manual uploads, pasted lists, or scheduled export files; do not assume website webhooks, event listeners, or realtime visitor callbacks exist.",
+    "Normalize visitor records by company, domain, visit date, source, page path, and identity fields before matching to Dench CRM.",
+    "Score intent using configured page behavior, recency, repeat visits, CRM status, relationship history, and account fit.",
+    "Enrich matched companies and likely buyers with Dench-native enrichment, CRM history, web search, and Gmail context when connected.",
+    "Draft follow-up that references observed account-level interest carefully without implying a specific private person visited unless the export proves it.",
+    "Respect send guardrails, quiet hours, duplicate checks, owner approval, and do-not-contact exclusions before creating or sending any message.",
+    "Log visitor evidence, match confidence, recommended action, and any drafts or tasks additively in CRM with source attribution.",
+  ],
 });

--- a/apps/web/lib/skill-templates/weekly-founder-digest.ts
+++ b/apps/web/lib/skill-templates/weekly-founder-digest.ts
@@ -1,13 +1,88 @@
-import { createSkillTemplate, externalApps } from "./create-template";
+import { defineSkillTemplate, externalApps } from "./create-template";
 
-export const weeklyFounderDigest = createSkillTemplate({
+export const weeklyFounderDigest = defineSkillTemplate({
   id: "weekly-founder-digest",
   title: "Weekly Founder Digest",
   summary: "Summarize the week across pipeline, customers, hiring, inbox, and priorities.",
   category: "Run Founder Ops",
   outcome: "Produces a weekly operating digest with wins, risks, asks, missed follow-ups, and priorities for the next week.",
+  userUseCase: "Use when a founder wants a manual or cron-scheduled weekly operating digest across customers, pipeline, fundraising, hiring, partner work, inbox, meetings, and unresolved commitments. The skill should turn scattered workspace activity into a crisp operating view, audience-specific summaries, and next-week priorities.",
   personas: ["Founder", "Operator"],
   requiredApps: [externalApps.gmail, externalApps.googleCalendar, externalApps.slack],
   triggerModes: ["scheduled", "manual"],
-  focusAreas: ["operating areas", "weekly schedule", "important people", "task policy"],
+  autonomy: "Can automate",
+  interviewQuestions: [
+    {
+      id: "digest-scope",
+      prompt: "Which operating areas should the weekly digest cover?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "sales-pipeline", label: "Sales pipeline" },
+        { id: "customers", label: "Customers" },
+        { id: "fundraising", label: "Fundraising" },
+        { id: "hiring", label: "Hiring" },
+        { id: "partners", label: "Partners" },
+        { id: "team-ops", label: "Team ops" },
+      ],
+    },
+    {
+      id: "delivery-cadence",
+      prompt: "When should the digest be generated?",
+      required: true,
+      options: [
+        { id: "friday-eod", label: "Friday EOD" },
+        { id: "sunday-evening", label: "Sunday evening" },
+        { id: "monday-morning", label: "Monday morning" },
+        { id: "manual-only", label: "Manual only" },
+      ],
+      freeformHint: "Include timezone, recipients, and whether to skip quiet weeks.",
+    },
+    {
+      id: "priority-rules",
+      prompt: "What is important enough to make the founder digest?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "revenue-impact", label: "Revenue impact" },
+        { id: "customer-risk", label: "Customer risk" },
+        { id: "investor-board", label: "Investor/board" },
+        { id: "blocked-commitments", label: "Blocked commitments" },
+        { id: "founder-mentioned", label: "Founder mentioned" },
+      ],
+    },
+    {
+      id: "audience-versions",
+      prompt: "Which audience versions should the skill prepare?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "private-founder", label: "Private founder" },
+        { id: "leadership-team", label: "Leadership team" },
+        { id: "board-safe", label: "Board-safe" },
+        { id: "assistant-task-list", label: "Task list" },
+      ],
+    },
+    {
+      id: "workspace-write-policy",
+      prompt: "What should the skill write back to CRM or workspace records?",
+      required: true,
+      allowMultiple: true,
+      options: [
+        { id: "no-write", label: "No writes" },
+        { id: "task-creation", label: "Create tasks" },
+        { id: "notes", label: "Add notes" },
+        { id: "status-suggestions", label: "Suggest status updates" },
+      ],
+    },
+  ],
+  skillInstructions: [
+    "Use Dench CRM, enrichment, web search, files, Gmail, Calendar, and Slack to extract meetings, commitments, decisions, asks, unresolved threads, and material business changes.",
+    "Support manual generation and cron-scheduled weekly digest messages only; do not rely on automatic app events.",
+    "Make each scheduled digest idempotent by recording the covered week, source windows, generated digest ID, and created task IDs.",
+    "Respect the workspace write policy: prefer additive tasks and notes with source attribution; never overwrite human-authored status fields without explicit approval.",
+    "Alert owners for urgent items discovered during the digest, including missing next steps, stalled commitments, customer risk, or founder follow-up needed.",
+    "Produce audience-specific versions: private founder memo, leadership-safe summary, board-safe excerpt, and concrete task list with owners and due dates.",
+    "Use a founder-ops tone: concise, opinionated, low-drama, commercially grounded, and focused on decisions, leverage, and follow-through.",
+  ],
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replaces generated skill-template seed content with hand-authored workflow definitions for all 38 templates.
- Adds explicit `userUseCase` and structured `interviewQuestions` metadata so prompts ask workflow-specific questions one at a time.
- Updates prompt generation, gallery search, exports, and quality tests to enforce the new hand-authored template contract.

## Verification
- Passed: static validation script confirmed all 38 template files include `userUseCase`, 4-5 interview questions, >=6 instructions, no old generated-template leftovers, and no Apollo required app references.
- Passed: `git diff --check`.
- Blocked: `pnpm exec vitest run lib/skill-templates.test.ts app/components/templates/skill-template-gallery.test.tsx` could not run because this machine has no `node` or `pnpm` installed (`node: command not found`, `pnpm: command not found`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8362b764-e389-4d8e-9b62-17d44f7bc638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8362b764-e389-4d8e-9b62-17d44f7bc638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

