### PR TITLE
fix(web): type onboarding skill template id as SkillTemplateId

### DIFF
--- a/apps/web/app/api/onboarding/skill-template/consume/route.test.ts
+++ b/apps/web/app/api/onboarding/skill-template/consume/route.test.ts
@@ -65,14 +65,14 @@ describe("skill template consume API", () => {
   });
 
   it("ignores invalid persisted template ids", async () => {
-    const state: OnboardingState = {
+    const state = {
       ...readOnboardingState(),
       currentStep: "complete",
       skillTemplate: {
         templateId: "unknown-template",
         selectedAt: "2026-04-15T00:00:00.000Z",
       },
-    };
+    } as OnboardingState;
     writeOnboardingState(state);
 
     const res = await POST();

--- a/apps/web/lib/denchclaw-state.ts
+++ b/apps/web/lib/denchclaw-state.ts
@@ -20,6 +20,13 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { resolveDenchClawDir } from "./workspace";
+import { SKILL_TEMPLATE_IDS, type SkillTemplateId } from "./skill-templates/types";
+
+function isValidSkillTemplateId(value: unknown): value is SkillTemplateId {
+  return (
+    typeof value === "string" && (SKILL_TEMPLATE_IDS as readonly string[]).includes(value)
+  );
+}
 
 // ---------------------------------------------------------------------------
 // File names
@@ -91,7 +98,7 @@ export type BackfillProgress = {
 };
 
 export type OnboardingSkillTemplate = {
-  templateId?: string;
+  templateId?: SkillTemplateId;
   selectedAt?: string;
   promptConsumedAt?: string;
 };
@@ -252,7 +259,7 @@ function sanitizeSkillTemplate(input: unknown): OnboardingSkillTemplate | undefi
   }
   const raw = input as Record<string, unknown>;
   const skillTemplate: OnboardingSkillTemplate = {};
-  if (typeof raw.templateId === "string") {
+  if (isValidSkillTemplateId(raw.templateId)) {
     skillTemplate.templateId = raw.templateId;
   }
   if (typeof raw.selectedAt === "string") {


### PR DESCRIPTION
Fixes Next.js build failure: `selectedTemplateId` expected `SkillTemplateId | undefined` but state exposed `string | undefined`.

- Type `OnboardingSkillTemplate.templateId` as `SkillTemplateId` and validate in `sanitizeSkillTemplate` using `SKILL_TEMPLATE_IDS`.
- Consume route test uses `as OnboardingState` for the invalid persisted-id fixture.

Verified: `pnpm --dir apps/web build` passes locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrows persisted onboarding state typing and adds allowlist validation for `skillTemplate.templateId`, which could only affect users with previously persisted invalid values (now ignored). Test-only adjustments reflect the stricter typing.
> 
> **Overview**
> Tightens onboarding state persistence by changing `OnboardingSkillTemplate.templateId` from `string` to `SkillTemplateId` and sanitizing persisted `skillTemplate.templateId` by validating it against `SKILL_TEMPLATE_IDS` (invalid IDs are dropped).
> 
> Updates the skill-template consume API test fixture to use a casted `OnboardingState` when intentionally persisting an invalid template id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5466a00ae8b21f68133b0e49bb0b29d014e18a69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->