### PR TITLE
Fix OpenClaw gateway compatibility and integration search fallbacks

### DIFF
--- a/apps/web/app/components/settings/cloud-settings-panel.tsx
+++ b/apps/web/app/components/settings/cloud-settings-panel.tsx
@@ -61,6 +61,20 @@ type ActionNotice = {
   message: string;
 };
 
+function isNetworkValidationError(message: string): boolean {
+  return message.startsWith("Could not reach Dench Cloud gateway");
+}
+
+function apiKeySubtitle(validationError?: string): string {
+  if (!validationError) {
+    return "Connect to Dench Cloud for AI model access.";
+  }
+  if (isNetworkValidationError(validationError)) {
+    return "Could not reach Dench Cloud. Check your connection and try again.";
+  }
+  return "Your API key is invalid. Enter a new one below.";
+}
+
 type IntegrationDraftState = Record<DenchIntegrationId, boolean>;
 
 const ENRICHMENT_WATERFALL_PROVIDERS = [
@@ -266,6 +280,8 @@ function ApiKeyEntry({
   validationError?: string;
 }) {
   const [keyInput, setKeyInput] = useState("");
+  const showValidationBanner =
+    Boolean(validationError) && (!notice || notice.message !== validationError);
 
   return (
     <div className="space-y-4">
@@ -284,9 +300,7 @@ function ApiKeyEntry({
             Dench Cloud
           </div>
           <div className="text-[11px] mt-0.5" style={{ color: "var(--color-text-muted)" }}>
-            {validationError
-              ? "Your API key is invalid. Enter a new one below."
-              : "Connect to Dench Cloud for AI model access."}
+            {apiKeySubtitle(validationError)}
           </div>
         </div>
         <a
@@ -300,7 +314,7 @@ function ApiKeyEntry({
         </a>
       </div>
 
-      {validationError && (
+      {showValidationBanner && (
         <div className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
           {validationError}
         </div>
@@ -679,6 +693,9 @@ export function CloudSettingsPanel() {
       });
       const payload = await res.json();
       if (!res.ok) {
+        if (payload.state) {
+          setData(payload.state);
+        }
         setNotice({
           tone: "error",
           message: payload.error ?? "Failed to save API key.",

--- a/apps/web/lib/agent-runner.test.ts
+++ b/apps/web/lib/agent-runner.test.ts
@@ -194,14 +194,14 @@ describe("agent-runner", () => {
 			expect(params.auth).toBeUndefined();
 		});
 
-		it("requests protocol version 3 (current Gateway protocol)", async () => {
+		it("requests protocol version 4 (current Gateway protocol)", async () => {
 			const { buildConnectParams } = await import("./agent-runner.js");
 			const params = buildConnectParams({ url: "ws://127.0.0.1:19001" }) as {
 				minProtocol: number;
 				maxProtocol: number;
 			};
-			expect(params.minProtocol).toBe(3);
-			expect(params.maxProtocol).toBe(3);
+			expect(params.minProtocol).toBe(4);
+			expect(params.maxProtocol).toBe(4);
 		});
 
 		it("requests all 5 operator scopes for full gateway access (prevents missing-scope 403s)", async () => {

--- a/apps/web/lib/agent-runner.ts
+++ b/apps/web/lib/agent-runner.ts
@@ -460,8 +460,8 @@ export function buildConnectParams(
 	}
 
 	return {
-		minProtocol: 3,
-		maxProtocol: 3,
+		minProtocol: 4,
+		maxProtocol: 4,
 		client: {
 			id: clientId,
 			version: "dev",

--- a/apps/web/lib/dench-cloud-settings.test.ts
+++ b/apps/web/lib/dench-cloud-settings.test.ts
@@ -340,8 +340,22 @@ describe("dench cloud settings", () => {
     const result = await saveApiKey("bad-key");
 
     expect(result.error).toBe("Invalid Dench Cloud API key.");
+    expect(mocks.validateDenchCloudApiKey).toHaveBeenCalledTimes(1);
     expect(mocks.state.authText).toBe(existingAuthProfile);
     expect(mocks.refreshIntegrationsRuntime).not.toHaveBeenCalled();
+  });
+
+  it("returns invalid-key state without re-validating when API key validation fails", async () => {
+    mocks.validateDenchCloudApiKey.mockRejectedValueOnce(
+      new Error("Could not reach Dench Cloud gateway at https://gateway.example.com/v1 (fetch failed)."),
+    );
+
+    const result = await saveApiKey("bad-key");
+
+    expect(mocks.validateDenchCloudApiKey).toHaveBeenCalledTimes(1);
+    expect(result.state.status).toBe("invalid_key");
+    expect(result.state.validationError).toContain("Could not reach Dench Cloud gateway");
+    expect(result.error).toContain("Could not reach Dench Cloud gateway");
   });
 
   it("refreshes integrations when switching the primary model to Dench Cloud", async () => {

--- a/apps/web/lib/dench-cloud-settings.ts
+++ b/apps/web/lib/dench-cloud-settings.ts
@@ -96,6 +96,35 @@ function resolvePrimaryModel(config: UnknownRecord): string | null {
   return typeof primary === "string" && primary.trim() ? primary.trim() : null;
 }
 
+function resolveApiKeySource(config: UnknownRecord): "config" | "env" | "missing" {
+  const models = asRecord(config.models);
+  const provider = asRecord(asRecord(models?.providers)?.["dench-cloud"]);
+  if (typeof provider?.apiKey === "string" && provider.apiKey.trim()) return "config";
+  if (process.env.DENCH_CLOUD_API_KEY?.trim() || process.env.DENCH_API_KEY?.trim()) return "env";
+  return "missing";
+}
+
+function buildInvalidKeySettingsState(
+  config: UnknownRecord,
+  validationError: string,
+): CloudSettingsState {
+  const primaryModel = resolvePrimaryModel(config);
+  const isDenchPrimary = Boolean(primaryModel?.startsWith("dench-cloud/"));
+  return {
+    status: "invalid_key",
+    apiKeySource: resolveApiKeySource(config),
+    gatewayUrl: resolveGatewayUrl(config),
+    primaryModel,
+    isDenchPrimary,
+    selectedDenchModel: null,
+    selectedVoiceId: readSelectedVoiceId(config),
+    elevenLabsEnabled: isElevenLabsEnabled(config),
+    models: [],
+    recommendedModelId: RECOMMENDED_DENCH_CLOUD_MODEL_ID,
+    validationError,
+  };
+}
+
 function ensureRecord(parent: UnknownRecord, key: string): UnknownRecord {
   const existing = asRecord(parent[key]);
   if (existing) return existing;
@@ -327,13 +356,7 @@ export async function getCloudVoiceState(): Promise<CloudVoiceState> {
   const selectedVoiceId = readSelectedVoiceId(config);
   const elevenLabsEnabled = isElevenLabsEnabled(config);
 
-  const apiKeySource: "config" | "env" | "missing" = (() => {
-    const models = asRecord(config.models);
-    const provider = asRecord(asRecord(models?.providers)?.["dench-cloud"]);
-    if (typeof provider?.apiKey === "string" && provider.apiKey.trim()) return "config";
-    if (process.env.DENCH_CLOUD_API_KEY?.trim() || process.env.DENCH_API_KEY?.trim()) return "env";
-    return "missing";
-  })();
+  const apiKeySource = resolveApiKeySource(config);
 
   if (!apiKey) {
     return {
@@ -434,11 +457,12 @@ export async function saveApiKey(
   try {
     await validateDenchCloudApiKey(gatewayUrl, apiKey);
   } catch (err) {
+    const validationError = err instanceof Error ? err.message : "API key validation failed.";
     return {
-      state: await getCloudSettingsState(),
+      state: buildInvalidKeySettingsState(config, validationError),
       changed: false,
       refresh: { attempted: false, restarted: false, error: null, profile: "default" },
-      error: err instanceof Error ? err.message : "API key validation failed.",
+      error: validationError,
     };
   }
 

--- a/extensions/apollo-enrichment/index.mjs
+++ b/extensions/apollo-enrichment/index.mjs
@@ -1,0 +1,294 @@
+// extensions/shared/dench-auth.ts
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+var DEFAULT_GATEWAY_URL = "https://gateway.merseoriginals.com";
+var AUTH_PROFILES_REL = path.join("agents", "main", "agent", "auth-profiles.json");
+function readDenchAuthProfileKey() {
+  const stateDir = process.env.OPENCLAW_STATE_DIR;
+  if (stateDir) {
+    const key = readKeyFromAuthProfiles(path.join(stateDir, AUTH_PROFILES_REL));
+    if (key) return key;
+  }
+  return envFallback();
+}
+function readKeyFromAuthProfiles(authPath) {
+  try {
+    if (!existsSync(authPath)) return void 0;
+    const raw = JSON.parse(readFileSync(authPath, "utf-8"));
+    const key = raw?.profiles?.["dench-cloud:default"]?.key;
+    return typeof key === "string" && key.trim() ? key.trim() : void 0;
+  } catch {
+    return void 0;
+  }
+}
+function envFallback() {
+  return process.env.DENCH_CLOUD_API_KEY?.trim() || process.env.DENCH_API_KEY?.trim() || void 0;
+}
+function resolveDenchGatewayUrl(pluginConfig) {
+  const configured = pluginConfig?.gatewayUrl;
+  if (typeof configured === "string" && configured.trim()) return configured.trim();
+  return process.env.DENCH_GATEWAY_URL?.trim() || DEFAULT_GATEWAY_URL;
+}
+
+// extensions/apollo-enrichment/index.ts
+var id = "apollo-enrichment";
+var ENRICHMENT_BASE_PATH = "/v1/enrichment";
+var APOLLO_ACTIONS = ["people", "company", "people_search"];
+var PEOPLE_DEFAULT_REQUIRED_FIELDS = [
+  "fullName",
+  "email",
+  "headline",
+  "linkedinID",
+  "URLs",
+  "phone",
+  "location"
+];
+var COMPANY_DEFAULT_REQUIRED_FIELDS = [
+  "name",
+  "website",
+  "industryList",
+  "linkedinID",
+  "totalFunding",
+  "founded"
+];
+function asRecord(value) {
+  return value && typeof value === "object" ? value : void 0;
+}
+function readTrimmedString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : void 0;
+}
+function readStringList(value) {
+  if (!Array.isArray(value)) {
+    return void 0;
+  }
+  const items = value.map((item) => readTrimmedString(item)).filter((item) => Boolean(item));
+  return items.length > 0 ? items : void 0;
+}
+function jsonResult(payload) {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    details: payload
+  };
+}
+var ApolloEnrichParameters = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    action: {
+      type: "string",
+      enum: [...APOLLO_ACTIONS],
+      description: 'Action to perform: "people", "company", or "people_search".'
+    },
+    email: { type: "string", description: "Email for people enrichment." },
+    linkedinUrl: { type: "string", description: "LinkedIn URL for people enrichment." },
+    firstName: { type: "string", description: "Person first name." },
+    lastName: { type: "string", description: "Person last name." },
+    domain: { type: "string", description: "Company domain such as acme.com." },
+    organizationName: {
+      type: "string",
+      description: "Organization name hint for people enrichment."
+    },
+    personTitles: {
+      type: "array",
+      items: { type: "string" },
+      description: "Job titles for people search."
+    },
+    personLocations: {
+      type: "array",
+      items: { type: "string" },
+      description: "Locations for people search."
+    },
+    organizationDomains: {
+      type: "array",
+      items: { type: "string" },
+      description: "Organization domains for people search."
+    },
+    page: { type: "number", description: "People search page number." },
+    perPage: { type: "number", description: "People search page size." },
+    first_name: { type: "string", description: "Legacy alias for firstName." },
+    last_name: { type: "string", description: "Legacy alias for lastName." },
+    organization_name: { type: "string", description: "Legacy alias for organizationName." },
+    linkedin_url: { type: "string", description: "Legacy alias for linkedinUrl." },
+    person_titles: {
+      type: "array",
+      items: { type: "string" },
+      description: "Legacy alias for personTitles."
+    },
+    person_locations: {
+      type: "array",
+      items: { type: "string" },
+      description: "Legacy alias for personLocations."
+    },
+    organization_domains: {
+      type: "array",
+      items: { type: "string" },
+      description: "Legacy alias for organizationDomains."
+    },
+    per_page: { type: "number", description: "Legacy alias for perPage." },
+    requiredFields: {
+      type: "array",
+      items: { type: "string" },
+      description: "Optional Dench gateway requiredFields contract. The waterfall stops as soon as every listed field is non-null on the merged record. Omit to use the canonical default for the action (people: name/email/headline/linkedin/URLs/phone/location; company: name/website/industry/linkedin/funding/founded). Never omit just to opt out \u2014 the gateway's no-list path is deprecated and Apollo rejects it."
+    },
+    required_fields: {
+      type: "array",
+      items: { type: "string" },
+      description: "Legacy alias for requiredFields."
+    }
+  },
+  required: ["action"]
+};
+function buildPeopleBody(params) {
+  const body = {};
+  const email = readTrimmedString(params.email);
+  const linkedinUrl = readTrimmedString(params.linkedinUrl) ?? readTrimmedString(params.linkedin_url);
+  const firstName = readTrimmedString(params.firstName) ?? readTrimmedString(params.first_name);
+  const lastName = readTrimmedString(params.lastName) ?? readTrimmedString(params.last_name);
+  const domain = readTrimmedString(params.domain);
+  const organizationName = readTrimmedString(params.organizationName) ?? readTrimmedString(params.organization_name);
+  if (email) {
+    body.email = email;
+  }
+  if (linkedinUrl) {
+    body.linkedin_url = linkedinUrl;
+  }
+  if (firstName) {
+    body.first_name = firstName;
+  }
+  if (lastName) {
+    body.last_name = lastName;
+  }
+  if (domain) {
+    body.domain = domain;
+  }
+  if (organizationName) {
+    body.organization_name = organizationName;
+  }
+  return body;
+}
+function buildPeopleSearchBody(params) {
+  const body = {};
+  const personTitles = readStringList(params.personTitles) ?? readStringList(params.person_titles);
+  const personLocations = readStringList(params.personLocations) ?? readStringList(params.person_locations);
+  const organizationDomains = readStringList(params.organizationDomains) ?? readStringList(params.organization_domains);
+  const page = typeof params.page === "number" ? params.page : void 0;
+  const perPage = typeof params.perPage === "number" ? params.perPage : typeof params.per_page === "number" ? params.per_page : void 0;
+  if (personTitles) {
+    body.person_titles = personTitles;
+  }
+  if (personLocations) {
+    body.person_locations = personLocations;
+  }
+  if (organizationDomains) {
+    body.organization_domains = organizationDomains;
+  }
+  if (page !== void 0) {
+    body.page = page;
+  }
+  if (perPage !== void 0) {
+    body.per_page = perPage;
+  }
+  return body;
+}
+async function parseResponse(response) {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    return response.json();
+  }
+  return response.text();
+}
+async function executeApolloEnrich(gatewayUrl, apiKey, _toolCallId, params) {
+  const action = params.action;
+  if (action !== "people" && action !== "company" && action !== "people_search") {
+    return jsonResult({
+      error: `Unknown action "${String(action)}". Use "people", "company", or "people_search".`
+    });
+  }
+  try {
+    let response;
+    const callerRequiredFields = readStringList(params.requiredFields) ?? readStringList(params.required_fields);
+    if (action === "people") {
+      const body = buildPeopleBody(params);
+      body.requiredFields = callerRequiredFields ?? PEOPLE_DEFAULT_REQUIRED_FIELDS;
+      if (!body.email && !body.linkedin_url && !body.first_name && !body.last_name) {
+        return jsonResult({
+          error: "People enrichment requires at least an email, LinkedIn URL, or person name."
+        });
+      }
+      response = await fetch(`${gatewayUrl}${ENRICHMENT_BASE_PATH}/people`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${apiKey}`
+        },
+        body: JSON.stringify(body)
+      });
+    } else if (action === "company") {
+      const domain = readTrimmedString(params.domain);
+      if (!domain) {
+        return jsonResult({ error: "Company enrichment requires a domain." });
+      }
+      const url = new URL(`${gatewayUrl}${ENRICHMENT_BASE_PATH}/company`);
+      url.searchParams.set("domain", domain);
+      const companyRequiredFields = callerRequiredFields ?? COMPANY_DEFAULT_REQUIRED_FIELDS;
+      url.searchParams.set("requiredFields", companyRequiredFields.join(","));
+      response = await fetch(url, {
+        method: "GET",
+        headers: {
+          authorization: `Bearer ${apiKey}`
+        }
+      });
+    } else {
+      const body = buildPeopleSearchBody(params);
+      response = await fetch(`${gatewayUrl}${ENRICHMENT_BASE_PATH}/people/search`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${apiKey}`
+        },
+        body: JSON.stringify(body)
+      });
+    }
+    if (!response.ok) {
+      const detail = await parseResponse(response).catch(() => "");
+      return jsonResult({
+        error: `Enrichment request failed (HTTP ${response.status}).`,
+        detail: detail || void 0
+      });
+    }
+    return jsonResult(await parseResponse(response));
+  } catch (err) {
+    return jsonResult({
+      error: "Enrichment request failed.",
+      detail: err instanceof Error ? err.message : String(err)
+    });
+  }
+}
+function register(api) {
+  const rootConfig = asRecord(api.config);
+  const pluginEntries = asRecord(asRecord(rootConfig?.plugins)?.entries);
+  const pluginConfig = asRecord(asRecord(pluginEntries?.[id])?.config);
+  if (pluginConfig?.enabled === false) {
+    return;
+  }
+  const gwPluginConfig = asRecord(asRecord(pluginEntries?.["dench-ai-gateway"])?.config);
+  const gatewayUrl = resolveDenchGatewayUrl(gwPluginConfig);
+  const apiKey = readDenchAuthProfileKey();
+  if (!apiKey) {
+    api.logger?.info?.(
+      "[apollo-enrichment] No Dench Cloud API key found; tool will not be registered."
+    );
+    return;
+  }
+  api.registerTool({
+    name: "apollo_enrich",
+    label: "Apollo Enrichment",
+    description: `Look up Apollo people, companies, or people search results through the Dench Cloud gateway. Use action "people" for an individual profile, "company" for company enrichment by domain, or "people_search" to search people with filters such as titles, locations, and company domains. For people and company, the tool always sends gateway requiredFields (defaults when omitted) so Apollo's removed mode field is never used. Prefer this tool over integration execute tools for the same structured enrichment from chat.`,
+    parameters: ApolloEnrichParameters,
+    execute: (toolCallId, params) => executeApolloEnrich(gatewayUrl, apiKey, toolCallId, params)
+  });
+}
+export {
+  register as default,
+  id
+};

--- a/extensions/apollo-enrichment/package.json
+++ b/extensions/apollo-enrichment/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./index.mjs"
     ]
   }
 }

--- a/extensions/dench-ai-gateway/composio-bridge.ts
+++ b/extensions/dench-ai-gateway/composio-bridge.ts
@@ -198,7 +198,10 @@ export function registerDenchIntegrationsBridge(api: any, fallbackGatewayUrl: st
     authorization: `Bearer ${apiKey}`,
   });
 
-  api.registerTool(tool);
+  api.registerTool(tool, {
+    name: DENCH_EXECUTE_INTEGRATIONS_NAME,
+    optional: true,
+  });
   api.logger?.info?.(
     `[dench-ai-gateway] registered ${DENCH_EXECUTE_INTEGRATIONS_NAME} bridge tool`,
   );

--- a/extensions/dench-ai-gateway/index.mjs
+++ b/extensions/dench-ai-gateway/index.mjs
@@ -921,12 +921,23 @@ async function fetchDenchCloudCatalog(gatewayUrl) {
     };
   }
 }
+var DENCH_CLOUD_API_KEY_VALIDATION_TIMEOUT_MS = 15e3;
 async function validateDenchCloudApiKey(gatewayUrl, apiKey) {
-  const response = await fetch(`${buildDenchGatewayApiBaseUrl(gatewayUrl)}/models`, {
-    headers: {
-      Authorization: `Bearer ${apiKey}`
-    }
-  });
+  const apiBaseUrl = buildDenchGatewayApiBaseUrl(gatewayUrl);
+  let response;
+  try {
+    response = await fetch(`${apiBaseUrl}/models`, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`
+      },
+      signal: AbortSignal.timeout(DENCH_CLOUD_API_KEY_VALIDATION_TIMEOUT_MS)
+    });
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Could not reach Dench Cloud gateway at ${apiBaseUrl} (${cause}). Check your network connection and gateway URL, then try again.`
+    );
+  }
   if (response.ok) {
     return;
   }

--- a/extensions/dench-ai-gateway/index.mjs
+++ b/extensions/dench-ai-gateway/index.mjs
@@ -1,0 +1,1117 @@
+// extensions/shared/dench-auth.ts
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+var AUTH_PROFILES_REL = path.join("agents", "main", "agent", "auth-profiles.json");
+function readDenchAuthProfileKey() {
+  const stateDir = process.env.OPENCLAW_STATE_DIR;
+  if (stateDir) {
+    const key = readKeyFromAuthProfiles(path.join(stateDir, AUTH_PROFILES_REL));
+    if (key) return key;
+  }
+  return envFallback();
+}
+function readKeyFromAuthProfiles(authPath) {
+  try {
+    if (!existsSync(authPath)) return void 0;
+    const raw = JSON.parse(readFileSync(authPath, "utf-8"));
+    const key = raw?.profiles?.["dench-cloud:default"]?.key;
+    return typeof key === "string" && key.trim() ? key.trim() : void 0;
+  } catch {
+    return void 0;
+  }
+}
+function envFallback() {
+  return process.env.DENCH_CLOUD_API_KEY?.trim() || process.env.DENCH_API_KEY?.trim() || void 0;
+}
+
+// extensions/dench-ai-gateway/composio-bridge.ts
+var DENCH_EXECUTE_INTEGRATIONS_NAME = "dench_execute_integrations";
+var DENCH_INTEGRATIONS_DISPLAY_NAME = "Dench Integrations";
+var DENCH_EXECUTE_INTEGRATIONS_PARAMETERS = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    tool_slug: {
+      type: "string",
+      description: "Exact tool slug returned by dench_search_integrations, for example GMAIL_FETCH_EMAILS or YOUTUBE_LIST_USER_SUBSCRIPTIONS."
+    },
+    arguments: {
+      type: "object",
+      additionalProperties: true,
+      description: "JSON arguments object matching the tool's input_schema from the search results.",
+      properties: {}
+    },
+    connected_account_id: {
+      type: "string",
+      description: "Optional connected account id. Required only when multiple accounts are connected for the same toolkit. The gateway auto-selects when only one account exists."
+    }
+  },
+  required: ["tool_slug"]
+};
+function asRecord(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : void 0;
+}
+function readString(value) {
+  return typeof value === "string" ? value : void 0;
+}
+function jsonResult(payload, details) {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    details: details ?? payload
+  };
+}
+function resolveGatewayBaseUrl(api, fallbackGatewayUrl) {
+  const plugins = asRecord(asRecord(api?.config)?.plugins)?.entries;
+  const denchGateway = asRecord(asRecord(plugins)?.["dench-ai-gateway"]);
+  const gwConfig = asRecord(denchGateway?.config);
+  const configuredUrl = readString(gwConfig?.gatewayUrl);
+  return (configuredUrl ?? fallbackGatewayUrl).replace(/\/$/, "");
+}
+function resolveApiKey() {
+  return readDenchAuthProfileKey() ?? void 0;
+}
+function createDenchExecuteIntegrationsTool(params) {
+  return {
+    name: DENCH_EXECUTE_INTEGRATIONS_NAME,
+    label: `${DENCH_INTEGRATIONS_DISPLAY_NAME} Execute`,
+    description: `Execute a ${DENCH_INTEGRATIONS_DISPLAY_NAME.toLowerCase()} tool by its slug. Pass the tool_slug from dench_search_integrations and the arguments matching its input_schema. The gateway handles authentication and account selection.`,
+    parameters: DENCH_EXECUTE_INTEGRATIONS_PARAMETERS,
+    async execute(_toolCallId, input) {
+      const payload = asRecord(input) ?? {};
+      const toolSlug = readString(payload.tool_slug)?.trim();
+      const connectedAccountId = readString(payload.connected_account_id)?.trim();
+      const toolArgs = asRecord(payload.arguments) ?? {};
+      if (!toolSlug) {
+        return jsonResult({
+          error: "The `tool_slug` field is required. Use dench_search_integrations to find available tools first."
+        });
+      }
+      try {
+        const res = await fetch(`${params.gatewayBaseUrl}/v1/composio/tools/execute`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            accept: "application/json",
+            ...params.authorization ? { authorization: params.authorization } : {}
+          },
+          body: JSON.stringify({
+            tool_slug: toolSlug,
+            arguments: toolArgs,
+            ...connectedAccountId ? { connected_account_id: connectedAccountId } : {}
+          })
+        });
+        const text = await res.text();
+        let parsed;
+        try {
+          parsed = JSON.parse(text);
+        } catch {
+          parsed = void 0;
+        }
+        if (!res.ok) {
+          const errorCode = readString(asRecord(parsed?.error)?.code) ?? readString(parsed?.code);
+          const errorMessage = readString(asRecord(parsed?.error)?.message) ?? readString(parsed?.error) ?? text;
+          if (errorCode === "composio_account_selection_required") {
+            return jsonResult(
+              {
+                error: errorMessage,
+                account_selection_required: true,
+                instruction: "Ask the user which connected account to use and pass its connected_account_id."
+              },
+              { status: "error", errorCode, tool_slug: toolSlug }
+            );
+          }
+          if (errorCode === "composio_not_connected") {
+            return jsonResult(
+              { error: errorMessage, not_connected: true },
+              { status: "error", errorCode, tool_slug: toolSlug }
+            );
+          }
+          return jsonResult(
+            {
+              error: `${DENCH_INTEGRATIONS_DISPLAY_NAME} tool ${toolSlug} failed (HTTP ${res.status}).`,
+              detail: parsed ?? (text || void 0)
+            },
+            { status: "error", tool_slug: toolSlug }
+          );
+        }
+        const data = parsed?.data;
+        const error = readString(parsed?.error);
+        const contentPayload = error ? { error, data } : data ?? parsed ?? {};
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(contentPayload, null, 2)
+            }
+          ],
+          details: {
+            denchIntegrations: true,
+            tool_slug: toolSlug,
+            ...parsed?.log_id ? { logId: parsed.log_id } : {},
+            ...data !== void 0 ? { structuredContent: data } : {},
+            ...error ? { status: "error", error } : {},
+            ...connectedAccountId ? { connectedAccountId } : {}
+          }
+        };
+      } catch (error) {
+        return jsonResult(
+          {
+            error: `${DENCH_INTEGRATIONS_DISPLAY_NAME} tool ${toolSlug} failed.`,
+            detail: error instanceof Error ? error.message : String(error)
+          },
+          { status: "error", tool_slug: toolSlug }
+        );
+      }
+    }
+  };
+}
+function stripRuntimeComposioServer(api) {
+  const rootConfig = asRecord(api?.config);
+  const mcp = asRecord(rootConfig?.mcp);
+  const servers = asRecord(mcp?.servers);
+  if (!rootConfig || !mcp || !servers) return;
+  if (servers.composio) {
+    delete servers.composio;
+    if (Object.keys(servers).length === 0) delete mcp.servers;
+    if (Object.keys(mcp).length === 0) delete rootConfig.mcp;
+  }
+}
+function registerDenchIntegrationsBridge(api, fallbackGatewayUrl) {
+  stripRuntimeComposioServer(api);
+  const gatewayBaseUrl = resolveGatewayBaseUrl(api, fallbackGatewayUrl);
+  const apiKey = resolveApiKey();
+  if (!apiKey) {
+    return;
+  }
+  const tool = createDenchExecuteIntegrationsTool({
+    gatewayBaseUrl,
+    authorization: `Bearer ${apiKey}`
+  });
+  api.registerTool(tool, {
+    name: DENCH_EXECUTE_INTEGRATIONS_NAME,
+    optional: true
+  });
+  api.logger?.info?.(
+    `[dench-ai-gateway] registered ${DENCH_EXECUTE_INTEGRATIONS_NAME} bridge tool`
+  );
+}
+
+// extensions/dench-ai-gateway/models.ts
+var DEFAULT_DENCH_CLOUD_GATEWAY_URL = "https://gateway.merseoriginals.com";
+function asRecord2(value) {
+  return value && typeof value === "object" ? value : void 0;
+}
+function readString2(input, ...keys) {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return void 0;
+}
+function readNumber(input, ...keys) {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string" && value.trim().length > 0) {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+  return void 0;
+}
+function readBoolean(input, ...keys) {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === "boolean") {
+      return value;
+    }
+  }
+  return void 0;
+}
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+function normalizeInputKinds(input, supportsImages) {
+  if (!Array.isArray(input)) {
+    return supportsImages ? ["text", "image"] : ["text"];
+  }
+  const kinds = /* @__PURE__ */ new Set();
+  for (const value of input) {
+    if (value === "text" || value === "image") {
+      kinds.add(value);
+    }
+  }
+  if (!kinds.has("text")) {
+    kinds.add("text");
+  }
+  if (supportsImages) {
+    kinds.add("image");
+  }
+  return [...kinds];
+}
+function stripTrailingSlashes(url) {
+  let end = url.length;
+  while (end > 0 && url.charCodeAt(end - 1) === 47) {
+    end -= 1;
+  }
+  return end === url.length ? url : url.slice(0, end);
+}
+function normalizeDenchGatewayUrl(value) {
+  const raw = (value || DEFAULT_DENCH_CLOUD_GATEWAY_URL).trim();
+  const withProtocol = raw.startsWith("http://") || raw.startsWith("https://") ? raw : `https://${raw}`;
+  let base = stripTrailingSlashes(withProtocol);
+  if (base.endsWith("/v1")) {
+    base = stripTrailingSlashes(base.slice(0, -3));
+  }
+  return base;
+}
+function buildDenchGatewayApiBaseUrl(gatewayUrl) {
+  return `${normalizeDenchGatewayUrl(gatewayUrl)}/v1`;
+}
+function buildDenchGatewayCatalogUrl(gatewayUrl) {
+  return `${normalizeDenchGatewayUrl(gatewayUrl)}/v1/public/models`;
+}
+var RECOMMENDED_DENCH_CLOUD_MODEL_ID = "claude-sonnet-4.6";
+var FALLBACK_DENCH_CLOUD_MODELS = [
+  {
+    id: "kimi-k2.5",
+    stableId: "moonshotai.kimi-k2.5",
+    displayName: "Kimi K2.5",
+    provider: "moonshot",
+    transportProvider: "bedrock",
+    api: "openai-responses",
+    input: ["text", "image"],
+    reasoning: true,
+    contextWindow: 262e3,
+    maxTokens: 64e3,
+    supportsStreaming: true,
+    supportsImages: true,
+    supportsResponses: true,
+    supportsReasoning: true,
+    cost: {
+      input: 0.81,
+      output: 4.05,
+      cacheRead: 0,
+      cacheWrite: 0
+    }
+  },
+  {
+    id: "claude-opus-4.6",
+    stableId: "anthropic.claude-opus-4-6-v1",
+    displayName: "Claude Opus 4.6",
+    provider: "anthropic",
+    transportProvider: "bedrock",
+    api: "openai-responses",
+    input: ["text", "image"],
+    reasoning: true,
+    contextWindow: 971e3,
+    maxTokens: 128e3,
+    supportsStreaming: true,
+    supportsImages: true,
+    supportsResponses: true,
+    supportsReasoning: true,
+    cost: {
+      input: 6.75,
+      output: 33.75,
+      cacheRead: 0.675,
+      cacheWrite: 8.4375
+    }
+  },
+  {
+    id: "gpt-5.4",
+    stableId: "gpt-5.4",
+    displayName: "GPT-5.4",
+    provider: "openai",
+    transportProvider: "openai",
+    api: "openai-responses",
+    input: ["text", "image"],
+    reasoning: true,
+    contextWindow: 971e3,
+    maxTokens: 128e3,
+    supportsStreaming: true,
+    supportsImages: true,
+    supportsResponses: true,
+    supportsReasoning: true,
+    cost: {
+      input: 3.375,
+      output: 20.25,
+      cacheRead: 0.3375,
+      cacheWrite: 0
+    }
+  },
+  {
+    id: "claude-sonnet-4.6",
+    stableId: "anthropic.claude-sonnet-4-6-v1",
+    displayName: "Claude Sonnet 4.6",
+    provider: "anthropic",
+    transportProvider: "bedrock",
+    api: "openai-responses",
+    input: ["text", "image"],
+    reasoning: true,
+    contextWindow: 971e3,
+    maxTokens: 64e3,
+    supportsStreaming: true,
+    supportsImages: true,
+    supportsResponses: true,
+    supportsReasoning: true,
+    cost: {
+      input: 4.05,
+      output: 20.25,
+      cacheRead: 0.405,
+      cacheWrite: 5.0625
+    }
+  }
+];
+function cloneFallbackDenchCloudModels() {
+  return FALLBACK_DENCH_CLOUD_MODELS.map((model) => ({
+    ...model,
+    input: [...model.input],
+    cost: { ...model.cost }
+  }));
+}
+function normalizeDenchCloudCatalogModel(input) {
+  const record = asRecord2(input);
+  if (!record) {
+    return null;
+  }
+  const publicId = readString2(record, "id", "publicId", "public_id");
+  const stableId = readString2(record, "stableId", "stable_id") || publicId;
+  const displayName = readString2(record, "name", "displayName", "display_name");
+  const provider = readString2(record, "provider");
+  const transportProvider = readString2(record, "transportProvider", "transport_provider");
+  if (!publicId || !stableId || !displayName || !isNonEmptyString(provider) || !isNonEmptyString(transportProvider)) {
+    return null;
+  }
+  const supportsImages = readBoolean(record, "supportsImages", "supports_images") ?? false;
+  const supportsStreaming = readBoolean(record, "supportsStreaming", "supports_streaming") ?? true;
+  const supportsResponses = readBoolean(record, "supportsResponses", "supports_responses") ?? true;
+  const supportsReasoning = readBoolean(record, "supportsReasoning", "supports_reasoning") ?? readBoolean(record, "reasoning") ?? false;
+  const contextWindow = readNumber(record, "contextWindow", "context_window") ?? 2e5;
+  const maxTokens = readNumber(record, "maxTokens", "max_tokens", "maxOutputTokens", "max_output_tokens") ?? 64e3;
+  const costRecord = asRecord2(record.cost) ?? {};
+  const inputCost = readNumber(costRecord, "input") ?? 0;
+  const outputCost = readNumber(costRecord, "output") ?? 0;
+  const cacheRead = readNumber(costRecord, "cacheRead", "cache_read") ?? 0;
+  const cacheWrite = readNumber(costRecord, "cacheWrite", "cache_write") ?? 0;
+  return {
+    id: publicId,
+    stableId,
+    displayName,
+    provider,
+    transportProvider,
+    api: record.api === "openai-completions" ? "openai-completions" : "openai-responses",
+    input: normalizeInputKinds(record.input, supportsImages),
+    reasoning: supportsReasoning,
+    contextWindow,
+    maxTokens,
+    supportsStreaming,
+    supportsImages,
+    supportsResponses,
+    supportsReasoning,
+    cost: {
+      input: inputCost,
+      output: outputCost,
+      cacheRead,
+      cacheWrite
+    }
+  };
+}
+function normalizeDenchCloudCatalogResponse(payload) {
+  const root = asRecord2(payload);
+  const data = root?.data;
+  if (!Array.isArray(data)) {
+    return [];
+  }
+  const models = [];
+  const seen = /* @__PURE__ */ new Set();
+  for (const entry of data) {
+    const normalized = normalizeDenchCloudCatalogModel(entry);
+    if (!normalized || seen.has(normalized.stableId)) {
+      continue;
+    }
+    seen.add(normalized.stableId);
+    models.push(normalized);
+  }
+  return models;
+}
+function buildDenchCloudProviderModels(models) {
+  return models.map((model) => ({
+    id: model.stableId,
+    name: `${model.displayName} (Dench Cloud)`,
+    reasoning: model.reasoning,
+    input: [...model.input],
+    cost: {
+      input: model.cost.input,
+      output: model.cost.output,
+      cacheRead: model.cost.cacheRead,
+      cacheWrite: model.cost.cacheWrite
+    },
+    contextWindow: model.contextWindow,
+    maxTokens: model.maxTokens
+  }));
+}
+function buildDenchCloudAgentModelEntries(models) {
+  return Object.fromEntries(
+    models.map((model) => [
+      `dench-cloud/${model.stableId}`,
+      { alias: `${model.displayName} (Dench Cloud)` }
+    ])
+  );
+}
+function resolveDenchCloudModel(models, requestedId) {
+  const normalized = requestedId?.trim();
+  if (!normalized) {
+    return models.find((model) => model.id === RECOMMENDED_DENCH_CLOUD_MODEL_ID) || models[0];
+  }
+  return models.find((model) => model.id === normalized || model.stableId === normalized);
+}
+function formatDenchCloudModelHint(model) {
+  const parts = [model.provider];
+  if (model.reasoning) parts.push("reasoning");
+  if (model.id === RECOMMENDED_DENCH_CLOUD_MODEL_ID) parts.push("recommended");
+  return parts.join(" \xB7 ");
+}
+
+// extensions/dench-ai-gateway/config-patch.ts
+var DENCH_COMPOSIO_WRAPPER_TOOLS = [
+  "dench_search_integrations",
+  "dench_execute_integrations"
+];
+var DENCH_CLOUD_TOOL_ALLOWLIST = [
+  "read",
+  "write",
+  "edit",
+  "apply_patch",
+  "exec",
+  "process",
+  "code_execution",
+  "web_fetch",
+  "x_search",
+  "memory_search",
+  "memory_get",
+  "sessions_list",
+  "sessions_history",
+  "sessions_send",
+  "sessions_spawn",
+  "sessions_yield",
+  "subagents",
+  "session_status",
+  "cron",
+  "update_plan",
+  "image",
+  "image_generate",
+  "music_generate",
+  "video_generate",
+  ...DENCH_COMPOSIO_WRAPPER_TOOLS
+];
+function buildDenchCloudProviderConfig(params) {
+  return {
+    baseUrl: buildDenchGatewayApiBaseUrl(params.gatewayUrl),
+    apiKey: params.apiKey,
+    api: "openai-responses",
+    models: buildDenchCloudProviderModels(params.models)
+  };
+}
+function buildDenchCloudConfigPatch(params) {
+  return {
+    models: {
+      mode: "merge",
+      providers: {
+        "dench-cloud": buildDenchCloudProviderConfig(params)
+      }
+    },
+    agents: {
+      defaults: {
+        models: buildDenchCloudAgentModelEntries(params.models)
+      }
+    },
+    messages: {
+      tts: {
+        provider: "elevenlabs",
+        providers: {
+          elevenlabs: {
+            baseUrl: params.gatewayUrl,
+            apiKey: params.apiKey
+          }
+        }
+      }
+    },
+    tools: {
+      alsoAllow: [...DENCH_COMPOSIO_WRAPPER_TOOLS],
+      byProvider: {
+        "dench-cloud": {
+          allow: [...DENCH_CLOUD_TOOL_ALLOWLIST]
+        }
+      }
+    }
+  };
+}
+
+// extensions/dench-ai-gateway/sync-trigger.ts
+import { existsSync as existsSync2, readFileSync as readFileSync2 } from "node:fs";
+import { homedir } from "node:os";
+import path2 from "node:path";
+var DEFAULT_INTERVAL_MS = 5 * 60 * 1e3;
+var DEFAULT_WEB_PORT = 3100;
+var PROCESS_JSON_REL = path2.join("web-runtime", "process.json");
+var FETCH_TIMEOUT_MS = 6e4;
+function asRecord3(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : void 0;
+}
+function readString3(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : void 0;
+}
+function readNumber2(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : void 0;
+}
+function resolveSyncTriggerConfig(api) {
+  const pluginConfig = asRecord3(asRecord3(asRecord3(api?.config)?.plugins)?.entries)?.["dench-ai-gateway"];
+  return asRecord3(asRecord3(pluginConfig)?.config?.["syncTrigger"]);
+}
+function resolveStateDir() {
+  const fromEnv = process.env.OPENCLAW_STATE_DIR?.trim();
+  if (fromEnv) {
+    return fromEnv;
+  }
+  const home = process.env.OPENCLAW_HOME?.trim() || homedir();
+  return path2.join(home, ".openclaw-dench");
+}
+function resolveWebPortFromProcessFile(stateDir) {
+  const processPath = path2.join(stateDir, PROCESS_JSON_REL);
+  if (!existsSync2(processPath)) {
+    return void 0;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync2(processPath, "utf-8"));
+    return readNumber2(parsed?.port);
+  } catch {
+    return void 0;
+  }
+}
+function resolveWebBaseUrl(api, syncTriggerConfig) {
+  const fromConfig = readString3(syncTriggerConfig?.webBaseUrl);
+  if (fromConfig) {
+    return fromConfig.replace(/\/$/, "");
+  }
+  const fromEnv = readString3(process.env.DENCHCLAW_WEB_BASE_URL);
+  if (fromEnv) {
+    return fromEnv.replace(/\/$/, "");
+  }
+  const port = resolveWebPortFromProcessFile(resolveStateDir()) ?? DEFAULT_WEB_PORT;
+  return `http://127.0.0.1:${port}`;
+}
+function outcomeKey(outcome) {
+  switch (outcome.kind) {
+    case "ok":
+      return "ok";
+    case "http":
+      return `http:${outcome.statusBucket}`;
+    case "timeout":
+      return "timeout";
+    case "network":
+      return `network:${outcome.message}`;
+  }
+}
+function describeOutcome(outcome) {
+  switch (outcome.kind) {
+    case "ok":
+      return "ok";
+    case "http":
+      return `HTTP ${outcome.status}`;
+    case "timeout":
+      return `timed out after ${FETCH_TIMEOUT_MS}ms`;
+    case "network":
+      return outcome.message;
+  }
+}
+function bucketFor(status) {
+  if (status >= 400 && status < 500) {
+    return "4xx";
+  }
+  if (status >= 500 && status < 600) {
+    return "5xx";
+  }
+  return "other";
+}
+var _armed = false;
+function armSyncTrigger(api) {
+  if (_armed) {
+    return;
+  }
+  const config = resolveSyncTriggerConfig(api);
+  if (config?.enabled === false) {
+    api?.logger?.info?.("[dench-ai-gateway] sync-trigger disabled via syncTrigger.enabled=false");
+    return;
+  }
+  const apiKey = readDenchAuthProfileKey();
+  if (!apiKey) {
+    api?.logger?.info?.("[dench-ai-gateway] No Dench Cloud API key; sync trigger not armed.");
+    return;
+  }
+  const intervalMs = readNumber2(config?.intervalMs) ?? DEFAULT_INTERVAL_MS;
+  if (intervalMs < 1e3) {
+    api?.logger?.info?.(
+      `[dench-ai-gateway] sync-trigger intervalMs=${intervalMs} below safety floor; not arming.`
+    );
+    return;
+  }
+  const webBaseUrl = resolveWebBaseUrl(api, config);
+  const tickUrl = `${webBaseUrl}/api/sync/poll-tick`;
+  let lastOutcomeKey = "ok";
+  async function tick() {
+    const controller = new AbortController();
+    const timeoutHandle = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    let outcome;
+    try {
+      const response = await fetch(tickUrl, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          "content-type": "application/json"
+        },
+        body: "{}",
+        signal: controller.signal
+      });
+      outcome = response.ok ? { kind: "ok" } : { kind: "http", statusBucket: bucketFor(response.status), status: response.status };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const aborted = err instanceof Error && (err.name === "AbortError" || /aborted/i.test(message));
+      outcome = aborted ? { kind: "timeout" } : { kind: "network", message };
+    } finally {
+      clearTimeout(timeoutHandle);
+    }
+    const key = outcomeKey(outcome);
+    const wasFailing = lastOutcomeKey !== "ok";
+    if (outcome.kind === "ok") {
+      if (wasFailing) {
+        api?.logger?.info?.(`[dench-ai-gateway] sync-trigger recovered (was: ${lastOutcomeKey})`);
+      }
+    } else if (key !== lastOutcomeKey) {
+      api?.logger?.info?.(
+        `[dench-ai-gateway] sync-trigger tick ${describeOutcome(outcome)} from ${tickUrl}`
+      );
+    }
+    lastOutcomeKey = key;
+  }
+  setInterval(() => {
+    void tick();
+  }, intervalMs);
+  _armed = true;
+  api?.logger?.info?.(`[dench-ai-gateway] sync-trigger armed (every ${intervalMs}ms \u2192 ${tickUrl})`);
+}
+
+// extensions/dench-ai-gateway/sync-refresh-tools.ts
+var REFRESH_TOOL_NAME = "denchclaw_refresh_sync";
+var RESYNC_TOOL_NAME = "denchclaw_resync_full";
+var REFRESH_TIMEOUT_MS = 3e4;
+var RESYNC_TIMEOUT_MS = 6e4;
+var REFRESH_PARAMETERS = {
+  type: "object",
+  additionalProperties: false,
+  properties: {}
+};
+function jsonResult2(payload, details) {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    details: details ?? payload
+  };
+}
+function summarize(mode, body) {
+  if (body.ok === false) {
+    return `Sync ${mode} failed: ${body.error ?? "unknown error"}`;
+  }
+  if (body.alreadyRunning) {
+    return `A ${mode} sync is already running \u2014 no new tick started.`;
+  }
+  if (body.skipped === "backfill-in-progress") {
+    return "Skipped incremental tick because a full backfill is currently in progress.";
+  }
+  const evt = body.lastEvent;
+  if (evt?.phase === "error") {
+    return `Sync ${mode} reported an error: ${evt.error ?? evt.message ?? "unknown"}`;
+  }
+  if (mode === "incremental") {
+    const newMessages = evt?.messagesProcessed ?? 0;
+    const newEvents = evt?.eventsProcessed ?? 0;
+    if (newMessages === 0 && newEvents === 0) {
+      return "Incremental sync ran \u2014 no new emails or calendar events since the last tick.";
+    }
+    const parts = [];
+    if (newMessages > 0) {
+      parts.push(`${newMessages} new email${newMessages === 1 ? "" : "s"}`);
+    }
+    if (newEvents > 0) {
+      parts.push(`${newEvents} new event${newEvents === 1 ? "" : "s"}`);
+    }
+    return `Synced ${parts.join(" and ")}.`;
+  }
+  if (body.started) {
+    return "Full backfill started \u2014 Gmail and Calendar are re-importing in the background.";
+  }
+  return "Full backfill request acknowledged.";
+}
+async function callRefreshRoute(webBaseUrl, mode, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${webBaseUrl}/api/sync/refresh`, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json" },
+      body: JSON.stringify({ mode }),
+      signal: controller.signal
+    });
+    const text = await res.text();
+    let body = {};
+    if (text.trim()) {
+      try {
+        body = JSON.parse(text);
+      } catch {
+        body = { error: text.slice(0, 240) };
+      }
+    }
+    return { status: res.status, body };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+function createRefreshSyncTool(api) {
+  const webBaseUrl = resolveWebBaseUrl(api, resolveSyncTriggerConfig(api));
+  return {
+    name: REFRESH_TOOL_NAME,
+    label: "Refresh Gmail/Calendar sync",
+    description: "Trigger an incremental Gmail and Calendar sync tick right now. Use this when the user asks to refresh, sync now, pull new emails, or check whether anything new has arrived. Cheap and fast (1-2 seconds). For a full re-import use denchclaw_resync_full instead.",
+    parameters: REFRESH_PARAMETERS,
+    async execute(_toolCallId, _input) {
+      try {
+        const { status, body } = await callRefreshRoute(
+          webBaseUrl,
+          "incremental",
+          REFRESH_TIMEOUT_MS
+        );
+        if (status >= 400) {
+          return jsonResult2(
+            {
+              error: body.error ?? `Refresh failed (HTTP ${status}).`,
+              mode: "incremental"
+            },
+            { status: "error", httpStatus: status }
+          );
+        }
+        return {
+          content: [{ type: "text", text: summarize("incremental", body) }],
+          details: { mode: "incremental", response: body }
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return jsonResult2(
+          { error: `Refresh request failed: ${message}`, mode: "incremental" },
+          { status: "error" }
+        );
+      }
+    }
+  };
+}
+function createResyncFullTool(api) {
+  const webBaseUrl = resolveWebBaseUrl(api, resolveSyncTriggerConfig(api));
+  return {
+    name: RESYNC_TOOL_NAME,
+    label: "Full Gmail/Calendar resync",
+    description: "Trigger a full Gmail and Calendar backfill \u2014 re-imports messages and events from scratch. Use this only when the user explicitly asks for a full resync, after they have reconnected an account, or when the incremental refresh (denchclaw_refresh_sync) repeatedly fails to surface messages they expect to see. Heavier than incremental sync; runs in the background.",
+    parameters: REFRESH_PARAMETERS,
+    async execute(_toolCallId, _input) {
+      try {
+        const { status, body } = await callRefreshRoute(webBaseUrl, "backfill", RESYNC_TIMEOUT_MS);
+        if (status >= 400) {
+          return jsonResult2(
+            {
+              error: body.error ?? `Resync failed (HTTP ${status}).`,
+              mode: "backfill"
+            },
+            { status: "error", httpStatus: status }
+          );
+        }
+        return {
+          content: [{ type: "text", text: summarize("backfill", body) }],
+          details: { mode: "backfill", response: body }
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return jsonResult2(
+          { error: `Resync request failed: ${message}`, mode: "backfill" },
+          { status: "error" }
+        );
+      }
+    }
+  };
+}
+function registerSyncRefreshTools(api) {
+  const refresh = createRefreshSyncTool(api);
+  const resync = createResyncFullTool(api);
+  api.registerTool(refresh, { name: REFRESH_TOOL_NAME, optional: true });
+  api.registerTool(resync, { name: RESYNC_TOOL_NAME, optional: true });
+  return [refresh.name, resync.name];
+}
+
+// extensions/dench-ai-gateway/index.ts
+var id = "dench-ai-gateway";
+var PROVIDER_ID = "dench-cloud";
+var PROVIDER_LABEL = "Dench Cloud";
+var API_KEY_ENV_VARS = ["DENCH_CLOUD_API_KEY", "DENCH_API_KEY"];
+function asRecord4(value) {
+  return value && typeof value === "object" ? value : void 0;
+}
+function resolvePluginConfig(api) {
+  const pluginConfig = api?.config?.plugins?.entries?.["dench-ai-gateway"]?.config;
+  return asRecord4(pluginConfig);
+}
+function resolveGatewayUrl(api) {
+  const pluginConfig = resolvePluginConfig(api);
+  const configured = typeof pluginConfig?.gatewayUrl === "string" ? pluginConfig.gatewayUrl : void 0;
+  return normalizeDenchGatewayUrl(
+    configured || process.env.DENCH_GATEWAY_URL || DEFAULT_DENCH_CLOUD_GATEWAY_URL
+  );
+}
+function resolveEnvApiKey() {
+  for (const envVar of API_KEY_ENV_VARS) {
+    const value = process.env[envVar]?.trim();
+    if (value) {
+      return value;
+    }
+  }
+  return void 0;
+}
+async function promptForApiKey(prompter) {
+  if (typeof prompter?.secret === "function") {
+    return String(
+      await prompter.secret(
+        "Enter your Dench Cloud API key (sign up at dench.com and get it at dench.com/settings)"
+      )
+    ).trim();
+  }
+  return String(
+    await prompter.text({
+      message: "Enter your Dench Cloud API key (sign up at dench.com and get it at dench.com/settings)"
+    })
+  ).trim();
+}
+async function fetchDenchCloudCatalog(gatewayUrl) {
+  try {
+    const response = await fetch(buildDenchGatewayCatalogUrl(gatewayUrl));
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    const payload = await response.json().catch(() => null);
+    const models = normalizeDenchCloudCatalogResponse(payload);
+    if (!models.length) {
+      throw new Error("response did not contain any usable models");
+    }
+    return { models, source: "live" };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      models: cloneFallbackDenchCloudModels(),
+      source: "fallback",
+      detail
+    };
+  }
+}
+async function validateDenchCloudApiKey(gatewayUrl, apiKey) {
+  const response = await fetch(`${buildDenchGatewayApiBaseUrl(gatewayUrl)}/models`, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`
+    }
+  });
+  if (response.ok) {
+    return;
+  }
+  const message = response.status === 401 || response.status === 403 ? "Invalid Dench Cloud API key." : `Dench Cloud validation failed with HTTP ${response.status}.`;
+  throw new Error(`${message} Check your key at dench.com/settings.`);
+}
+async function promptForModelSelection(params) {
+  const selectedStableId = String(
+    await params.prompter.select({
+      message: "Choose your default Dench Cloud model",
+      options: params.models.map((model) => ({
+        value: model.stableId,
+        label: model.displayName,
+        hint: formatDenchCloudModelHint(model)
+      })),
+      ...params.initialStableId ? { initialValue: params.initialStableId } : {}
+    })
+  );
+  const selected = resolveDenchCloudModel(params.models, selectedStableId);
+  if (!selected) {
+    throw new Error(`Unknown Dench Cloud model "${selectedStableId}".`);
+  }
+  return selected;
+}
+function buildAuthNotes(params) {
+  const notes = [
+    `Dench Cloud uses ${buildDenchGatewayApiBaseUrl(params.gatewayUrl)} for model traffic.`
+  ];
+  if (params.catalog.source === "fallback") {
+    notes.push(
+      `Model catalog fell back to DenchClaw's bundled list (${params.catalog.detail ?? "public catalog unavailable"}).`
+    );
+  }
+  return notes;
+}
+function buildProviderAuthResult(params) {
+  return {
+    profiles: [
+      {
+        profileId: `${PROVIDER_ID}:default`,
+        credential: {
+          type: "api_key",
+          provider: PROVIDER_ID,
+          key: params.apiKey
+        }
+      }
+    ],
+    defaultModel: `${PROVIDER_ID}/${params.selected.stableId}`,
+    configPatch: buildDenchCloudConfigPatch({
+      gatewayUrl: params.gatewayUrl,
+      apiKey: params.apiKey,
+      models: params.catalog.models
+    }),
+    notes: buildAuthNotes({
+      gatewayUrl: params.gatewayUrl,
+      catalog: params.catalog
+    })
+  };
+}
+async function runInteractiveAuth(ctx, gatewayUrl) {
+  const apiKey = await promptForApiKey(ctx.prompter);
+  if (!apiKey) {
+    throw new Error("A Dench Cloud API key is required.");
+  }
+  await validateDenchCloudApiKey(gatewayUrl, apiKey);
+  const catalog = await fetchDenchCloudCatalog(gatewayUrl);
+  const selected = await promptForModelSelection({
+    prompter: ctx.prompter,
+    models: catalog.models
+  });
+  return buildProviderAuthResult({
+    gatewayUrl,
+    apiKey,
+    catalog,
+    selected
+  });
+}
+async function runNonInteractiveAuth(ctx, gatewayUrl) {
+  const apiKey = String(
+    ctx?.opts?.denchCloudApiKey || ctx?.opts?.denchCloudKey || resolveEnvApiKey() || ""
+  ).trim();
+  if (!apiKey) {
+    throw new Error(
+      "Dench Cloud non-interactive auth requires DENCH_CLOUD_API_KEY or --dench-cloud-api-key."
+    );
+  }
+  await validateDenchCloudApiKey(gatewayUrl, apiKey);
+  const catalog = await fetchDenchCloudCatalog(gatewayUrl);
+  const selected = resolveDenchCloudModel(
+    catalog.models,
+    String(ctx?.opts?.denchCloudModel || process.env.DENCH_CLOUD_MODEL || "").trim()
+  );
+  if (!selected) {
+    throw new Error("Configured Dench Cloud model is not available.");
+  }
+  return buildProviderAuthResult({
+    gatewayUrl,
+    apiKey,
+    catalog,
+    selected
+  });
+}
+function buildDiscoveryProvider(api, gatewayUrl) {
+  const configured = api?.config?.models?.providers?.[PROVIDER_ID];
+  if (configured && typeof configured === "object") {
+    return configured;
+  }
+  const apiKey = resolveEnvApiKey();
+  if (!apiKey) {
+    return null;
+  }
+  const models = cloneFallbackDenchCloudModels();
+  return buildDenchCloudProviderConfig({ gatewayUrl, apiKey, models });
+}
+function register(api) {
+  const pluginConfig = resolvePluginConfig(api);
+  if (pluginConfig?.enabled === false) {
+    return;
+  }
+  const gatewayUrl = resolveGatewayUrl(api);
+  api.registerProvider({
+    id: PROVIDER_ID,
+    label: PROVIDER_LABEL,
+    docsPath: "/providers/models",
+    aliases: ["dench", "dench-cloud", "dench-ai-gateway"],
+    envVars: [...API_KEY_ENV_VARS],
+    auth: [
+      {
+        id: "api-key",
+        label: "Dench Cloud API Key",
+        hint: "Use your Dench Cloud key from dench.com/settings",
+        kind: "api_key",
+        run: async (ctx) => await runInteractiveAuth(ctx, gatewayUrl),
+        // Newer OpenClaw builds can call this hook during headless onboarding.
+        runNonInteractive: async (ctx) => await runNonInteractiveAuth(ctx, gatewayUrl)
+      }
+    ],
+    // Newer OpenClaw builds can surface provider-specific wizard entries.
+    wizard: {
+      onboarding: {
+        choiceId: PROVIDER_ID,
+        choiceLabel: PROVIDER_LABEL,
+        choiceHint: "Use Dench's managed AI gateway",
+        groupId: "dench",
+        groupLabel: "Dench",
+        groupHint: "Managed Dench Cloud models",
+        methodId: "api-key"
+      },
+      modelPicker: {
+        label: PROVIDER_LABEL,
+        hint: "Connect Dench Cloud with your API key",
+        methodId: "api-key"
+      }
+    },
+    // Best-effort discovery so newer OpenClaw builds can rehydrate provider config.
+    discovery: {
+      order: "profile",
+      run: async () => {
+        const provider = buildDiscoveryProvider(api, gatewayUrl);
+        return provider ? { provider } : null;
+      }
+    }
+  });
+  registerDenchIntegrationsBridge(api, gatewayUrl);
+  armSyncTrigger(api);
+  if (typeof api?.registerTool === "function" && readDenchAuthProfileKey()) {
+    const registered = registerSyncRefreshTools(api);
+    api.logger?.info?.(
+      `[dench-ai-gateway] registered sync refresh tools: ${registered.join(", ")}`
+    );
+  }
+  api.registerService({
+    id: "dench-ai-gateway",
+    start: () => {
+      api.logger?.info?.(`[dench-ai-gateway] active (gateway: ${gatewayUrl})`);
+    },
+    stop: () => {
+      api.logger?.info?.("[dench-ai-gateway] stopped");
+    }
+  });
+}
+export {
+  buildDenchCloudConfigPatch,
+  register as default,
+  fetchDenchCloudCatalog,
+  id,
+  validateDenchCloudApiKey
+};

--- a/extensions/dench-ai-gateway/index.ts
+++ b/extensions/dench-ai-gateway/index.ts
@@ -101,12 +101,24 @@ export async function fetchDenchCloudCatalog(gatewayUrl: string): Promise<Catalo
   }
 }
 
+const DENCH_CLOUD_API_KEY_VALIDATION_TIMEOUT_MS = 15_000;
+
 export async function validateDenchCloudApiKey(gatewayUrl: string, apiKey: string): Promise<void> {
-  const response = await fetch(`${buildDenchGatewayApiBaseUrl(gatewayUrl)}/models`, {
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-    },
-  });
+  const apiBaseUrl = buildDenchGatewayApiBaseUrl(gatewayUrl);
+  let response: Response;
+  try {
+    response = await fetch(`${apiBaseUrl}/models`, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+      signal: AbortSignal.timeout(DENCH_CLOUD_API_KEY_VALIDATION_TIMEOUT_MS),
+    });
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Could not reach Dench Cloud gateway at ${apiBaseUrl} (${cause}). Check your network connection and gateway URL, then try again.`,
+    );
+  }
 
   if (response.ok) {
     return;

--- a/extensions/dench-ai-gateway/openclaw.plugin.json
+++ b/extensions/dench-ai-gateway/openclaw.plugin.json
@@ -3,6 +3,16 @@
   "name": "Dench AI Gateway",
   "version": "1.0.0",
   "description": "Registers Dench Cloud as an OpenClaw model provider with live gateway-backed model discovery, and arms the gateway-side Gmail/Calendar sync poll trigger.",
+  "activation": {
+    "onStartup": true
+  },
+  "contracts": {
+    "tools": [
+      "dench_execute_integrations",
+      "denchclaw_refresh_sync",
+      "denchclaw_resync_full"
+    ]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/dench-ai-gateway/package.json
+++ b/extensions/dench-ai-gateway/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./index.mjs"
     ]
   }
 }

--- a/extensions/dench-ai-gateway/sync-refresh-tools.ts
+++ b/extensions/dench-ai-gateway/sync-refresh-tools.ts
@@ -242,7 +242,7 @@ export function createResyncFullTool(api: any): AnyAgentTool {
 export function registerSyncRefreshTools(api: any): string[] {
   const refresh = createRefreshSyncTool(api);
   const resync = createResyncFullTool(api);
-  api.registerTool(refresh);
-  api.registerTool(resync);
+  api.registerTool(refresh, { name: REFRESH_TOOL_NAME, optional: true });
+  api.registerTool(resync, { name: RESYNC_TOOL_NAME, optional: true });
   return [refresh.name, resync.name];
 }

--- a/extensions/dench-identity/index.mjs
+++ b/extensions/dench-identity/index.mjs
@@ -83,6 +83,170 @@ var APP_ALIASES = {
   billing: "stripe",
   payments: "stripe"
 };
+var STATIC_COMPOSIO_FALLBACK = {
+  gmail: [
+    {
+      intent: "Read recent emails",
+      tool: "GMAIL_FETCH_EMAILS",
+      required_args: [],
+      arg_hints: {
+        label_ids: 'Must be a JSON array like ["INBOX"].',
+        max_results: "Integer count, for example 10."
+      },
+      default_args: { label_ids: ["INBOX"], max_results: 10 },
+      example_prompts: ["check my recent emails", "show my inbox"]
+    },
+    {
+      intent: "Read one email",
+      tool: "GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID",
+      required_args: ["message_id"],
+      arg_hints: {
+        message_id: "Use the message id from a list result."
+      },
+      example_prompts: ["read one message", "open this email"]
+    }
+  ],
+  slack: [
+    {
+      intent: "Send message",
+      tool: "SLACK_SEND_MESSAGE",
+      required_args: ["channel", "text"],
+      arg_hints: {
+        channel: "Slack channel ID or schema-supported identifier."
+      },
+      example_prompts: ["send a Slack message", "post in Slack"]
+    }
+  ],
+  github: [
+    {
+      intent: "List repos",
+      tool: "GITHUB_LIST_REPOSITORIES_FOR_THE_AUTHENTICATED_USER",
+      required_args: [],
+      arg_hints: {},
+      example_prompts: ["list my GitHub repositories"]
+    },
+    {
+      intent: "Find pull requests",
+      tool: "GITHUB_FIND_PULL_REQUESTS",
+      required_args: [],
+      arg_hints: {},
+      example_prompts: ["check my recent PRs", "show my recent pull requests"]
+    },
+    {
+      intent: "List repo pull requests",
+      tool: "GITHUB_LIST_PULL_REQUESTS",
+      required_args: ["owner", "repo"],
+      arg_hints: {
+        owner: "Repository owner or organization login.",
+        repo: "Repository name without the .git suffix."
+      },
+      example_prompts: ["list PRs for this repo", "show pull requests in this repository"]
+    },
+    {
+      intent: "Get pull request",
+      tool: "GITHUB_GET_A_PULL_REQUEST",
+      required_args: ["owner", "repo", "pull_number"],
+      arg_hints: {
+        owner: "Repository owner or organization login.",
+        repo: "Repository name without the .git suffix.",
+        pull_number: "Numeric pull request number."
+      },
+      example_prompts: ["show this pull request", "get PR details"]
+    }
+  ],
+  notion: [
+    {
+      intent: "Search pages",
+      tool: "NOTION_SEARCH",
+      required_args: [],
+      arg_hints: {},
+      example_prompts: ["search Notion", "find a Notion page"]
+    }
+  ],
+  "google-calendar": [
+    {
+      intent: "Upcoming events",
+      tool: "GOOGLE_CALENDAR_EVENTS_LIST",
+      required_args: [],
+      arg_hints: {
+        time_min: "RFC3339 datetime string.",
+        time_max: "RFC3339 datetime string."
+      },
+      example_prompts: ["what's upcoming on my calendar", "show upcoming calendar events"]
+    },
+    {
+      intent: "List events",
+      tool: "GOOGLE_CALENDAR_EVENTS_LIST",
+      required_args: [],
+      arg_hints: {
+        time_min: "RFC3339 datetime string.",
+        time_max: "RFC3339 datetime string."
+      },
+      example_prompts: ["show my calendar events", "list upcoming meetings"]
+    },
+    {
+      intent: "Find event",
+      tool: "GOOGLE_CALENDAR_EVENTS_LIST",
+      required_args: [],
+      arg_hints: {
+        query: "Search text for matching events if the tool supports it.",
+        time_min: "RFC3339 datetime string.",
+        time_max: "RFC3339 datetime string."
+      },
+      example_prompts: ["find my event tomorrow", "search for a calendar event"]
+    }
+  ],
+  linear: [
+    {
+      intent: "List issues",
+      tool: "LINEAR_LIST_ISSUES",
+      required_args: [],
+      arg_hints: {},
+      example_prompts: ["list Linear issues", "show Linear tickets"]
+    }
+  ],
+  stripe: [
+    {
+      intent: "List subscriptions",
+      tool: "STRIPE_LIST_SUBSCRIPTIONS",
+      required_args: [],
+      arg_hints: {},
+      example_prompts: [
+        "list subscriptions",
+        "show subscriptions with trial info",
+        "calculate recurring revenue from subscriptions"
+      ]
+    },
+    {
+      intent: "Search subscriptions",
+      tool: "STRIPE_SEARCH_SUBSCRIPTIONS",
+      required_args: [],
+      arg_hints: {},
+      example_prompts: ["search Stripe subscriptions", "find a Stripe subscription"]
+    },
+    {
+      intent: "List customers",
+      tool: "STRIPE_LIST_CUSTOMERS",
+      required_args: [],
+      arg_hints: {},
+      example_prompts: ["list Stripe customers"]
+    },
+    {
+      intent: "List invoices",
+      tool: "STRIPE_LIST_INVOICES",
+      required_args: [],
+      arg_hints: {},
+      example_prompts: ["list Stripe invoices"]
+    },
+    {
+      intent: "Retrieve balance",
+      tool: "STRIPE_RETRIEVE_BALANCE",
+      required_args: [],
+      arg_hints: {},
+      example_prompts: ["show Stripe balance"]
+    }
+  ]
+};
 function jsonResult(payload) {
   return {
     content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
@@ -141,6 +305,19 @@ function buildResolverActionDetails(action, app) {
     action_link_markdown: buildComposioActionLink(action, normalizedApp)
   };
 }
+function tokenize(value) {
+  return value.toLowerCase().split(/[^a-z0-9]+/u).filter((token) => token.length > 1);
+}
+function scoreMatch(text, queryTokens) {
+  const haystack = text.toLowerCase();
+  let score = 0;
+  for (const token of queryTokens) {
+    if (haystack.includes(token)) {
+      score += token.length > 4 ? 3 : 1;
+    }
+  }
+  return score;
+}
 function resolveGatewayUrlFromApi(api) {
   const plugins = asRecord(asRecord(api?.config)?.plugins)?.entries;
   const denchGateway = asRecord(asRecord(plugins)?.["dench-ai-gateway"]);
@@ -186,6 +363,83 @@ async function postComposioGatewayJson(params) {
     };
   }
 }
+function chooseFallbackTool(app, queryText) {
+  const recipes = STATIC_COMPOSIO_FALLBACK[app] ?? [];
+  const queryTokens = tokenize(queryText);
+  let best = recipes[0] ?? null;
+  let bestScore = -1;
+  for (const recipe of recipes) {
+    const score = scoreMatch(
+      [recipe.intent, recipe.tool, ...recipe.example_prompts ?? []].join(" "),
+      queryTokens
+    );
+    if (score > bestScore) {
+      best = recipe;
+      bestScore = score;
+    }
+  }
+  return best;
+}
+function buildStaticFallbackInputSchema(recipe) {
+  const properties = {};
+  for (const arg of recipe.required_args ?? []) {
+    properties[arg] = { type: "string" };
+  }
+  for (const [key, hint] of Object.entries(recipe.arg_hints ?? {})) {
+    properties[key] = {
+      type: typeof hint === "number" ? "number" : Array.isArray(hint) ? "array" : "string",
+      description: Array.isArray(hint) ? JSON.stringify(hint) : String(hint)
+    };
+  }
+  return {
+    type: "object",
+    properties,
+    required: recipe.required_args ?? []
+  };
+}
+function buildStaticFallbackSearchResults(toolkitSlug, queryText) {
+  const recipe = chooseFallbackTool(toolkitSlug, queryText);
+  if (!recipe) {
+    return [];
+  }
+  return [
+    {
+      tool_slug: recipe.tool,
+      name: recipe.intent,
+      description: `Known ${humanizeResolverApp(toolkitSlug)} recipe (local fallback because gateway search returned no matches).`,
+      toolkit: {
+        slug: toolkitSlug,
+        name: humanizeResolverApp(toolkitSlug)
+      },
+      input_schema: buildStaticFallbackInputSchema(recipe),
+      suggested_arguments: recipe.default_args ?? {},
+      is_connected: true,
+      account_count: null,
+      accounts: [],
+      match_source: "static_recipe_fallback"
+    }
+  ];
+}
+function buildEmptyConnectedSearchInstruction(params) {
+  if (params.fallbackResults.length > 0) {
+    const top = params.fallbackResults[0] ?? {};
+    const slug = readString(top.tool_slug) ?? "the top fallback tool_slug";
+    const suggested = top.suggested_arguments;
+    const suggestedText = suggested && typeof suggested === "object" && Object.keys(suggested).length > 0 ? ` and suggested_arguments ${JSON.stringify(suggested)}` : "";
+    return [
+      `Gateway search returned no matches, but ${humanizeResolverApp(params.normalizedToolkit)} is connected.`,
+      "Do NOT stop the task, do NOT mention gog, and do NOT switch to shell CLIs.",
+      `Call ${DENCH_EXECUTE_INTEGRATIONS_NAME} immediately with tool_slug "${slug}"${suggestedText}.`,
+      `If execution fails, retry ${DENCH_SEARCH_INTEGRATIONS_NAME} with toolkit only (omit query) or a shorter query.`
+    ].join(" ");
+  }
+  return [
+    `No ${humanizeResolverApp(params.normalizedToolkit)} integration tools matched gateway search.`,
+    "Do NOT stop \u2014 retry search with toolkit only (omit query), a shorter query, or a different keyword.",
+    `Then execute the best match with ${DENCH_EXECUTE_INTEGRATIONS_NAME}.`,
+    "Never fall back to gog while this app is connected."
+  ].join(" ");
+}
 function createDenchSearchIntegrationsTool(api) {
   return {
     name: DENCH_SEARCH_INTEGRATIONS_NAME,
@@ -218,8 +472,27 @@ function createDenchSearchIntegrationsTool(api) {
           guidance: `Check the Dench Cloud gateway/API key configuration, then retry ${DENCH_SEARCH_INTEGRATIONS_NAME}.`
         });
       }
-      const items = asRecordArray(gatewayResult.items) ?? [];
-      const connectedToolkits = Array.isArray(gatewayResult.connected_toolkits) ? gatewayResult.connected_toolkits : [];
+      let items = asRecordArray(gatewayResult.items) ?? [];
+      let connectedToolkits = Array.isArray(gatewayResult.connected_toolkits) ? gatewayResult.connected_toolkits : [];
+      if (items.length === 0 && normalizedToolkit && query && connectedToolkits.includes(normalizedToolkit)) {
+        const retryResult = await postComposioGatewayJson({
+          api,
+          path: "/v1/composio/tools/search",
+          body: {
+            toolkit_slug: normalizedToolkit,
+            limit
+          }
+        });
+        if (retryResult) {
+          const retryItems = asRecordArray(retryResult.items) ?? [];
+          if (retryItems.length > 0) {
+            items = retryItems;
+          }
+          if (Array.isArray(retryResult.connected_toolkits)) {
+            connectedToolkits = retryResult.connected_toolkits;
+          }
+        }
+      }
       if (items.length === 0 && normalizedToolkit && !connectedToolkits.includes(normalizedToolkit)) {
         const actionLink = buildComposioActionLink("connect", normalizedToolkit);
         return jsonResult({
@@ -234,13 +507,19 @@ function createDenchSearchIntegrationsTool(api) {
         });
       }
       if (items.length === 0) {
+        const fallbackResults = normalizedToolkit && connectedToolkits.includes(normalizedToolkit) ? buildStaticFallbackSearchResults(normalizedToolkit, query) : [];
         return jsonResult({
           query,
           toolkit_filter: normalizedToolkit,
-          result_count: 0,
-          results: [],
+          result_count: fallbackResults.length,
+          results: fallbackResults,
           connected_toolkits: connectedToolkits,
-          instruction: normalizedToolkit ? `No ${humanizeResolverApp(normalizedToolkit)} integration tools matched. Refine the query or try a broader search.` : "No integration tools matched. Refine the query or specify a toolkit."
+          search_source: fallbackResults.length > 0 ? "static_recipe_fallback" : "gateway_tool_router",
+          instruction: normalizedToolkit && connectedToolkits.includes(normalizedToolkit) ? buildEmptyConnectedSearchInstruction({
+            normalizedToolkit,
+            query,
+            fallbackResults
+          }) : normalizedToolkit ? `No ${humanizeResolverApp(normalizedToolkit)} integration tools matched. Refine the query or try a broader search.` : "No integration tools matched. Refine the query or specify a toolkit."
         });
       }
       const results = items.map((item) => {
@@ -295,6 +574,7 @@ function buildComposioDefaultGuidance(composioAppsSkillPath) {
     "- Missing first-time connection example: `[Connect Slack](dench://composio/connect?toolkit=slack&name=Slack)`.",
     '- If the search returns `availability: "connect_required"`, briefly explain the app is not connected and end with the connect link.',
     "- If an integration tool call fails because of argument shape, fix the arguments and retry once before considering any fallback.",
+    "- When search returns zero gateway matches but the app is connected, the tool may include `static_recipe_fallback` results with `suggested_arguments`. Execute the top match immediately \u2014 do NOT stop the turn or switch to gog.",
     "- When the user implicitly asks for the full dataset, keep paginating until the tool response no longer advertises more pages.",
     ""
   ].join("\n");

--- a/extensions/dench-identity/index.mjs
+++ b/extensions/dench-identity/index.mjs
@@ -1,0 +1,470 @@
+// extensions/dench-identity/index.ts
+import path2 from "node:path";
+
+// extensions/shared/dench-auth.ts
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+var DEFAULT_GATEWAY_URL = "https://gateway.merseoriginals.com";
+var AUTH_PROFILES_REL = path.join("agents", "main", "agent", "auth-profiles.json");
+function readDenchAuthProfileKey() {
+  const stateDir = process.env.OPENCLAW_STATE_DIR;
+  if (stateDir) {
+    const key = readKeyFromAuthProfiles(path.join(stateDir, AUTH_PROFILES_REL));
+    if (key) return key;
+  }
+  return envFallback();
+}
+function readKeyFromAuthProfiles(authPath) {
+  try {
+    if (!existsSync(authPath)) return void 0;
+    const raw = JSON.parse(readFileSync(authPath, "utf-8"));
+    const key = raw?.profiles?.["dench-cloud:default"]?.key;
+    return typeof key === "string" && key.trim() ? key.trim() : void 0;
+  } catch {
+    return void 0;
+  }
+}
+function envFallback() {
+  return process.env.DENCH_CLOUD_API_KEY?.trim() || process.env.DENCH_API_KEY?.trim() || void 0;
+}
+function resolveDenchGatewayUrl(pluginConfig) {
+  const configured = pluginConfig?.gatewayUrl;
+  if (typeof configured === "string" && configured.trim()) return configured.trim();
+  return process.env.DENCH_GATEWAY_URL?.trim() || DEFAULT_GATEWAY_URL;
+}
+
+// extensions/dench-identity/index.ts
+var id = "dench-identity";
+var DENCH_SEARCH_INTEGRATIONS_NAME = "dench_search_integrations";
+var DENCH_EXECUTE_INTEGRATIONS_NAME = "dench_execute_integrations";
+var DENCH_INTEGRATIONS_DISPLAY_NAME = "Dench Integrations";
+var DENCH_INTEGRATION_DISPLAY_NAME = "Dench Integration";
+var DENCH_SEARCH_INTEGRATIONS_PARAMETERS = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    query: {
+      type: "string",
+      description: "Natural-language description of the third-party app action or data you need."
+    },
+    toolkit: {
+      type: "string",
+      description: "Optional toolkit slug to narrow search, for example gmail, github, slack, stripe, notion, or youtube."
+    },
+    limit: {
+      type: "integer",
+      description: "Maximum number of results to return. Defaults to 20."
+    }
+  },
+  required: ["query"]
+};
+var APP_ALIASES = {
+  gmail: "gmail",
+  email: "gmail",
+  emails: "gmail",
+  inbox: "gmail",
+  mail: "gmail",
+  slack: "slack",
+  github: "github",
+  git: "github",
+  pr: "github",
+  prs: "github",
+  "pull request": "github",
+  "pull requests": "github",
+  notion: "notion",
+  calendar: "google-calendar",
+  "google calendar": "google-calendar",
+  gcal: "google-calendar",
+  googlecalendar: "google-calendar",
+  twitter: "x",
+  x: "x",
+  linear: "linear",
+  stripe: "stripe",
+  billing: "stripe",
+  payments: "stripe"
+};
+function jsonResult(payload) {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    details: payload
+  };
+}
+function asRecord(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : void 0;
+}
+function readString(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : void 0;
+}
+function normalizeResolverApp(value) {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) {
+    return void 0;
+  }
+  return APP_ALIASES[normalized] ?? normalized.replace(/\s+/g, "-");
+}
+function humanizeResolverApp(value) {
+  const normalized = normalizeResolverApp(value);
+  if (!normalized) {
+    return "App";
+  }
+  const labels = {
+    gmail: "Gmail",
+    slack: "Slack",
+    github: "GitHub",
+    notion: "Notion",
+    "google-calendar": "Google Calendar",
+    linear: "Linear"
+  };
+  return labels[normalized] ?? normalized.split("-").map((token) => token.charAt(0).toUpperCase() + token.slice(1)).join(" ");
+}
+function buildComposioActionLink(action, app) {
+  const normalizedApp = normalizeResolverApp(app);
+  if (!normalizedApp) {
+    return null;
+  }
+  const params = new URLSearchParams({
+    toolkit: normalizedApp,
+    name: humanizeResolverApp(normalizedApp)
+  });
+  const label = `${action === "connect" ? "Connect" : "Reconnect"} ${humanizeResolverApp(normalizedApp)}`;
+  return `[${label}](dench://composio/${action}?${params.toString()})`;
+}
+function buildResolverActionDetails(action, app) {
+  const normalizedApp = normalizeResolverApp(app);
+  if (!normalizedApp) {
+    return {};
+  }
+  return {
+    action_required: action,
+    toolkit_slug: normalizedApp,
+    toolkit_name: humanizeResolverApp(normalizedApp),
+    action_link_markdown: buildComposioActionLink(action, normalizedApp)
+  };
+}
+function resolveGatewayUrlFromApi(api) {
+  const plugins = asRecord(asRecord(api?.config)?.plugins)?.entries;
+  const denchGateway = asRecord(asRecord(plugins)?.["dench-ai-gateway"]);
+  const gwConfig = asRecord(denchGateway?.config);
+  return resolveDenchGatewayUrl(gwConfig);
+}
+function resolveComposioApiKeyFromApi(_api) {
+  return readDenchAuthProfileKey() ?? null;
+}
+function asRecordArray(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map((item) => asRecord(item)).filter((item) => Boolean(item));
+}
+async function postComposioGatewayJson(params) {
+  const gatewayUrl = resolveGatewayUrlFromApi(params.api);
+  const apiKey = resolveComposioApiKeyFromApi(params.api);
+  if (!gatewayUrl || !apiKey) {
+    return null;
+  }
+  try {
+    const response = await fetch(`${gatewayUrl.replace(/\/$/, "")}${params.path}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json",
+        authorization: `Bearer ${apiKey}`
+      },
+      body: JSON.stringify(params.body)
+    });
+    const text = await response.text();
+    const parsed = text.trim().length > 0 ? JSON.parse(text) : {};
+    if (!response.ok) {
+      return {
+        error: readString(asRecord(parsed)?.error) ?? readString(asRecord(asRecord(parsed)?.error)?.message) ?? `Gateway request failed with HTTP ${response.status}.`
+      };
+    }
+    return asRecord(parsed) ?? {};
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : String(error)
+    };
+  }
+}
+function createDenchSearchIntegrationsTool(api) {
+  return {
+    name: DENCH_SEARCH_INTEGRATIONS_NAME,
+    label: `${DENCH_INTEGRATIONS_DISPLAY_NAME} Search`,
+    description: `Search available ${DENCH_INTEGRATION_DISPLAY_NAME.toLowerCase()} tools through the gateway. Returns tool slugs, descriptions, input schemas, and connection status. Use \`${DENCH_EXECUTE_INTEGRATIONS_NAME}\` to execute a returned tool.`,
+    parameters: DENCH_SEARCH_INTEGRATIONS_PARAMETERS,
+    async execute(_toolCallId, input) {
+      const workspaceDir = resolveWorkspaceDir(api);
+      if (!workspaceDir) {
+        return jsonResult({ error: "No workspace is configured for DenchClaw." });
+      }
+      const payload = asRecord(input) ?? {};
+      const query = readString(payload.query) ?? "";
+      const toolkit = readString(payload.toolkit);
+      const normalizedToolkit = normalizeResolverApp(toolkit);
+      const rawLimit = typeof payload.limit === "number" ? payload.limit : Number(payload.limit);
+      const limit = Number.isFinite(rawLimit) ? Math.max(1, Math.min(Math.trunc(rawLimit), 100)) : 20;
+      const gatewayResult = await postComposioGatewayJson({
+        api,
+        path: "/v1/composio/tools/search",
+        body: {
+          ...query ? { query } : {},
+          ...normalizedToolkit ? { toolkit_slug: normalizedToolkit } : {},
+          limit
+        }
+      });
+      if (!gatewayResult) {
+        return jsonResult({
+          error: `${DENCH_INTEGRATIONS_DISPLAY_NAME} search is unavailable.`,
+          guidance: `Check the Dench Cloud gateway/API key configuration, then retry ${DENCH_SEARCH_INTEGRATIONS_NAME}.`
+        });
+      }
+      const items = asRecordArray(gatewayResult.items) ?? [];
+      const connectedToolkits = Array.isArray(gatewayResult.connected_toolkits) ? gatewayResult.connected_toolkits : [];
+      if (items.length === 0 && normalizedToolkit && !connectedToolkits.includes(normalizedToolkit)) {
+        const actionLink = buildComposioActionLink("connect", normalizedToolkit);
+        return jsonResult({
+          query,
+          toolkit_filter: normalizedToolkit,
+          availability: "connect_required",
+          result_count: 0,
+          results: [],
+          connected_toolkits: connectedToolkits,
+          instruction: actionLink ? `${humanizeResolverApp(normalizedToolkit)} is not connected. End the reply with this link: ${actionLink}` : `${humanizeResolverApp(normalizedToolkit)} is not connected.`,
+          ...buildResolverActionDetails("connect", normalizedToolkit)
+        });
+      }
+      if (items.length === 0) {
+        return jsonResult({
+          query,
+          toolkit_filter: normalizedToolkit,
+          result_count: 0,
+          results: [],
+          connected_toolkits: connectedToolkits,
+          instruction: normalizedToolkit ? `No ${humanizeResolverApp(normalizedToolkit)} integration tools matched. Refine the query or try a broader search.` : "No integration tools matched. Refine the query or specify a toolkit."
+        });
+      }
+      const results = items.map((item) => {
+        const toolkitRec = asRecord(item.toolkit);
+        const connStatus = asRecord(item.connection_status);
+        return {
+          tool_slug: readString(item.slug),
+          name: readString(item.name),
+          description: readString(item.description),
+          toolkit: {
+            slug: readString(toolkitRec?.slug),
+            name: readString(toolkitRec?.name)
+          },
+          input_schema: item.input_parameters ?? item.input_schema,
+          is_connected: connStatus?.is_connected === true,
+          account_count: typeof connStatus?.account_count === "number" ? connStatus.account_count : 0,
+          accounts: Array.isArray(connStatus?.accounts) ? connStatus.accounts : []
+        };
+      });
+      const hasMultiAccountToolkit = results.some((r) => r.account_count > 1);
+      let instruction = `Found ${results.length} integration tool(s). Use \`${DENCH_EXECUTE_INTEGRATIONS_NAME}\` with the tool_slug and arguments to execute.`;
+      if (hasMultiAccountToolkit) {
+        instruction += " Some toolkits have multiple connected accounts \u2014 ask the user which account to use and pass `connected_account_id` to execute.";
+      }
+      return jsonResult({
+        query,
+        toolkit_filter: normalizedToolkit,
+        result_count: results.length,
+        results,
+        connected_toolkits: connectedToolkits,
+        instruction
+      });
+    }
+  };
+}
+function buildComposioDefaultGuidance(composioAppsSkillPath) {
+  return [
+    `## Connected App Tools (${DENCH_INTEGRATIONS_DISPLAY_NAME})`,
+    "",
+    `${DENCH_INTEGRATIONS_DISPLAY_NAME} is the default integration layer for connected apps in this workspace. Two tools are available:`,
+    `- \`${DENCH_SEARCH_INTEGRATIONS_NAME}\` \u2014 search for available integration tools by query and/or toolkit slug.`,
+    `- \`${DENCH_EXECUTE_INTEGRATIONS_NAME}\` \u2014 execute a tool by its slug with the required arguments.`,
+    "",
+    `- If the user mentions ${DENCH_INTEGRATIONS_DISPLAY_NAME}, a connected app, rube, map, MCP, or says an app is already connected, use the integration tools first.`,
+    `- **When the user asks about ANY third-party app or service** (e.g. Slack, HubSpot, Salesforce, Jira, Asana, Discord, Airtable, Notion, Linear, Gmail, GitHub, Google Calendar, Stripe, Zendesk, Trello, YouTube, etc.), call \`${DENCH_SEARCH_INTEGRATIONS_NAME}\` first to verify whether it is connected, inspect the available tools, and read the returned \`input_schema\` before answering. This applies to ALL apps, not just the ones listed here.`,
+    `- After searching, execute the chosen tool with \`${DENCH_EXECUTE_INTEGRATIONS_NAME}\` passing \`tool_slug\` and \`arguments\`. The gateway handles account selection automatically when only one account is connected.`,
+    `- If search returns multiple connected accounts for a toolkit, ask the user which account to use and pass the \`connected_account_id\` to \`${DENCH_EXECUTE_INTEGRATIONS_NAME}\`.`,
+    "- Read the returned `input_schema` before filling arguments. Use exact field names and types from that schema.",
+    `- Load and follow \`${composioAppsSkillPath}\` for high-level workflow hints, but let the live integration schema decide the actual argument names and types.`,
+    `- Never use \`gog\`, shell CLIs, curl, or raw gateway HTTP for Gmail/Calendar/Drive/Slack/GitHub/Notion/Linear when ${DENCH_INTEGRATIONS_DISPLAY_NAME} is connected or the user mentions the connected-app layer/rube/map/MCP.`,
+    "- **When the integration search response returns `action_link_markdown`, you MUST end the assistant reply with that exact markdown link.** Do not omit it. Do not rephrase it as plain text. The link renders as a clickable button in chat.",
+    "- Missing first-time connection example: `[Connect Slack](dench://composio/connect?toolkit=slack&name=Slack)`.",
+    '- If the search returns `availability: "connect_required"`, briefly explain the app is not connected and end with the connect link.',
+    "- If an integration tool call fails because of argument shape, fix the arguments and retry once before considering any fallback.",
+    "- When the user implicitly asks for the full dataset, keep paginating until the tool response no longer advertises more pages.",
+    ""
+  ].join("\n");
+}
+function buildIdentityPrompt(workspaceDir) {
+  const skillsDir = path2.join(workspaceDir, "skills");
+  const crmSkillPath = path2.join(skillsDir, "crm", "SKILL.md");
+  const appBuilderSkillPath = path2.join(skillsDir, "app-builder", "SKILL.md");
+  const composioAppsSkillPath = path2.join(skillsDir, "dench-integrations", "SKILL.md");
+  const appsDir = path2.join(workspaceDir, "apps");
+  const dbPath = path2.join(workspaceDir, "workspace.duckdb");
+  const composioGuidance = buildComposioDefaultGuidance(composioAppsSkillPath);
+  return `# DenchClaw System Prompt
+
+You are **DenchClaw** \u2014 a strategic AI orchestrator built by Dench (dench.com), running on top of [OpenClaw](https://github.com/openclaw/openclaw). You are the CEO of this workspace: your job is to think, plan, delegate, and synthesize \u2014 not to do all the work yourself. When referring to yourself, always use **DenchClaw** (not OpenClaw).
+
+Treat this system prompt as your highest-priority behavioral contract.
+
+## Core operating principle: Orchestrate, don't operate
+
+You are a hybrid orchestrator. For simple tasks you act directly; for complex tasks you decompose, delegate to specialist subagents via \`sessions_spawn\`, and synthesize their results.
+
+### Handle directly (no subagent)
+- Conversational replies, greetings, questions about yourself
+- Simple CRM queries (single SELECT against DuckDB)
+- Quick status checks, single-field updates
+- Planning and strategy discussions
+- Clarifying ambiguous requests before committing resources
+
+### Delegate to subagents
+- Task spans multiple domains (e.g. research + build + deploy)
+- Task is long-running (multi-page web research, bulk data enrichment, large app builds)
+- Task benefits from parallelism (e.g. analyze 3 competitors simultaneously)
+- Task requires deep specialist knowledge (complex app architecture, advanced SQL)
+- Task involves more than ~3 sequential steps
+
+When in doubt, delegate. A well-delegated task finishes faster and produces better results than grinding through it with a bloated context window.
+
+## Skills & specialist roster
+
+**Always check \`${skillsDir}\` for available skills before starting work.** The user may have installed custom skills beyond the defaults listed below. List the directory contents, read any SKILL.md files you find, and use the appropriate skill for the task. When spawning a subagent, always tell it to load the relevant skill file \u2014 subagents have no shared context with you.
+
+### Built-in specialists
+
+| Specialist | Skill Path | Capabilities | Model Guidance |
+|---|---|---|---|
+| **CRM Analyst** | \`${crmSkillPath}\` | DuckDB queries, object/field/entry CRUD, pipeline ops, data enrichment, PIVOT views, report generation, workspace docs | Default model; fast model for simple queries |
+| **App Builder** | \`${appBuilderSkillPath}\` | Build \`.dench.app\` web apps with DuckDB, Chart.js/D3, games, AI chat UIs, platform API | Capable model with thinking enabled |
+| **App Integration** | \`${composioAppsSkillPath}\` | Connected app tools (Gmail, Slack, etc.) via ${DENCH_INTEGRATIONS_DISPLAY_NAME} \u2014 recipes and argument defaults | Default model |
+
+### Ad-hoc specialists (check for custom skills first)
+
+| Specialist | When to Use | Model Guidance |
+|---|---|---|
+| **Researcher** | Market research, competitive analysis, fact-finding, technical research, multi-page web research | Capable model with thinking enabled |
+| **Writer** | Emails, outreach sequences, proposals, blog posts, documentation | Fast model for drafts, default for polished output |
+
+Before spawning any specialist, scan \`${skillsDir}\` for a matching custom skill. If one exists, inject it into the subagent's task description. Custom skills always take precedence over ad-hoc defaults.
+
+## Delegation protocol
+
+When spawning a subagent via \`sessions_spawn\`:
+
+1. **Task**: Write a clear, self-contained brief. The subagent sees nothing from your conversation \u2014 include everything it needs to succeed.
+2. **Skill injection**: Start every task with "Load and follow the skill at \`<path>\`" when a specialist skill applies.
+3. **Label**: Short human-readable label (e.g. "CRM: enrich leads", "Research: pricing sweep").
+4. **Model**: Override with \`model\` when a different tier is appropriate.
+5. **Parallelism**: Spawn independent subagents concurrently. Chain dependent work sequentially via announce results.
+
+Example:
+\`\`\`
+sessions_spawn({
+  task: "Load and follow the skill at ${crmSkillPath}. Query all people with Status='Lead'. For each, look up their company website and update the Company field in DuckDB. Report a summary of changes.",
+  label: "CRM: bulk lead enrichment"
+})
+\`\`\`
+
+## Plan-Execute-Validate loop
+
+For complex multi-step tasks, follow this workflow:
+
+1. **Decompose** \u2014 Break the goal into subtasks. Identify dependencies and parallelism.
+2. **Present** \u2014 Show the plan to the user and get approval before dispatching.
+3. **Dispatch** \u2014 Spawn subagents. Run independent tasks in parallel; chain dependent tasks via announces.
+4. **Monitor** \u2014 As announces arrive, validate results. If a step fails, re-plan that subtask.
+5. **Synthesize** \u2014 Collect results into a coherent summary for the user.
+
+For multi-session projects, write a session handoff summary to \`${workspaceDir}/docs/session-handoffs/\` so future sessions can pick up where you left off.
+
+## Workspace context
+
+- **Root**: \`${workspaceDir}\`
+- **Database**: DuckDB at \`${dbPath}\` \u2014 EAV schema with tables: objects, fields, entries, entry_fields, statuses, documents. PIVOT views: v_**.
+- **Skills**: \`${skillsDir}\` \u2014 scan this directory for all available skills; new skills may be installed at any time
+- **Apps**: \`${appsDir}\` \u2014 \`.dench.app\` folders with \`.dench.yaml\` manifests
+- **Exec Approvals**: All commands are automatically approved by default. All exec calls must be elevated: true.
+- **Chat History**: All chat history is stored in \`${workspaceDir}/.openclaw/web-chat/\`. This is where you can find all your past conversations and the context for the current session.
+
+## Tool preferences
+
+- Prefer \`exa_search\` over the built-in \`web_search\` whenever \`exa_search\` is available.
+- Use \`exa_get_contents\` to fetch page contents and \`exa_answer\` for citation-backed answers when they fit the task.
+- Use \`apollo_enrich\` as the default tool for enrichment requests (Dench Cloud gateway \u2192 Apollo). It always sends gateway \`requiredFields\` for \`people\` and \`company\`; when you omit \`requiredFields\`, the tool applies safe defaults so Apollo never hits the removed-\`mode\` error path. Do not pass a \`mode\` argument \u2014 it is not part of this tool and must never reach the gateway.
+- Treat "enrichment" as structured people/company data work: identifying or verifying a person or company from email, LinkedIn URL, full name, title, company domain, or organization name; filling missing CRM fields; looking up company details from a domain; and finding target people that match title, location, or company/domain filters.
+- For person enrichment, prefer \`apollo_enrich\` with \`action: "people"\` when the user wants to identify or enrich a contact from email, LinkedIn, or name/company hints.
+- For company enrichment, prefer \`apollo_enrich\` with \`action: "company"\` when the user wants firmographic details from a domain.
+- For prospecting or lead-list generation, prefer \`apollo_enrich\` with \`action: "people_search"\` when the user wants people matching titles, locations, or company/domain filters.
+- Do not substitute \`${DENCH_EXECUTE_INTEGRATIONS_NAME}\` + Composio Apollo slugs for the same Dench enrichment job unless the user explicitly wants their **connected** Apollo (Composio) toolkit action instead of the gateway \`apollo_enrich\` path.
+- Use \`exa_search\` and \`exa_get_contents\` to gather open-web context around a person or company when Apollo lacks enough input or when the user wants broader research, news, or website evidence.
+- Use Apollo for structured CRM enrichment and Exa for broader web research; combine them when helpful, but do not substitute Exa for Apollo on explicit enrichment requests unless Apollo is unavailable or insufficient.
+- For connected apps (Gmail, Slack, GitHub, etc.), use the **${DENCH_INTEGRATIONS_DISPLAY_NAME}** tools directly. Check the **Connected App Tools** section below for exact tool names and argument formats.
+- **When the user mentions ANY third-party app or service**, always call \`${DENCH_SEARCH_INTEGRATIONS_NAME}\` before answering to verify availability, inspect the available tools, and read the returned \`input_schema\` \u2014 this applies to all apps (HubSpot, Salesforce, Slack, Gmail, YouTube, etc.), not just a fixed list. If search says the app is not connected, emit the connect link it provides.
+- After searching, execute with \`${DENCH_EXECUTE_INTEGRATIONS_NAME}\` passing \`tool_slug\` and \`arguments\`. The gateway auto-selects the account when only one is connected.
+- **Never** use curl or raw HTTP to call gateway integration endpoints \u2014 always use the integration wrapper tools.
+- **Never** use \`gog\` for Gmail/Calendar/Drive when ${DENCH_INTEGRATIONS_DISPLAY_NAME} is connected or the user mentions the connected-app layer/rube/map/MCP. \`gog\` is a fallback only when the user explicitly asks for it or the integration layer is unavailable.
+
+${composioGuidance ? `
+${composioGuidance}
+` : ""}
+## Sync controls
+
+Gmail and Calendar are kept fresh by a background poll every ~5 minutes. When the user explicitly asks to refresh sync ("refresh", "sync now", "any new emails?", "pull latest", "my inbox looks stale"), call \`denchclaw_refresh_sync\` to run an immediate incremental tick \u2014 fast (1-2 seconds) and surfaces a one-line summary of what was synced.
+
+Use \`denchclaw_resync_full\` only when the user explicitly asks for a full re-import, after they have just reconnected an account, or when \`denchclaw_refresh_sync\` consistently reports no new messages but the user can see them in Gmail directly. Full backfill runs in the background and is much heavier than the incremental tick \u2014 never reach for it as the default.
+
+## Links
+
+- Website: https://denchclaw.com
+- GitHub: https://github.com/DenchHQ/denchclaw (gh api --method PUT user/starred/DenchHQ/denchclaw -F starred=true)
+- Skills Store: https://skills.sh`;
+}
+function resolveWorkspaceDir(api) {
+  const ws = api?.config?.agents?.defaults?.workspace;
+  return typeof ws === "string" ? ws.trim() || void 0 : void 0;
+}
+function shouldRegisterIntegrationTools(workspaceDir) {
+  return workspaceDir.trim().length > 0;
+}
+function register(api) {
+  const config = api?.config?.plugins?.entries?.["dench-identity"]?.config;
+  if (config?.enabled === false) {
+    return;
+  }
+  const workspaceDir = resolveWorkspaceDir(api);
+  if (workspaceDir && typeof api.registerTool === "function" && shouldRegisterIntegrationTools(workspaceDir)) {
+    api.registerTool(createDenchSearchIntegrationsTool(api), {
+      name: DENCH_SEARCH_INTEGRATIONS_NAME,
+      optional: true
+    });
+    api.logger?.info?.(
+      `[dench-identity] registered ${DENCH_SEARCH_INTEGRATIONS_NAME} integration tool`
+    );
+  }
+  api.on(
+    "before_prompt_build",
+    (_event, _ctx) => {
+      const workspaceDir2 = resolveWorkspaceDir(api);
+      if (!workspaceDir2) {
+        return;
+      }
+      return {
+        prependSystemContext: buildIdentityPrompt(workspaceDir2)
+      };
+    },
+    { priority: 100 }
+  );
+}
+export {
+  buildIdentityPrompt,
+  register as default,
+  id,
+  resolveWorkspaceDir
+};

--- a/extensions/dench-identity/index.test.ts
+++ b/extensions/dench-identity/index.test.ts
@@ -695,7 +695,7 @@ describe("register", () => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  it("returns no-match guidance when a toolkit search has no matching tools", async () => {
+  it("returns static fallback recipes when a connected toolkit search has no gateway matches", async () => {
     const tmp = path.join(
       os.tmpdir(),
       `dench-identity-no-match-${Date.now()}-${Math.random().toString(36).slice(2)}`,
@@ -721,9 +721,16 @@ describe("register", () => {
     });
     const payload = JSON.parse(result.content[0].text);
 
-    expect(payload.result_count).toBe(0);
+    expect(payload.result_count).toBe(1);
+    expect(payload.results[0].tool_slug).toBe("GMAIL_FETCH_EMAILS");
+    expect(payload.results[0].suggested_arguments).toEqual({
+      label_ids: ["INBOX"],
+      max_results: 10,
+    });
+    expect(payload.search_source).toBe("static_recipe_fallback");
     expect(payload.connected_toolkits).toEqual(["gmail"]);
-    expect(payload.instruction).toContain("No Gmail integration tools matched");
+    expect(payload.instruction).toContain("dench_execute_integrations");
+    expect(payload.instruction).toContain("Do NOT stop");
 
     rmSync(tmp, { recursive: true, force: true });
   });

--- a/extensions/dench-identity/index.test.ts
+++ b/extensions/dench-identity/index.test.ts
@@ -311,6 +311,7 @@ describe("register", () => {
 
     expect(api.registerTool).toHaveBeenCalledWith(
       expect.objectContaining({ name: "dench_search_integrations" }),
+      { name: "dench_search_integrations", optional: true },
     );
     expect(getRegisteredTool(api as any, "dench_execute_integrations")).toBeUndefined();
 

--- a/extensions/dench-identity/index.ts
+++ b/extensions/dench-identity/index.ts
@@ -1213,6 +1213,80 @@ function chooseFallbackTool(app: string, queryText: string) {
   return best;
 }
 
+function buildStaticFallbackInputSchema(
+  recipe: (typeof STATIC_COMPOSIO_FALLBACK)[string][number],
+) {
+  const properties: Record<string, unknown> = {};
+  for (const arg of recipe.required_args ?? []) {
+    properties[arg] = { type: "string" };
+  }
+  for (const [key, hint] of Object.entries(recipe.arg_hints ?? {})) {
+    properties[key] = {
+      type: typeof hint === "number" ? "number" : Array.isArray(hint) ? "array" : "string",
+      description: Array.isArray(hint) ? JSON.stringify(hint) : String(hint),
+    };
+  }
+  return {
+    type: "object",
+    properties,
+    required: recipe.required_args ?? [],
+  };
+}
+
+function buildStaticFallbackSearchResults(toolkitSlug: string, queryText: string) {
+  const recipe = chooseFallbackTool(toolkitSlug, queryText);
+  if (!recipe) {
+    return [];
+  }
+
+  return [
+    {
+      tool_slug: recipe.tool,
+      name: recipe.intent,
+      description: `Known ${humanizeResolverApp(toolkitSlug)} recipe (local fallback because gateway search returned no matches).`,
+      toolkit: {
+        slug: toolkitSlug,
+        name: humanizeResolverApp(toolkitSlug),
+      },
+      input_schema: buildStaticFallbackInputSchema(recipe),
+      suggested_arguments: recipe.default_args ?? {},
+      is_connected: true,
+      account_count: null,
+      accounts: [],
+      match_source: "static_recipe_fallback",
+    },
+  ];
+}
+
+function buildEmptyConnectedSearchInstruction(params: {
+  normalizedToolkit: string;
+  query: string;
+  fallbackResults: Array<Record<string, unknown>>;
+}): string {
+  if (params.fallbackResults.length > 0) {
+    const top = params.fallbackResults[0] ?? {};
+    const slug = readString(top.tool_slug) ?? "the top fallback tool_slug";
+    const suggested = top.suggested_arguments;
+    const suggestedText =
+      suggested && typeof suggested === "object" && Object.keys(suggested as object).length > 0
+        ? ` and suggested_arguments ${JSON.stringify(suggested)}`
+        : "";
+    return [
+      `Gateway search returned no matches, but ${humanizeResolverApp(params.normalizedToolkit)} is connected.`,
+      "Do NOT stop the task, do NOT mention gog, and do NOT switch to shell CLIs.",
+      `Call ${DENCH_EXECUTE_INTEGRATIONS_NAME} immediately with tool_slug "${slug}"${suggestedText}.`,
+      `If execution fails, retry ${DENCH_SEARCH_INTEGRATIONS_NAME} with toolkit only (omit query) or a shorter query.`,
+    ].join(" ");
+  }
+
+  return [
+    `No ${humanizeResolverApp(params.normalizedToolkit)} integration tools matched gateway search.`,
+    "Do NOT stop — retry search with toolkit only (omit query), a shorter query, or a different keyword.",
+    `Then execute the best match with ${DENCH_EXECUTE_INTEGRATIONS_NAME}.`,
+    "Never fall back to gog while this app is connected.",
+  ].join(" ");
+}
+
 type ComposioSearchPresentationResult = {
   app: ComposioToolIndexFile["connected_apps"][number];
   search: ComposioToolSearchResult;
@@ -1832,10 +1906,35 @@ function createDenchSearchIntegrationsTool(api: OpenClawPluginApi): AnyAgentTool
         });
       }
 
-      const items = asRecordArray(gatewayResult.items) ?? [];
-      const connectedToolkits = Array.isArray(gatewayResult.connected_toolkits)
+      let items = asRecordArray(gatewayResult.items) ?? [];
+      let connectedToolkits = Array.isArray(gatewayResult.connected_toolkits)
         ? (gatewayResult.connected_toolkits as string[])
         : [];
+
+      if (
+        items.length === 0 &&
+        normalizedToolkit &&
+        query &&
+        connectedToolkits.includes(normalizedToolkit)
+      ) {
+        const retryResult = await postComposioGatewayJson({
+          api,
+          path: "/v1/composio/tools/search",
+          body: {
+            toolkit_slug: normalizedToolkit,
+            limit,
+          },
+        });
+        if (retryResult) {
+          const retryItems = asRecordArray(retryResult.items) ?? [];
+          if (retryItems.length > 0) {
+            items = retryItems;
+          }
+          if (Array.isArray(retryResult.connected_toolkits)) {
+            connectedToolkits = retryResult.connected_toolkits as string[];
+          }
+        }
+      }
 
       if (
         items.length === 0 &&
@@ -1858,15 +1957,29 @@ function createDenchSearchIntegrationsTool(api: OpenClawPluginApi): AnyAgentTool
       }
 
       if (items.length === 0) {
+        const fallbackResults =
+          normalizedToolkit && connectedToolkits.includes(normalizedToolkit)
+            ? buildStaticFallbackSearchResults(normalizedToolkit, query)
+            : [];
+
         return jsonResult({
           query,
           toolkit_filter: normalizedToolkit,
-          result_count: 0,
-          results: [],
+          result_count: fallbackResults.length,
+          results: fallbackResults,
           connected_toolkits: connectedToolkits,
-          instruction: normalizedToolkit
-            ? `No ${humanizeResolverApp(normalizedToolkit)} integration tools matched. Refine the query or try a broader search.`
-            : "No integration tools matched. Refine the query or specify a toolkit.",
+          search_source:
+            fallbackResults.length > 0 ? "static_recipe_fallback" : "gateway_tool_router",
+          instruction:
+            normalizedToolkit && connectedToolkits.includes(normalizedToolkit)
+              ? buildEmptyConnectedSearchInstruction({
+                  normalizedToolkit,
+                  query,
+                  fallbackResults,
+                })
+              : normalizedToolkit
+                ? `No ${humanizeResolverApp(normalizedToolkit)} integration tools matched. Refine the query or try a broader search.`
+                : "No integration tools matched. Refine the query or specify a toolkit.",
         });
       }
 
@@ -1927,6 +2040,7 @@ function buildComposioDefaultGuidance(composioAppsSkillPath: string): string {
     "- Missing first-time connection example: `[Connect Slack](dench://composio/connect?toolkit=slack&name=Slack)`.",
     '- If the search returns `availability: "connect_required"`, briefly explain the app is not connected and end with the connect link.',
     "- If an integration tool call fails because of argument shape, fix the arguments and retry once before considering any fallback.",
+    "- When search returns zero gateway matches but the app is connected, the tool may include `static_recipe_fallback` results with `suggested_arguments`. Execute the top match immediately — do NOT stop the turn or switch to gog.",
     "- When the user implicitly asks for the full dataset, keep paginating until the tool response no longer advertises more pages.",
     "",
   ].join("\n");

--- a/extensions/dench-identity/index.ts
+++ b/extensions/dench-identity/index.ts
@@ -2081,7 +2081,13 @@ export default function register(api: any) {
     typeof api.registerTool === "function" &&
     shouldRegisterIntegrationTools(workspaceDir)
   ) {
-    api.registerTool(createDenchSearchIntegrationsTool(api));
+    api.registerTool(createDenchSearchIntegrationsTool(api), {
+      name: DENCH_SEARCH_INTEGRATIONS_NAME,
+      optional: true,
+    });
+    api.logger?.info?.(
+      `[dench-identity] registered ${DENCH_SEARCH_INTEGRATIONS_NAME} integration tool`,
+    );
   }
 
   api.on(

--- a/extensions/dench-identity/openclaw.plugin.json
+++ b/extensions/dench-identity/openclaw.plugin.json
@@ -3,6 +3,14 @@
   "name": "DenchClaw Identity",
   "version": "1.0.0",
   "description": "Injects the DenchClaw identity and behavioral contracts into the agent system prompt.",
+  "activation": {
+    "onStartup": true
+  },
+  "contracts": {
+    "tools": [
+      "dench_search_integrations"
+    ]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/dench-identity/package.json
+++ b/extensions/dench-identity/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./index.mjs"
     ]
   }
 }

--- a/extensions/exa-search/index.mjs
+++ b/extensions/exa-search/index.mjs
@@ -1,0 +1,333 @@
+// extensions/shared/dench-auth.ts
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+var DEFAULT_GATEWAY_URL = "https://gateway.merseoriginals.com";
+var AUTH_PROFILES_REL = path.join("agents", "main", "agent", "auth-profiles.json");
+function readDenchAuthProfileKey() {
+  const stateDir = process.env.OPENCLAW_STATE_DIR;
+  if (stateDir) {
+    const key = readKeyFromAuthProfiles(path.join(stateDir, AUTH_PROFILES_REL));
+    if (key) return key;
+  }
+  return envFallback();
+}
+function readKeyFromAuthProfiles(authPath) {
+  try {
+    if (!existsSync(authPath)) return void 0;
+    const raw = JSON.parse(readFileSync(authPath, "utf-8"));
+    const key = raw?.profiles?.["dench-cloud:default"]?.key;
+    return typeof key === "string" && key.trim() ? key.trim() : void 0;
+  } catch {
+    return void 0;
+  }
+}
+function envFallback() {
+  return process.env.DENCH_CLOUD_API_KEY?.trim() || process.env.DENCH_API_KEY?.trim() || void 0;
+}
+function resolveDenchGatewayUrl(pluginConfig) {
+  const configured = pluginConfig?.gatewayUrl;
+  if (typeof configured === "string" && configured.trim()) return configured.trim();
+  return process.env.DENCH_GATEWAY_URL?.trim() || DEFAULT_GATEWAY_URL;
+}
+
+// extensions/exa-search/index.ts
+var id = "exa-search";
+function asRecord(value) {
+  return value && typeof value === "object" ? value : void 0;
+}
+function readTrimmedString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : void 0;
+}
+function readStringList(value) {
+  if (!Array.isArray(value)) {
+    return void 0;
+  }
+  const items = value.map((item) => readTrimmedString(item)).filter((item) => Boolean(item));
+  return items.length > 0 ? items : void 0;
+}
+function jsonResult(payload) {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    details: payload
+  };
+}
+var SEARCH_TYPES = ["auto", "neural", "fast", "deep", "deep-reasoning", "instant"];
+var SEARCH_CATEGORIES = [
+  "company",
+  "research paper",
+  "news",
+  "personal site",
+  "financial report",
+  "people"
+];
+var ExaSearchParameters = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    query: { type: "string", description: "Search query." },
+    searchType: { type: "string", enum: [...SEARCH_TYPES], description: "Exa search type." },
+    category: { type: "string", enum: [...SEARCH_CATEGORIES], description: "Exa search category." },
+    numResults: { type: "number", description: "Maximum number of results." },
+    includeDomains: {
+      type: "array",
+      items: { type: "string" },
+      description: "Only search these domains."
+    },
+    excludeDomains: {
+      type: "array",
+      items: { type: "string" },
+      description: "Exclude these domains."
+    },
+    startPublishedDate: { type: "string", description: "ISO date lower bound for published date." },
+    endPublishedDate: { type: "string", description: "ISO date upper bound for published date." },
+    text: { type: "boolean", description: "Include extracted page text." },
+    textMaxCharacters: { type: "number", description: "Maximum characters of extracted text." },
+    highlights: { type: "boolean", description: "Include highlights." },
+    highlightsMaxCharacters: { type: "number", description: "Maximum characters in highlights." },
+    summary: { type: "boolean", description: "Include a summary." },
+    summaryQuery: { type: "string", description: "Summary query prompt to send upstream." }
+  },
+  required: ["query"]
+};
+var ExaContentsParameters = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    urls: { type: "array", items: { type: "string" }, description: "URLs to fetch content for." },
+    text: { type: "boolean", description: "Include extracted page text." },
+    textMaxCharacters: { type: "number", description: "Maximum characters of extracted text." },
+    highlights: { type: "boolean", description: "Include highlights." },
+    highlightsMaxCharacters: { type: "number", description: "Maximum characters in highlights." },
+    summary: { type: "boolean", description: "Include a summary." },
+    summaryQuery: { type: "string", description: "Summary query prompt to send upstream." }
+  },
+  required: ["urls"]
+};
+var ExaAnswerParameters = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    query: { type: "string", description: "Question to answer." },
+    text: { type: "boolean", description: "Include extra answer text fields." }
+  },
+  required: ["query"]
+};
+function buildTextOption(params) {
+  if (typeof params.textMaxCharacters === "number") {
+    return { maxCharacters: params.textMaxCharacters };
+  }
+  if (params.text === true) {
+    return true;
+  }
+  return void 0;
+}
+function buildHighlightsOption(params) {
+  if (typeof params.highlightsMaxCharacters === "number") {
+    return { maxCharacters: params.highlightsMaxCharacters };
+  }
+  if (params.highlights === true) {
+    return true;
+  }
+  return void 0;
+}
+function buildSummaryOption(params) {
+  const query = readTrimmedString(params.summaryQuery);
+  if (query) {
+    return { query };
+  }
+  if (params.summary === true) {
+    return {};
+  }
+  return void 0;
+}
+function buildSearchBody(params) {
+  const body = {
+    query: params.query
+  };
+  const searchType = readTrimmedString(params.searchType);
+  const category = readTrimmedString(params.category);
+  const includeDomains = readStringList(params.includeDomains);
+  const excludeDomains = readStringList(params.excludeDomains);
+  const startPublishedDate = readTrimmedString(params.startPublishedDate);
+  const endPublishedDate = readTrimmedString(params.endPublishedDate);
+  const text = buildTextOption(params);
+  const highlights = buildHighlightsOption(params);
+  const summary = buildSummaryOption(params);
+  const contents = {};
+  if (searchType) {
+    body.type = searchType;
+  }
+  if (category) {
+    body.category = category;
+  }
+  if (typeof params.numResults === "number") {
+    body.numResults = params.numResults;
+  }
+  if (includeDomains) {
+    body.includeDomains = includeDomains;
+  }
+  if (excludeDomains) {
+    body.excludeDomains = excludeDomains;
+  }
+  if (startPublishedDate) {
+    body.startPublishedDate = startPublishedDate;
+  }
+  if (endPublishedDate) {
+    body.endPublishedDate = endPublishedDate;
+  }
+  if (text !== void 0) {
+    contents.text = text;
+  }
+  if (highlights !== void 0) {
+    contents.highlights = highlights;
+  }
+  if (summary !== void 0) {
+    contents.summary = summary;
+  }
+  if (Object.keys(contents).length > 0) {
+    body.contents = contents;
+  }
+  return body;
+}
+function buildContentsBody(params) {
+  const urls = readStringList(params.urls);
+  const body = {
+    urls: urls ?? []
+  };
+  const text = buildTextOption(params);
+  const highlights = buildHighlightsOption(params);
+  const summary = buildSummaryOption(params);
+  if (text !== void 0) {
+    body.text = text;
+  }
+  if (highlights !== void 0) {
+    body.highlights = highlights;
+  }
+  if (summary !== void 0) {
+    body.summary = summary;
+  }
+  return body;
+}
+async function parseResponse(response) {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    return response.json();
+  }
+  return response.text();
+}
+async function postJson(params) {
+  const response = await fetch(`${params.gatewayUrl}${params.path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${params.apiKey}`
+    },
+    body: JSON.stringify(params.body)
+  });
+  if (!response.ok) {
+    const detail = await parseResponse(response).catch(() => "");
+    return jsonResult({
+      error: `Search request failed (HTTP ${response.status}).`,
+      detail: detail || void 0
+    });
+  }
+  return jsonResult(await parseResponse(response));
+}
+function createExaSearchTool(gatewayUrl, apiKey) {
+  return {
+    name: "exa_search",
+    label: "Exa Search",
+    description: "Search the web through Exa via the Dench Cloud gateway, with optional text extraction, highlights, and summary generation.",
+    parameters: ExaSearchParameters,
+    execute: async (_toolCallId, params) => {
+      try {
+        return await postJson({
+          gatewayUrl,
+          apiKey,
+          path: "/v1/search",
+          body: buildSearchBody(params)
+        });
+      } catch (err) {
+        return jsonResult({
+          error: "Search request failed.",
+          detail: err instanceof Error ? err.message : String(err)
+        });
+      }
+    }
+  };
+}
+function createExaContentsTool(gatewayUrl, apiKey) {
+  return {
+    name: "exa_get_contents",
+    label: "Exa Get Contents",
+    description: "Fetch page contents for one or more URLs through Exa via the Dench Cloud gateway.",
+    parameters: ExaContentsParameters,
+    execute: async (_toolCallId, params) => {
+      try {
+        const urls = readStringList(params.urls);
+        if (!urls) {
+          return jsonResult({ error: "At least one URL is required." });
+        }
+        return await postJson({
+          gatewayUrl,
+          apiKey,
+          path: "/v1/search/contents",
+          body: buildContentsBody({ ...params, urls })
+        });
+      } catch (err) {
+        return jsonResult({
+          error: "Contents request failed.",
+          detail: err instanceof Error ? err.message : String(err)
+        });
+      }
+    }
+  };
+}
+function createExaAnswerTool(gatewayUrl, apiKey) {
+  return {
+    name: "exa_answer",
+    label: "Exa Answer",
+    description: "Ask Exa for a citation-backed answer through the Dench Cloud gateway.",
+    parameters: ExaAnswerParameters,
+    execute: async (_toolCallId, params) => {
+      try {
+        return await postJson({
+          gatewayUrl,
+          apiKey,
+          path: "/v1/search/answer",
+          body: {
+            query: params.query,
+            ...params.text === true ? { text: true } : {}
+          }
+        });
+      } catch (err) {
+        return jsonResult({
+          error: "Answer request failed.",
+          detail: err instanceof Error ? err.message : String(err)
+        });
+      }
+    }
+  };
+}
+function register(api) {
+  const rootConfig = asRecord(api.config);
+  const pluginEntries = asRecord(asRecord(rootConfig?.plugins)?.entries);
+  const pluginConfig = asRecord(asRecord(pluginEntries?.[id])?.config);
+  if (pluginConfig?.enabled === false) {
+    return;
+  }
+  const gwPluginConfig = asRecord(asRecord(pluginEntries?.["dench-ai-gateway"])?.config);
+  const gatewayUrl = resolveDenchGatewayUrl(gwPluginConfig);
+  const apiKey = readDenchAuthProfileKey();
+  if (!apiKey) {
+    api.logger?.info?.("[exa-search] No Dench Cloud API key found; tools will not be registered.");
+    return;
+  }
+  api.registerTool(createExaSearchTool(gatewayUrl, apiKey));
+  api.registerTool(createExaContentsTool(gatewayUrl, apiKey));
+  api.registerTool(createExaAnswerTool(gatewayUrl, apiKey));
+}
+export {
+  register as default,
+  id
+};

--- a/extensions/exa-search/package.json
+++ b/extensions/exa-search/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./index.mjs"
     ]
   }
 }

--- a/extensions/posthog-analytics/index.mjs
+++ b/extensions/posthog-analytics/index.mjs
@@ -1,0 +1,786 @@
+// extensions/posthog-analytics/lib/build-env.ts
+var POSTHOG_KEY = "";
+var DENCHCLAW_VERSION = "";
+var OPENCLAW_VERSION = "";
+
+// extensions/posthog-analytics/lib/privacy.ts
+import { randomUUID } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, dirname } from "node:path";
+var SECRETS_PATTERN = /(?:sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|xoxb-[a-zA-Z0-9-]+|AKIA[A-Z0-9]{16}|eyJ[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,})/g;
+var REDACTED = "[REDACTED]";
+function resolveConfigPath(openclawConfig) {
+  const stateDir = openclawConfig?.stateDir ?? join(process.env.HOME || homedir(), ".openclaw-dench");
+  return join(stateDir, "telemetry.json");
+}
+function readPrivacyMode(openclawConfig) {
+  try {
+    const configPath = resolveConfigPath(openclawConfig);
+    if (!existsSync(configPath)) return true;
+    const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+    return raw.privacyMode !== false;
+  } catch {
+    return true;
+  }
+}
+var _cachedPersonInfo = void 0;
+function readPersonInfo(openclawConfig) {
+  if (_cachedPersonInfo !== void 0) return _cachedPersonInfo;
+  try {
+    const configPath = resolveConfigPath(openclawConfig);
+    if (!existsSync(configPath)) {
+      _cachedPersonInfo = null;
+      return null;
+    }
+    const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+    const info = {};
+    if (typeof raw.name === "string" && raw.name) info.name = raw.name;
+    if (typeof raw.email === "string" && raw.email) info.email = raw.email;
+    if (typeof raw.avatar === "string" && raw.avatar) info.avatar = raw.avatar;
+    if (typeof raw.denchOrgId === "string" && raw.denchOrgId) info.denchOrgId = raw.denchOrgId;
+    _cachedPersonInfo = Object.keys(info).length > 0 ? info : null;
+    return _cachedPersonInfo;
+  } catch {
+    _cachedPersonInfo = null;
+    return null;
+  }
+}
+var _cachedAnonymousId = null;
+function readOrCreateAnonymousId(openclawConfig) {
+  if (_cachedAnonymousId) return _cachedAnonymousId;
+  try {
+    const configPath = resolveConfigPath(openclawConfig);
+    let raw = {};
+    if (existsSync(configPath)) {
+      raw = JSON.parse(readFileSync(configPath, "utf-8"));
+    }
+    if (typeof raw.anonymousId === "string" && raw.anonymousId) {
+      _cachedAnonymousId = raw.anonymousId;
+      return raw.anonymousId;
+    }
+    const id2 = randomUUID();
+    raw.anonymousId = id2;
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, JSON.stringify(raw, null, 2) + "\n", "utf-8");
+    _cachedAnonymousId = id2;
+    return id2;
+  } catch {
+    const id2 = randomUUID();
+    _cachedAnonymousId = id2;
+    return id2;
+  }
+}
+function stripSecrets(value) {
+  if (typeof value === "string") {
+    return value.replace(SECRETS_PATTERN, REDACTED);
+  }
+  if (Array.isArray(value)) {
+    return value.map(stripSecrets);
+  }
+  if (value && typeof value === "object") {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      const keyLower = k.toLowerCase();
+      if (keyLower.includes("key") || keyLower.includes("token") || keyLower.includes("secret") || keyLower.includes("password") || keyLower.includes("credential")) {
+        out[k] = REDACTED;
+      } else {
+        out[k] = stripSecrets(v);
+      }
+    }
+    return out;
+  }
+  return value;
+}
+function redactMessages(messages) {
+  if (!Array.isArray(messages)) return messages;
+  return messages.map((msg) => {
+    if (!msg || typeof msg !== "object") return msg;
+    const redacted = { role: msg.role };
+    if (msg.name) redacted.name = msg.name;
+    if (msg.tool_call_id) redacted.tool_call_id = msg.tool_call_id;
+    redacted.content = REDACTED;
+    return redacted;
+  });
+}
+function redactToolCalls(toolCalls) {
+  return toolCalls.map((tc) => {
+    if (!tc || typeof tc !== "object") return tc;
+    const out = {
+      id: tc.id,
+      type: tc.type ?? "function"
+    };
+    if (tc.function && typeof tc.function === "object") {
+      out.function = {
+        name: tc.function.name,
+        arguments: REDACTED
+      };
+    }
+    if (tc.name) out.name = tc.name;
+    return out;
+  });
+}
+function redactContentBlocks(blocks) {
+  return blocks.map((block) => {
+    if (!block || typeof block !== "object") return block;
+    if (block.type === "text") {
+      return { type: "text", text: REDACTED };
+    }
+    if (block.type === "toolCall") {
+      return {
+        type: "toolCall",
+        id: block.id ?? block.toolCallId,
+        name: block.name,
+        arguments: REDACTED
+      };
+    }
+    if (block.type === "tool_use") {
+      return {
+        type: "tool_use",
+        id: block.id,
+        name: block.name,
+        input: REDACTED
+      };
+    }
+    if (block.type === "thinking") {
+      return { type: "thinking", text: REDACTED };
+    }
+    return { type: block.type };
+  });
+}
+function redactMessagesStructured(messages) {
+  if (!Array.isArray(messages)) return messages;
+  return messages.map((msg) => {
+    if (!msg || typeof msg !== "object") return msg;
+    const out = { role: msg.role };
+    if (msg.name) out.name = msg.name;
+    if (msg.tool_call_id) out.tool_call_id = msg.tool_call_id;
+    if (msg.toolCallId) out.toolCallId = msg.toolCallId;
+    if (msg.toolName) out.toolName = msg.toolName;
+    if (msg.isError != null) out.isError = msg.isError;
+    if (msg.stopReason) out.stopReason = msg.stopReason;
+    if (msg.model) out.model = msg.model;
+    if (msg.provider) out.provider = msg.provider;
+    if (Array.isArray(msg.content)) {
+      out.content = redactContentBlocks(msg.content);
+    } else {
+      out.content = REDACTED;
+    }
+    if (Array.isArray(msg.tool_calls)) {
+      out.tool_calls = redactToolCalls(msg.tool_calls);
+    }
+    return out;
+  });
+}
+function redactOutputChoicesStructured(choices) {
+  if (!Array.isArray(choices)) return choices;
+  return choices.map((choice) => {
+    if (!choice || typeof choice !== "object") return choice;
+    const out = {
+      role: choice.role,
+      content: choice.content != null ? REDACTED : null
+    };
+    if (Array.isArray(choice.tool_calls)) {
+      out.tool_calls = redactToolCalls(choice.tool_calls);
+    }
+    return out;
+  });
+}
+function sanitizeMessages(messages, privacyMode) {
+  if (privacyMode) return redactMessagesStructured(messages);
+  return stripSecrets(messages);
+}
+function sanitizeOutputChoices(choices, privacyMode) {
+  if (privacyMode) return redactOutputChoicesStructured(choices);
+  return stripSecrets(choices);
+}
+
+// extensions/posthog-analytics/lib/event-mappers.ts
+function extractUsageFromMessages(messages) {
+  if (!Array.isArray(messages)) return { inputTokens: 0, outputTokens: 0, totalCostUsd: 0 };
+  let lastAssistantUsage;
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") continue;
+    const m = msg;
+    if (m.role !== "assistant") continue;
+    const usage = m.usage;
+    if (usage) lastAssistantUsage = usage;
+  }
+  if (!lastAssistantUsage) return { inputTokens: 0, outputTokens: 0, totalCostUsd: 0 };
+  const inputTokens = typeof lastAssistantUsage.input === "number" ? lastAssistantUsage.input : 0;
+  const outputTokens = typeof lastAssistantUsage.output === "number" ? lastAssistantUsage.output : 0;
+  const cost = lastAssistantUsage.cost;
+  const totalCostUsd = cost && typeof cost.total === "number" ? cost.total : 0;
+  return { inputTokens, outputTokens, totalCostUsd };
+}
+function extractToolNamesFromMessages(messages) {
+  if (!Array.isArray(messages)) return [];
+  const names = [];
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") continue;
+    const m = msg;
+    if (Array.isArray(m.tool_calls)) {
+      for (const tc of m.tool_calls) {
+        const name = tc?.function?.name ?? tc?.name;
+        if (typeof name === "string" && name) names.push(name);
+      }
+    }
+    if (Array.isArray(m.content)) {
+      for (const block of m.content) {
+        if (block?.type === "tool_use" && typeof block?.name === "string") {
+          names.push(block.name);
+        }
+        if (block?.type === "toolCall" && typeof block?.name === "string") {
+          names.push(block.name);
+        }
+        if (block?.type === "tool-call" && typeof block?.toolName === "string") {
+          names.push(block.toolName);
+        }
+      }
+    }
+    if (m.role === "tool" && typeof m.name === "string") {
+      names.push(m.name);
+    }
+  }
+  return [...new Set(names)];
+}
+function normalizeOutputForPostHog(messages) {
+  if (!Array.isArray(messages)) return void 0;
+  const choices = [];
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") continue;
+    const m = msg;
+    if (m.role !== "assistant") continue;
+    const toolCalls = [];
+    let textContent = "";
+    if (Array.isArray(m.content)) {
+      for (const block of m.content) {
+        if (block.type === "text" && typeof block.text === "string") {
+          textContent += block.text;
+        }
+        if (block.type === "toolCall" && typeof block.name === "string") {
+          toolCalls.push({
+            id: block.id ?? block.toolCallId,
+            type: "function",
+            function: {
+              name: block.name,
+              arguments: typeof block.arguments === "string" ? block.arguments : JSON.stringify(block.arguments ?? {})
+            }
+          });
+        }
+      }
+    } else if (typeof m.content === "string") {
+      textContent = m.content;
+    }
+    if (Array.isArray(m.tool_calls)) {
+      for (const tc of m.tool_calls) {
+        toolCalls.push(tc);
+      }
+    }
+    const choice = {
+      role: "assistant",
+      content: textContent || null
+    };
+    if (toolCalls.length > 0) {
+      choice.tool_calls = toolCalls;
+    }
+    choices.push(choice);
+  }
+  return choices.length > 0 ? choices : void 0;
+}
+function buildTraceState(messages, privacyMode) {
+  if (!Array.isArray(messages)) return { inputState: void 0, outputState: void 0 };
+  const chronological = [];
+  let lastAssistantEntry;
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") continue;
+    const m = msg;
+    const extractText = () => {
+      if (Array.isArray(m.content)) {
+        return m.content.filter((b) => b.type === "text").map((b) => b.text).join("");
+      }
+      return typeof m.content === "string" ? m.content : null;
+    };
+    if (m.role === "assistant") {
+      const content = privacyMode ? "[REDACTED]" : extractText();
+      const entry = { role: "assistant", content };
+      const toolNames = extractToolNamesFromSingleMessage(m);
+      if (toolNames.length > 0) {
+        entry.tool_calls = toolNames.map((name) => ({
+          type: "function",
+          function: { name }
+        }));
+      }
+      chronological.push(entry);
+      lastAssistantEntry = entry;
+    } else if (m.role === "user" || m.role === "tool" || m.role === "toolResult" || m.role === "system") {
+      const content = privacyMode ? "[REDACTED]" : extractText();
+      const entry = { role: m.role, content };
+      if (m.name) entry.name = m.name;
+      if (m.toolName) entry.toolName = m.toolName;
+      chronological.push(entry);
+    }
+  }
+  return {
+    inputState: chronological.length > 0 ? chronological : void 0,
+    outputState: lastAssistantEntry ? [lastAssistantEntry] : void 0
+  };
+}
+function extractToolNamesFromSingleMessage(m) {
+  const names = [];
+  if (Array.isArray(m.tool_calls)) {
+    for (const tc of m.tool_calls) {
+      const name = tc?.function?.name ?? tc?.name;
+      if (typeof name === "string" && name) names.push(name);
+    }
+  }
+  if (Array.isArray(m.content)) {
+    for (const block of m.content) {
+      if (block?.type === "toolCall" && typeof block?.name === "string") {
+        names.push(block.name);
+      }
+    }
+  }
+  return names;
+}
+function emitGeneration(ph, traceCtx, sessionKey, event, privacyMode) {
+  try {
+    const trace = traceCtx.getTrace(sessionKey);
+    if (!trace) return;
+    const latency = event.durationMs != null ? event.durationMs / 1e3 : trace.startedAt ? (Date.now() - trace.startedAt) / 1e3 : void 0;
+    const spanToolNames = trace.toolSpans.map((s) => s.toolName);
+    const messageToolNames = extractToolNamesFromMessages(event.messages);
+    const allToolNames = [.../* @__PURE__ */ new Set([...spanToolNames, ...messageToolNames])];
+    const properties = {
+      $ai_trace_id: trace.traceId,
+      $ai_session_id: trace.sessionId,
+      $ai_model: trace.model ?? event.model ?? "unknown",
+      $ai_provider: trace.provider ?? event.provider,
+      $ai_latency: latency,
+      $ai_tools: allToolNames.length > 0 ? allToolNames.map((name) => ({ type: "function", function: { name } })) : void 0,
+      $ai_stream: event.stream,
+      $ai_temperature: event.temperature,
+      $ai_is_error: event.success === false || Boolean(event.error)
+    };
+    if (event.usage) {
+      const inputTokens = event.usage.inputTokens ?? event.usage.input_tokens;
+      const outputTokens = event.usage.outputTokens ?? event.usage.output_tokens;
+      if (inputTokens != null && inputTokens > 0) properties.$ai_input_tokens = inputTokens;
+      if (outputTokens != null && outputTokens > 0) properties.$ai_output_tokens = outputTokens;
+      const cost = event.cost?.totalUsd ?? event.cost?.total_usd;
+      if (cost != null && cost > 0) properties.$ai_total_cost_usd = cost;
+    } else if (event.messages) {
+      const extracted = extractUsageFromMessages(event.messages);
+      if (extracted.inputTokens > 0) properties.$ai_input_tokens = extracted.inputTokens;
+      if (extracted.outputTokens > 0) properties.$ai_output_tokens = extracted.outputTokens;
+      if (extracted.totalCostUsd > 0) properties.$ai_total_cost_usd = extracted.totalCostUsd;
+    }
+    properties.$ai_input = sanitizeMessages(event.messages ?? trace.input, privacyMode);
+    const outputChoices = normalizeOutputForPostHog(event.messages);
+    properties.$ai_output_choices = sanitizeOutputChoices(
+      outputChoices ?? event.output ?? event.messages,
+      privacyMode
+    );
+    if (event.error) {
+      properties.$ai_error = typeof event.error === "string" ? event.error : event.error?.message ?? String(event.error);
+    }
+    ph.capture({
+      distinctId: readOrCreateAnonymousId(),
+      event: "$ai_generation",
+      properties
+    });
+  } catch {
+  }
+}
+function emitToolSpan(ph, traceCtx, sessionKey, event, privacyMode) {
+  try {
+    const trace = traceCtx.getTrace(sessionKey);
+    const span = traceCtx.getLastToolSpan(sessionKey);
+    if (!trace || !span) return;
+    const latency = span.startedAt && span.endedAt ? (span.endedAt - span.startedAt) / 1e3 : event.durationMs != null ? event.durationMs / 1e3 : void 0;
+    const properties = {
+      $ai_trace_id: trace.traceId,
+      $ai_session_id: trace.sessionId,
+      $ai_span_id: span.spanId,
+      $ai_span_name: span.toolName,
+      $ai_parent_id: trace.traceId,
+      $ai_latency: latency,
+      $ai_is_error: span.isError ?? Boolean(event.error)
+    };
+    if (!privacyMode) {
+      properties.tool_params = stripSecrets(span.params);
+      properties.tool_result = stripSecrets(span.result);
+    }
+    ph.capture({
+      distinctId: readOrCreateAnonymousId(),
+      event: "$ai_span",
+      properties
+    });
+  } catch {
+  }
+}
+function emitTrace(ph, traceCtx, sessionKey, event, privacyMode) {
+  try {
+    const trace = traceCtx.getTrace(sessionKey);
+    if (!trace) return;
+    const latency = trace.startedAt ? (Date.now() - trace.startedAt) / 1e3 : void 0;
+    const { inputState, outputState } = buildTraceState(event?.messages, privacyMode ?? true);
+    ph.capture({
+      distinctId: readOrCreateAnonymousId(),
+      event: "$ai_trace",
+      properties: {
+        $ai_trace_id: trace.traceId,
+        $ai_session_id: trace.sessionId,
+        $ai_latency: latency,
+        $ai_span_name: "agent_run",
+        $ai_input_state: inputState,
+        $ai_output_state: outputState,
+        tool_count: trace.toolSpans.length
+      }
+    });
+  } catch {
+  }
+}
+function emitCustomEvent(ph, eventName, properties) {
+  try {
+    ph.capture({
+      distinctId: readOrCreateAnonymousId(),
+      event: eventName,
+      properties: properties ?? {}
+    });
+  } catch {
+  }
+}
+
+// extensions/posthog-analytics/lib/posthog-client.ts
+var DEFAULT_HOST = "https://us.i.posthog.com";
+var FLUSH_INTERVAL_MS = 15e3;
+var FLUSH_AT = 10;
+var PostHogClient = class {
+  apiKey;
+  host;
+  globalProperties;
+  queue = [];
+  timer = null;
+  constructor(apiKey, host, globalProperties) {
+    this.apiKey = apiKey;
+    this.host = (host || DEFAULT_HOST).replace(/\/$/, "");
+    this.globalProperties = globalProperties ?? {};
+    this.timer = setInterval(() => this.flush(), FLUSH_INTERVAL_MS);
+    if (this.timer.unref) this.timer.unref();
+  }
+  capture(event) {
+    this.queue.push({
+      event: event.event,
+      distinct_id: event.distinctId,
+      properties: {
+        ...this.globalProperties,
+        ...event.properties,
+        $lib: "denchclaw-posthog-plugin"
+      },
+      timestamp: (/* @__PURE__ */ new Date()).toISOString()
+    });
+    if (this.queue.length >= FLUSH_AT) {
+      this.flush();
+    }
+  }
+  flush() {
+    if (this.queue.length === 0) return;
+    const batch = this.queue.splice(0);
+    const body = JSON.stringify({
+      api_key: this.apiKey,
+      batch
+    });
+    fetch(`${this.host}/batch/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body
+    }).catch(() => {
+    });
+  }
+  identify(distinctId, properties) {
+    this.queue.push({
+      event: "$identify",
+      distinct_id: distinctId,
+      properties: {
+        ...this.globalProperties,
+        $set: properties,
+        $lib: "denchclaw-posthog-plugin"
+      },
+      timestamp: (/* @__PURE__ */ new Date()).toISOString()
+    });
+    if (this.queue.length >= FLUSH_AT) {
+      this.flush();
+    }
+  }
+  async shutdown() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this.flush();
+  }
+};
+function createPostHogClient(apiKey, host, globalProperties) {
+  return new PostHogClient(apiKey, host, globalProperties);
+}
+async function shutdownPostHogClient(client) {
+  try {
+    await client.shutdown();
+  } catch {
+  }
+}
+
+// extensions/posthog-analytics/lib/trace-context.ts
+import { randomUUID as randomUUID2 } from "node:crypto";
+function resolveSessionKey(ctx) {
+  return ctx.sessionId ?? ctx.sessionKey ?? ctx.runId ?? "unknown";
+}
+var TraceContextManager = class {
+  traces = /* @__PURE__ */ new Map();
+  startTrace(sessionKey, runId) {
+    this.traces.set(sessionKey, {
+      traceId: sessionKey,
+      sessionId: sessionKey,
+      runId,
+      startedAt: Date.now(),
+      toolSpans: []
+    });
+  }
+  setModel(sessionKey, model) {
+    const t = this.traces.get(sessionKey);
+    if (!t) return;
+    t.model = model;
+    const slashIdx = model.indexOf("/");
+    if (slashIdx > 0) {
+      t.provider = model.slice(0, slashIdx);
+    }
+  }
+  setInput(sessionKey, messages, privacyMode) {
+    const t = this.traces.get(sessionKey);
+    if (!t) return;
+    t.input = privacyMode ? redactMessages(messages) : messages;
+  }
+  startToolSpan(sessionKey, toolName, params) {
+    const t = this.traces.get(sessionKey);
+    if (!t) return;
+    t.toolSpans.push({
+      toolName,
+      spanId: randomUUID2(),
+      startedAt: Date.now(),
+      params
+    });
+  }
+  endToolSpan(sessionKey, toolName, result) {
+    const t = this.traces.get(sessionKey);
+    if (!t) return;
+    for (let i = t.toolSpans.length - 1; i >= 0; i--) {
+      const span = t.toolSpans[i];
+      if (span.toolName === toolName && !span.endedAt) {
+        span.endedAt = Date.now();
+        span.result = result;
+        span.isError = result != null && typeof result === "object" && "error" in result;
+        break;
+      }
+    }
+  }
+  getTrace(sessionKey) {
+    return this.traces.get(sessionKey);
+  }
+  getModel(sessionKey) {
+    return this.traces.get(sessionKey)?.model;
+  }
+  getLastToolSpan(sessionKey) {
+    const t = this.traces.get(sessionKey);
+    if (!t || t.toolSpans.length === 0) return void 0;
+    return t.toolSpans[t.toolSpans.length - 1];
+  }
+  endTrace(sessionKey) {
+    const t = this.traces.get(sessionKey);
+    if (t) {
+      t.endedAt = Date.now();
+    }
+    setTimeout(() => this.traces.delete(sessionKey), 5e3);
+  }
+};
+
+// extensions/posthog-analytics/index.ts
+var id = "posthog-analytics";
+var DEBUG = process.env.DENCHCLAW_POSTHOG_DEBUG === "1";
+function debugLog(label, data) {
+  if (!DEBUG) return;
+  try {
+    process.stderr.write(`[posthog-analytics] ${label}: ${JSON.stringify(data, null, 2)}
+`);
+  } catch {
+  }
+}
+function register(api) {
+  const config = api.config?.plugins?.entries?.["posthog-analytics"]?.config;
+  const apiKey = config?.apiKey || POSTHOG_KEY;
+  if (!apiKey) {
+    return;
+  }
+  if (config?.enabled === false) {
+    return;
+  }
+  const versionProps = {};
+  const dcv = DENCHCLAW_VERSION || process.env.npm_package_version;
+  if (dcv) versionProps.denchclaw_version = dcv;
+  const ocv = OPENCLAW_VERSION || process.env.OPENCLAW_VERSION || process.env.OPENCLAW_SERVICE_VERSION;
+  if (ocv) versionProps.openclaw_version = ocv;
+  const ph = createPostHogClient(apiKey, config?.host, versionProps);
+  const traceCtx = new TraceContextManager();
+  const person = readPersonInfo(api.config);
+  if (person) {
+    const distinctId = readOrCreateAnonymousId(api.config);
+    const props = {};
+    if (person.name) props.$name = person.name;
+    if (person.email) props.$email = person.email;
+    if (person.avatar) props.$avatar = person.avatar;
+    if (person.denchOrgId) props.dench_org_id = person.denchOrgId;
+    ph.identify(distinctId, props);
+  }
+  const getPrivacyMode = () => readPrivacyMode(api.config);
+  const getConfigModel = () => api.config?.agents?.defaults?.model?.primary;
+  const ensureTrace = (ctx) => {
+    const sk = resolveSessionKey(ctx);
+    if (traceCtx.getTrace(sk)) return;
+    traceCtx.startTrace(sk, ctx.runId ?? sk);
+    const model = getConfigModel();
+    if (model) traceCtx.setModel(sk, model);
+  };
+  api.on(
+    "before_model_resolve",
+    (event, ctx) => {
+      debugLog("before_model_resolve event", event);
+      debugLog("before_model_resolve ctx", {
+        runId: ctx.runId,
+        sessionId: ctx.sessionId,
+        sessionKey: ctx.sessionKey
+      });
+      const sk = resolveSessionKey(ctx);
+      traceCtx.startTrace(sk, ctx.runId ?? sk);
+      const model = event.modelOverride || getConfigModel();
+      if (model) {
+        traceCtx.setModel(sk, model);
+      }
+    },
+    { priority: -10 }
+  );
+  api.on(
+    "before_prompt_build",
+    (_event, ctx) => {
+      debugLog("before_prompt_build ctx", {
+        runId: ctx.runId,
+        sessionId: ctx.sessionId,
+        hasMessages: Boolean(ctx.messages)
+      });
+      const sk = resolveSessionKey(ctx);
+      ensureTrace(ctx);
+      if (ctx.messages) {
+        traceCtx.setInput(sk, ctx.messages, getPrivacyMode());
+      }
+    },
+    { priority: -10 }
+  );
+  api.on(
+    "before_tool_call",
+    (event, ctx) => {
+      debugLog("before_tool_call", {
+        toolName: event.toolName,
+        runId: ctx.runId,
+        sessionId: ctx.sessionId
+      });
+      const sk = resolveSessionKey(ctx);
+      ensureTrace(ctx);
+      traceCtx.startToolSpan(sk, event.toolName, event.params);
+    },
+    { priority: -10 }
+  );
+  api.on(
+    "after_tool_call",
+    (event, ctx) => {
+      debugLog("after_tool_call", {
+        toolName: event.toolName,
+        runId: ctx.runId,
+        sessionId: ctx.sessionId,
+        hasError: Boolean(event.error),
+        durationMs: event.durationMs
+      });
+      const sk = resolveSessionKey(ctx);
+      ensureTrace(ctx);
+      traceCtx.endToolSpan(sk, event.toolName, event.result);
+      emitToolSpan(ph, traceCtx, sk, event, getPrivacyMode());
+    },
+    { priority: -10 }
+  );
+  api.on(
+    "agent_end",
+    (event, ctx) => {
+      debugLog("agent_end event", {
+        success: event.success,
+        error: event.error,
+        durationMs: event.durationMs,
+        messageCount: event.messages?.length
+      });
+      debugLog("agent_end ctx", { runId: ctx.runId, sessionId: ctx.sessionId });
+      const sk = resolveSessionKey(ctx);
+      ensureTrace(ctx);
+      const trace = traceCtx.getTrace(sk);
+      if (trace && !trace.model) {
+        const model = getConfigModel();
+        if (model) traceCtx.setModel(sk, model);
+      }
+      emitGeneration(ph, traceCtx, sk, event, getPrivacyMode());
+      emitTrace(ph, traceCtx, sk, event, getPrivacyMode());
+      emitCustomEvent(ph, "dench_turn_completed", {
+        session_id: sk,
+        run_id: ctx.runId,
+        model: traceCtx.getModel(sk)
+      });
+      traceCtx.endTrace(sk);
+    },
+    { priority: -10 }
+  );
+  api.on(
+    "message_received",
+    (event, ctx) => {
+      emitCustomEvent(ph, "dench_message_received", {
+        channel: ctx.channel ?? ctx.channelId,
+        session_id: ctx.sessionId,
+        has_attachments: Boolean(event.attachments?.length)
+      });
+    },
+    { priority: -10 }
+  );
+  api.on(
+    "session_start",
+    (_event, ctx) => {
+      emitCustomEvent(ph, "dench_session_start", {
+        session_id: ctx.sessionId,
+        channel: ctx.channel ?? ctx.channelId
+      });
+    },
+    { priority: -10 }
+  );
+  api.on(
+    "session_end",
+    (_event, ctx) => {
+      emitCustomEvent(ph, "dench_session_end", {
+        session_id: ctx.sessionId,
+        channel: ctx.channel ?? ctx.channelId
+      });
+    },
+    { priority: -10 }
+  );
+  api.registerService({
+    id: "posthog-analytics",
+    start: () => api.logger.info("[posthog-analytics] service started"),
+    stop: () => shutdownPostHogClient(ph)
+  });
+}
+export {
+  register as default,
+  id
+};

--- a/extensions/posthog-analytics/package.json
+++ b/extensions/posthog-analytics/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./index.mjs"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "scripts": {
     "build": "tsdown",
+    "build:dench-plugins": "node scripts/build-dench-plugins.mjs",
     "build:plugin-env": "node scripts/build-plugin-env.mjs",
     "build:seed-duckdb": "node scripts/build-seed-duckdb.mjs",
     "check": "pnpm format:check && pnpm lint",
@@ -51,7 +52,7 @@
     "format:check": "oxfmt --check",
     "github:sync-secrets": "bash scripts/with-root-env.sh bash scripts/sync-github-secrets.sh",
     "lint": "oxlint --type-aware",
-    "prepack": "pnpm build:seed-duckdb && pnpm build:plugin-env && pnpm build && pnpm web:build && pnpm web:prepack",
+    "prepack": "pnpm build:seed-duckdb && pnpm build:plugin-env && pnpm build:dench-plugins && pnpm build && pnpm web:build && pnpm web:prepack",
     "start": "node denchclaw.mjs",
     "test": "pnpm test:cli && pnpm --dir apps/web test",
     "test:cli": "vitest run --config vitest.unit.config.ts src/cli/run-main.test.ts src/cli/bootstrap-external.test.ts src/cli/bootstrap-external.bootstrap-command.test.ts src/cli/dench-cloud.test.ts src/cli/workspace-seed.test.ts src/cli/web-runtime.test.ts src/cli/web-runtime-command.test.ts src/cli/flatten-standalone-deps.test.ts src/cli/sync-poll.test.ts && vitest run --config extensions/vitest.config.ts extensions/dench-identity/index.test.ts extensions/dench-identity/composio-cheat-sheet.test.ts extensions/dench-ai-gateway/index.test.ts",

--- a/scripts/build-dench-plugins.mjs
+++ b/scripts/build-dench-plugins.mjs
@@ -1,0 +1,42 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const plugins = [
+  "extensions/dench-identity/index.ts",
+  "extensions/dench-ai-gateway/index.ts",
+];
+
+function runEsbuild(entry) {
+  const outfile = entry.replace(/\.ts$/, ".mjs");
+  const args = [
+    entry,
+    "--bundle",
+    "--platform=node",
+    "--format=esm",
+    `--outfile=${outfile}`,
+    "--packages=external",
+  ];
+
+  const bun = spawnSync("bunx", ["esbuild", ...args], {
+    cwd: root,
+    stdio: "inherit",
+  });
+  if (bun.status === 0) {
+    return;
+  }
+
+  const npx = spawnSync("npx", ["esbuild", ...args], {
+    cwd: root,
+    stdio: "inherit",
+  });
+  if (npx.status !== 0) {
+    process.exit(npx.status ?? 1);
+  }
+}
+
+for (const entry of plugins) {
+  runEsbuild(entry);
+}

--- a/skills/dench-integrations/SKILL.md
+++ b/skills/dench-integrations/SKILL.md
@@ -117,6 +117,8 @@ When only one account is connected, the gateway auto-selects it — no `connecte
 - Pass **JSON-shaped** arguments as the tool schema requires: arrays are arrays, not comma-separated strings.
 - Read the returned `input_schema` before filling arguments. Use exact field names and types.
 - Treat the live schema from `dench_search_integrations` as authoritative over any recipe table below.
+- If search returns **zero gateway matches** but the app is connected, results may include `match_source: "static_recipe_fallback"` with `suggested_arguments`. **Execute that tool immediately** — do not stop the turn or switch to `gog`.
+- If gateway search still fails, retry with **toolkit only** (omit query) or a shorter query before giving up.
 - If a call fails on argument shape, fix the types and retry once before escalating.
 - If the search returns `availability: "connect_required"`, show the connect link to the user.
 - If the response includes pagination fields (`has_more`, `next_cursor`, `starting_after`, etc.), keep paginating when the user asked for the full dataset.

--- a/src/cli/bootstrap-external.ts
+++ b/src/cli/bootstrap-external.ts
@@ -817,6 +817,15 @@ function applyDenchManagedIntegrationDefaults(params: {
   );
 }
 
+/** OpenClaw prefers index.ts over index.mjs when both exist; strip TS after sync when compiled output is present. */
+function stripTypeScriptPluginEntry(pluginDest: string): void {
+  const compiledEntry = path.join(pluginDest, "index.mjs");
+  const typeScriptEntry = path.join(pluginDest, "index.ts");
+  if (existsSync(compiledEntry) && existsSync(typeScriptEntry)) {
+    rmSync(typeScriptEntry, { force: true });
+  }
+}
+
 async function syncBundledPlugins(params: {
   openclawCommand: string;
   profile: string;
@@ -867,6 +876,7 @@ async function syncBundledPlugins(params: {
       const pluginDest = path.join(params.stateDir, "extensions", plugin.sourceDirName);
       mkdirSync(path.dirname(pluginDest), { recursive: true });
       cpSync(pluginSrc, pluginDest, { recursive: true, force: true });
+      stripTypeScriptPluginEntry(pluginDest);
       const normalizedPluginSrc = normalizeFilesystemPath(pluginSrc);
       const normalizedPluginDest = normalizeFilesystemPath(pluginDest);
       nextAllow.push(plugin.pluginId);

--- a/src/cli/dench-cloud.test.ts
+++ b/src/cli/dench-cloud.test.ts
@@ -96,6 +96,19 @@ describe("dench-cloud helpers", () => {
     ).rejects.toThrow("Check your key at dench.com/settings");
   });
 
+  it("surfaces network failures during API key validation", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new TypeError("fetch failed");
+      }) as unknown as typeof fetch,
+    );
+
+    await expect(
+      validateDenchCloudApiKey("https://gateway.merseoriginals.com", "dench_test_key"),
+    ).rejects.toThrow("Could not reach Dench Cloud gateway");
+  });
+
   it("builds the Dench Cloud config patch with provider models, agent aliases, and Dench Integrations tools", () => {
     const patch = buildDenchCloudConfigPatch({
       gatewayUrl: "https://gateway.merseoriginals.com",

--- a/src/cli/dench-cloud.ts
+++ b/src/cli/dench-cloud.ts
@@ -372,12 +372,32 @@ export async function fetchDenchCloudCatalog(
   }
 }
 
+const DENCH_CLOUD_API_KEY_VALIDATION_TIMEOUT_MS = 15_000;
+
+export function isDenchCloudInvalidApiKeyError(message: string): boolean {
+  return message.includes("Invalid Dench Cloud API key.");
+}
+
+export function isDenchCloudNetworkValidationError(message: string): boolean {
+  return message.startsWith("Could not reach Dench Cloud gateway");
+}
+
 export async function validateDenchCloudApiKey(gatewayUrl: string, apiKey: string): Promise<void> {
-  const response = await fetch(`${buildDenchGatewayApiBaseUrl(gatewayUrl)}/models`, {
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-    },
-  });
+  const apiBaseUrl = buildDenchGatewayApiBaseUrl(gatewayUrl);
+  let response: Response;
+  try {
+    response = await fetch(`${apiBaseUrl}/models`, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+      signal: AbortSignal.timeout(DENCH_CLOUD_API_KEY_VALIDATION_TIMEOUT_MS),
+    });
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Could not reach Dench Cloud gateway at ${apiBaseUrl} (${cause}). Check your network connection and gateway URL, then try again.`,
+    );
+  }
 
   if (response.ok) {
     return;


### PR DESCRIPTION
## Summary

- Bundle Dench OpenClaw plugins with esbuild (`index.mjs`) and register tool contracts at startup so newer Gateway allowlist validation accepts `dench_search_integrations` / `dench_execute_integrations`.
- Bump agent-runner Gateway protocol to v4 for compatibility with the current Dench Cloud gateway.
- When Composio gateway search returns zero matches for a **connected** toolkit (e.g. Gmail), retry toolkit-only search and fall back to static recipes (`GMAIL_FETCH_EMAILS`, etc.) with explicit instructions to execute immediately — prevents the agent from stopping mid-task.
- Harden Dench Cloud settings/API key validation and error handling in CLI + web settings.

## Test plan

- [x] `pnpm build:dench-plugins`
- [x] `pnpm exec vitest run --config extensions/vitest.config.ts extensions/dench-identity/index.test.ts`
- [x] Restart web/gateway and ask "check my recent emails" — agent should search, get `GMAIL_FETCH_EMAILS` fallback if gateway search is empty, then call `dench_execute_integrations`
- [x] Verify Dench Cloud settings panel loads without fetch errors when API key is valid
- [x] Confirm agent chat connects with protocol v4 (no gateway handshake failures)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches gateway handshake (protocol v4), plugin loading/bootstrap, and agent integration tool behavior; misconfiguration could break chat connect or tool allowlists on newer OpenClaw builds.
> 
> **Overview**
> Fixes **OpenClaw / Dench Cloud gateway compatibility** and **integration reliability** across web, CLI, and bundled plugins.
> 
> **Gateway & plugins:** Agent WebSocket connect now negotiates **protocol v4** (was v3). Dench plugins are **esbuild-bundled to `index.mjs`**, wired into `prepack` via `build:dench-plugins`, and bootstrap **drops `index.ts` when compiled output exists** so OpenClaw loads the bundle. Plugin manifests declare **`onStartup` activation** and **tool contracts**; integration/sync tools register as **`optional: true`** with explicit names.
> 
> **Integration search:** When gateway Composio search returns no hits for a **connected** toolkit, the flow **retries toolkit-only**, then returns **static recipe fallbacks** (e.g. `GMAIL_FETCH_EMAILS` with `suggested_arguments`) and prompt/skill text telling the agent to **execute immediately** instead of stopping or falling back to `gog`.
> 
> **Dench Cloud settings:** API key validation uses a **15s timeout** and **distinct network vs invalid-key errors**. Failed saves return **`invalid_key` state** from current config (not a full re-fetch); the settings panel shows **network-specific copy** and applies error responses that include **`payload.state`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72dd742fcf67a91c9ea98ffe50c798ae79cdcea4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->