### PR TITLE
feat(dench-cloud): implement tool provider policies and enhance confi…

### DIFF
--- a/apps/web/lib/agent-runner.ts
+++ b/apps/web/lib/agent-runner.ts
@@ -550,7 +550,7 @@ const MISSING_SCOPE_RE = /missing scope:\s*(\S+)/i;
  * missing or invalid.
  */
 export function enhanceScopeError(raw: string): string | null {
-	const match = MISSING_SCOPE_RE.exec(raw);
+	const match = raw.match(MISSING_SCOPE_RE);
 	if (!match) {
 		return null;
 	}

--- a/apps/web/lib/dench-cloud-settings.test.ts
+++ b/apps/web/lib/dench-cloud-settings.test.ts
@@ -96,6 +96,16 @@ const mocks = vi.hoisted(() => {
           "dench_search_integrations",
           "dench_execute_integrations",
         ],
+        byProvider: {
+          "dench-cloud": {
+            allow: [
+              "read",
+              "exec",
+              "dench_search_integrations",
+              "dench_execute_integrations",
+            ],
+          },
+        },
       },
     })),
     readConfiguredDenchCloudSettings: vi.fn(() => ({
@@ -271,6 +281,14 @@ describe("dench cloud settings", () => {
       "dench_execute_integrations",
       "dench_search_integrations",
     ]);
+    expect(written.tools.byProvider["dench-cloud"].allow).toEqual([
+      "dench_execute_integrations",
+      "dench_search_integrations",
+      "exec",
+      "read",
+    ]);
+    expect(written.tools.byProvider["dench-cloud"].profile).toBeUndefined();
+    expect(written.tools.byProvider["dench-cloud"].alsoAllow).toBeUndefined();
   });
 
   it("preserves unrelated auth profiles when saving the Dench Cloud API key", async () => {
@@ -348,6 +366,14 @@ describe("dench cloud settings", () => {
       "dench_execute_integrations",
       "dench_search_integrations",
     ]);
+    expect(written.tools.byProvider["dench-cloud"].allow).toEqual([
+      "dench_execute_integrations",
+      "dench_search_integrations",
+      "exec",
+      "read",
+    ]);
+    expect(written.tools.byProvider["dench-cloud"].profile).toBeUndefined();
+    expect(written.tools.byProvider["dench-cloud"].alsoAllow).toBeUndefined();
   });
 
   it("preserves a stored voiceId without re-enabling ElevenLabs during model changes", async () => {

--- a/apps/web/lib/dench-cloud-settings.ts
+++ b/apps/web/lib/dench-cloud-settings.ts
@@ -121,6 +121,58 @@ function syncAllowedTools(config: UnknownRecord, toolNames: string[]): void {
   tools.alsoAllow = Array.from(preserved).sort((left, right) => left.localeCompare(right));
 }
 
+function syncToolProviderPolicies(config: UnknownRecord, patchTools: UnknownRecord | undefined): void {
+  const patchByProvider = asRecord(patchTools?.byProvider);
+  if (!patchByProvider) {
+    return;
+  }
+
+  const tools = ensureRecord(config, "tools");
+  const byProvider = ensureRecord(tools, "byProvider");
+  for (const [providerId, rawProviderPatch] of Object.entries(patchByProvider)) {
+    const providerPatch = asRecord(rawProviderPatch);
+    if (!providerPatch) {
+      continue;
+    }
+
+    const providerPolicy = ensureRecord(byProvider, providerId);
+    const allow = readStringList(providerPatch.allow);
+    if (allow.length > 0) {
+      const preserved = new Set(
+        [...readStringList(providerPolicy.allow), ...readStringList(providerPolicy.alsoAllow)].filter(
+          (name) => !allow.includes(name),
+        ),
+      );
+      delete providerPolicy.alsoAllow;
+      for (const toolName of allow) {
+        preserved.add(toolName);
+      }
+      providerPolicy.allow = Array.from(preserved).sort((left, right) => left.localeCompare(right));
+    }
+
+    const alsoAllow = readStringList(providerPatch.alsoAllow);
+    if (alsoAllow.length > 0) {
+      const preserved = new Set(
+        [...readStringList(providerPolicy.alsoAllow), ...readStringList(providerPolicy.allow)].filter(
+          (name) => !alsoAllow.includes(name),
+        ),
+      );
+      delete providerPolicy.allow;
+      for (const toolName of alsoAllow) {
+        preserved.add(toolName);
+      }
+      providerPolicy.alsoAllow = Array.from(preserved).sort((left, right) => left.localeCompare(right));
+    }
+
+    const profile = readString(providerPatch.profile);
+    if (profile) {
+      providerPolicy.profile = profile;
+    } else if (allow.length > 0) {
+      delete providerPolicy.profile;
+    }
+  }
+}
+
 function readElevenLabsProvider(config: UnknownRecord): UnknownRecord | undefined {
   const tts = asRecord(asRecord(config.messages)?.tts);
   return asRecord(tts?.elevenlabs) ?? asRecord(asRecord(tts?.providers)?.elevenlabs);
@@ -430,6 +482,7 @@ export async function saveApiKey(
 
   const patchTools = asRecord((patch as UnknownRecord).tools);
   syncAllowedTools(config, readStringList(patchTools?.alsoAllow));
+  syncToolProviderPolicies(config, patchTools);
 
   writeConfig(config);
   if (options.syncAuthProfile !== false) {
@@ -497,6 +550,7 @@ export async function selectModel(stableId: string): Promise<CloudSettingsUpdate
 
   const patchTools = asRecord((patch as UnknownRecord).tools);
   syncAllowedTools(config, readStringList(patchTools?.alsoAllow));
+  syncToolProviderPolicies(config, patchTools);
 
   writeConfig(config);
 
@@ -595,6 +649,10 @@ export async function saveActiveCloudSettings(
         Object.assign(servers, patchServers);
       }
     }
+
+    const patchTools = asRecord((patch as UnknownRecord).tools);
+    syncAllowedTools(config, readStringList(patchTools?.alsoAllow));
+    syncToolProviderPolicies(config, patchTools);
 
     changed = true;
     requiresRefresh = true;

--- a/extensions/dench-ai-gateway/config-patch.ts
+++ b/extensions/dench-ai-gateway/config-patch.ts
@@ -24,6 +24,33 @@ const DENCH_COMPOSIO_WRAPPER_TOOLS = [
   "dench_search_integrations",
   "dench_execute_integrations",
 ] as const;
+const DENCH_CLOUD_TOOL_ALLOWLIST = [
+  "read",
+  "write",
+  "edit",
+  "apply_patch",
+  "exec",
+  "process",
+  "code_execution",
+  "web_fetch",
+  "x_search",
+  "memory_search",
+  "memory_get",
+  "sessions_list",
+  "sessions_history",
+  "sessions_send",
+  "sessions_spawn",
+  "sessions_yield",
+  "subagents",
+  "session_status",
+  "cron",
+  "update_plan",
+  "image",
+  "image_generate",
+  "music_generate",
+  "video_generate",
+  ...DENCH_COMPOSIO_WRAPPER_TOOLS,
+] as const;
 
 export function buildComposioMcpServerConfig(
   gatewayUrl: string,
@@ -81,6 +108,11 @@ export function buildDenchCloudConfigPatch(params: {
     },
     tools: {
       alsoAllow: [...DENCH_COMPOSIO_WRAPPER_TOOLS],
+      byProvider: {
+        "dench-cloud": {
+          allow: [...DENCH_CLOUD_TOOL_ALLOWLIST],
+        },
+      },
     },
   };
 }

--- a/src/cli/bootstrap-external.ts
+++ b/src/cli/bootstrap-external.ts
@@ -521,6 +521,48 @@ function mergeAllowedTools(existingTools: unknown, patchTools: unknown): string[
   return [...merged].sort((left, right) => left.localeCompare(right));
 }
 
+function mergeProviderToolPolicies(existingTools: unknown, patchTools: unknown): Record<string, unknown> {
+  const existingByProvider = asRecord(asRecord(existingTools)?.byProvider) ?? {};
+  const patchByProvider = asRecord(asRecord(patchTools)?.byProvider) ?? {};
+  const mergedByProvider: Record<string, unknown> = { ...existingByProvider };
+
+  for (const [providerId, rawPatchPolicy] of Object.entries(patchByProvider)) {
+    const patchPolicy = asRecord(rawPatchPolicy);
+    if (!patchPolicy) {
+      continue;
+    }
+
+    const existingPolicy = asRecord(mergedByProvider[providerId]) ?? {};
+    const nextPolicy: Record<string, unknown> = { ...existingPolicy };
+    const allow = uniqueStrings([
+      ...toStringArray(existingPolicy.allow),
+      ...toStringArray(existingPolicy.alsoAllow),
+      ...toStringArray(patchPolicy.allow),
+    ]).sort((left, right) => left.localeCompare(right));
+    const alsoAllow = uniqueStrings([
+      ...toStringArray(existingPolicy.alsoAllow),
+      ...toStringArray(existingPolicy.allow),
+      ...toStringArray(patchPolicy.alsoAllow),
+    ]).sort((left, right) => left.localeCompare(right));
+
+    if (allow.length > 0) {
+      delete nextPolicy.alsoAllow;
+      nextPolicy.allow = allow;
+    } else if (alsoAllow.length > 0) {
+      delete nextPolicy.allow;
+      nextPolicy.alsoAllow = alsoAllow;
+    }
+    if (typeof patchPolicy.profile === "string" && patchPolicy.profile.trim()) {
+      nextPolicy.profile = patchPolicy.profile.trim();
+    } else if (allow.length > 0) {
+      delete nextPolicy.profile;
+    }
+    mergedByProvider[providerId] = nextPolicy;
+  }
+
+  return mergedByProvider;
+}
+
 function toFiniteNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
@@ -2814,6 +2856,10 @@ function preStageDenchCloudConfig(params: {
       nextConfig.tools,
       (configPatch as Record<string, unknown>).tools,
     );
+    tools.byProvider = mergeProviderToolPolicies(
+      nextConfig.tools,
+      (configPatch as Record<string, unknown>).tools,
+    );
     delete tools.allow;
     nextConfig.tools = tools;
 
@@ -3041,6 +3087,18 @@ async function applyDenchCloudBootstrapConfig(params: {
       errorMessage: "Failed to enable Dench Integrations wrapper tools.",
     });
   }
+
+  const nextByProvider = mergeProviderToolPolicies(
+    (raw as Record<string, unknown> | undefined)?.tools,
+    (configPatch as Record<string, unknown>).tools,
+  );
+  await setOpenClawConfigJson({
+    openclawCommand: params.openclawCommand,
+    profile: params.profile,
+    key: "tools.byProvider",
+    value: nextByProvider,
+    errorMessage: "Failed to scope Dench Cloud tool policy.",
+  });
 
   writeAuthProfileKey(params.stateDir, params.apiKey);
   return appliedTtsShape;

--- a/src/cli/dench-cloud.test.ts
+++ b/src/cli/dench-cloud.test.ts
@@ -155,6 +155,10 @@ describe("dench-cloud helpers", () => {
       "dench_search_integrations",
       "dench_execute_integrations",
     ]);
+    expect(patch.tools.byProvider["dench-cloud"].allow).toContain("read");
+    expect(patch.tools.byProvider["dench-cloud"].allow).toContain("exec");
+    expect(patch.tools.byProvider["dench-cloud"].allow).toContain("dench_search_integrations");
+    expect(patch.tools.byProvider["dench-cloud"].allow).not.toContain("bundle-mcp");
   });
 
   it("keeps the runtime plugin patch in parity with the CLI/web helper", () => {

--- a/src/cli/dench-cloud.ts
+++ b/src/cli/dench-cloud.ts
@@ -132,6 +132,33 @@ export const DENCH_COMPOSIO_WRAPPER_TOOLS = [
   "dench_search_integrations",
   "dench_execute_integrations",
 ] as const;
+export const DENCH_CLOUD_TOOL_ALLOWLIST = [
+  "read",
+  "write",
+  "edit",
+  "apply_patch",
+  "exec",
+  "process",
+  "code_execution",
+  "web_fetch",
+  "x_search",
+  "memory_search",
+  "memory_get",
+  "sessions_list",
+  "sessions_history",
+  "sessions_send",
+  "sessions_spawn",
+  "sessions_yield",
+  "subagents",
+  "session_status",
+  "cron",
+  "update_plan",
+  "image",
+  "image_generate",
+  "music_generate",
+  "video_generate",
+  ...DENCH_COMPOSIO_WRAPPER_TOOLS,
+] as const;
 
 // Fallback list used only when the live gateway catalog is unreachable.
 // Live pricing always comes from the gateway's /v1/public/models response.
@@ -460,6 +487,11 @@ export function buildDenchCloudConfigPatch(params: {
     },
     tools: {
       alsoAllow: [...DENCH_COMPOSIO_WRAPPER_TOOLS],
+      byProvider: {
+        "dench-cloud": {
+          allow: [...DENCH_CLOUD_TOOL_ALLOWLIST],
+        },
+      },
     },
   };
 }


### PR DESCRIPTION
…guration management

- Refactored tool policy management to support provider-specific permissions.
- Added `syncToolProviderPolicies` function to handle tool permissions by provider.
- Updated tests to validate new provider policies for "dench-cloud".
- Introduced `DENCH_CLOUD_TOOL_ALLOWLIST` for consistent tool permissions across configurations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces provider-scoped tool permission merging/syncing across web, CLI bootstrap, and gateway config patches, which can change what tools agents are allowed to invoke and potentially break workflows if the allowlists are wrong. Low code-complexity otherwise, but it touches configuration/auth-adjacent behavior applied during bootstrap and settings saves.
> 
> **Overview**
> Adds **provider-specific tool policies** via `tools.byProvider`, and updates configuration writers to merge/sync these policies when saving Dench Cloud settings (web) or applying bootstrap patches (CLI).
> 
> Introduces a shared `DENCH_CLOUD_TOOL_ALLOWLIST` and updates both the CLI and `dench-ai-gateway` extension config patches to grant the Dench Cloud provider an explicit allowlist (while keeping the existing integrations wrapper tools under `tools.alsoAllow`).
> 
> Updates tests to assert `tools.byProvider["dench-cloud"].allow` behavior, and makes a small robustness tweak in `enhanceScopeError` by switching to `raw.match(...)` for missing-scope detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 118aa688eff035cfb1e75c7c0f7d8b1842c3b471. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->