### PR TITLE
Update dench.com banner copy

### DIFF
--- a/apps/web/app/components/deprecation-banner.test.tsx
+++ b/apps/web/app/components/deprecation-banner.test.tsx
@@ -9,9 +9,7 @@ describe("DeprecationBanner", () => {
     render(<DeprecationBanner />);
 
     expect(screen.getByTestId("deprecation-banner")).toBeInTheDocument();
-    expect(
-      screen.getByText(/You can still use DenchClaw, but it won't receive updates/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/For the latest features, go to/i)).toBeInTheDocument();
 
     const cta = screen.getByTestId("deprecation-banner-cta");
     expect(cta).toHaveAttribute("href", "https://dench.com");

--- a/apps/web/app/components/deprecation-banner.tsx
+++ b/apps/web/app/components/deprecation-banner.tsx
@@ -16,7 +16,7 @@ export function DeprecationBanner() {
         className="mx-auto max-w-6xl text-center text-[12.5px] leading-snug sm:text-[13px]"
         style={{ color: "var(--color-deprecation-muted)" }}
       >
-        You can still use DenchClaw, but it won&apos;t receive updates. for the latest features, go to{" "}
+        For the latest features, go to{" "}
         <a
           href={DENCH_URL}
           target="_blank"


### PR DESCRIPTION
## Summary
- Updates the site-wide top banner message to **"For the latest features, go to dench.com."**
- Removes the merged copy that suggested DenchClaw would not receive updates, aligning with the current plan to keep DenchClaw supported while pointing users to dench.com for newer capabilities.

## Test plan
- [x] `npm test -- deprecation-banner.test.tsx` in `apps/web`
- [ ] Confirm banner renders on workspace with correct link to https://dench.com
- [ ] Verify copy reads well in light and dark mode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change in a non-critical UI banner; link target and component behavior are unchanged.
> 
> **Overview**
> The site-wide **DeprecationBanner** copy is shortened so it no longer says DenchClaw will not receive updates. The banner now reads **"For the latest features, go to dench.com."** with the same link, styling, and accessibility attributes.
> 
> The **deprecation-banner** unit test assertion is updated to match the new message text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f95957b5bffc1e3be312d5446dce0a34c359243f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->