### PR TITLE
Add deprecation banner linking to dench.com

### DIFF
--- a/apps/web/app/components/deprecation-banner.test.tsx
+++ b/apps/web/app/components/deprecation-banner.test.tsx
@@ -1,0 +1,21 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DeprecationBanner } from "./deprecation-banner";
+
+describe("DeprecationBanner", () => {
+  it("renders the one-line message and dench.com link", () => {
+    render(<DeprecationBanner />);
+
+    expect(screen.getByTestId("deprecation-banner")).toBeInTheDocument();
+    expect(
+      screen.getByText(/You can still use DenchClaw, but it won't receive updates/i),
+    ).toBeInTheDocument();
+
+    const cta = screen.getByTestId("deprecation-banner-cta");
+    expect(cta).toHaveAttribute("href", "https://dench.com");
+    expect(cta).toHaveAttribute("target", "_blank");
+    expect(cta).toHaveTextContent("dench.com");
+  });
+});

--- a/apps/web/app/components/deprecation-banner.tsx
+++ b/apps/web/app/components/deprecation-banner.tsx
@@ -1,0 +1,34 @@
+const DENCH_URL = "https://dench.com";
+
+export function DeprecationBanner() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="deprecation-banner"
+      className="relative z-[10000] border-b px-4 py-2 sm:px-6"
+      style={{
+        background: "var(--color-deprecation-bg)",
+        borderColor: "var(--color-deprecation-border)",
+      }}
+    >
+      <p
+        className="mx-auto max-w-6xl text-center text-[12.5px] leading-snug sm:text-[13px]"
+        style={{ color: "var(--color-deprecation-muted)" }}
+      >
+        You can still use DenchClaw, but it won&apos;t receive updates. for the latest features, go to{" "}
+        <a
+          href={DENCH_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-semibold underline decoration-[var(--color-deprecation-border)] underline-offset-2 transition-opacity hover:opacity-80"
+          style={{ color: "var(--color-deprecation-text)" }}
+          data-testid="deprecation-banner-cta"
+        >
+          dench.com
+        </a>
+        .
+      </p>
+    </div>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -47,6 +47,16 @@
   --color-error: #dc2626;
   --color-info: #2563eb;
 
+  /* Deprecation banner */
+  --color-deprecation-bg: #fefce8;
+  --color-deprecation-border: #fde68a;
+  --color-deprecation-text: #713f12;
+  --color-deprecation-muted: #92400e;
+  --color-deprecation-icon-bg: rgba(250, 204, 21, 0.35);
+  --color-deprecation-cta-bg: #854d0e;
+  --color-deprecation-cta-text: #fffbeb;
+  --color-deprecation-cta-shadow: 0 1px 2px rgba(120, 53, 15, 0.12);
+
   /* Glassmorphism */
   --color-glass: rgba(255, 255, 255, 0.72);
   --color-glass-border: rgba(255, 255, 255, 0.85);
@@ -137,6 +147,16 @@
   --color-warning: #ffd60a;
   --color-error: #ff453a;
   --color-info: #0a84ff;
+
+  /* Deprecation banner */
+  --color-deprecation-bg: rgba(234, 179, 8, 0.14);
+  --color-deprecation-border: rgba(250, 204, 21, 0.28);
+  --color-deprecation-text: #fde68a;
+  --color-deprecation-muted: #fcd34d;
+  --color-deprecation-icon-bg: rgba(250, 204, 21, 0.18);
+  --color-deprecation-cta-bg: #fbbf24;
+  --color-deprecation-cta-text: #422006;
+  --color-deprecation-cta-shadow: none;
 
   /* Glassmorphism */
   --color-glass: rgba(46, 46, 46, 0.85);

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Suspense } from "react";
 import { ThemeProvider } from "next-themes";
 import { getOrCreateAnonymousId, readPersonInfo, readPrivacyMode } from "@/lib/telemetry";
+import { DeprecationBanner } from "./components/deprecation-banner";
 import { PostHogProvider } from "./components/posthog-provider";
 import "./globals.css";
 
@@ -66,6 +67,7 @@ export default function RootLayout({
         />
       </head>
       <body className="antialiased">
+        <DeprecationBanner />
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
           <Suspense fallback={null}>
             <PostHogProvider anonymousId={anonymousId} personInfo={personInfo ?? undefined} privacyMode={privacyMode}>


### PR DESCRIPTION
## Summary
- Adds a site-wide light-yellow banner at the top of every page informing users that DenchClaw still works but no longer receives updates
- Links to [dench.com](https://dench.com) for the latest features on the new platform
- Includes light/dark theme tokens and a unit test for the banner copy and link

## Test plan
- [x] `npm test -- deprecation-banner.test.tsx` in `apps/web`
- [ ] Verify banner renders on workspace and onboarding routes in light and dark mode
- [ ] Confirm `dench.com` link opens in a new tab

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7562e24eaa73e440ddfa584d3fe766c10f8fb267. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->