### PR TITLE
Bare `npx denchclaw` shows Dench Cloud welcome; full setup moves to `npx denchclaw bootstrap`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 ### Are you an AI agent reading this? In that case, use the prompt below to setup DenchClaw.
 
 ```
-Install DenchClaw (an OpenClaw CRM Framwork) by running "npx denchclaw", when it asks to update OpenClaw, update it as DenchClaw requires up to date OpenClaw. When it asks for my Dench API Key, help me fetch it from dench.com/api and set it up. Remember that DenchClaw creates a new OpenClaw Gateway (~/.openclaw-dench) on port 19001 by default, and a new main agent in that gateway working in ~/.openclaw-dench/workspace directory (Separate from the usual non-DenchClaw OpenClaw gateway that usually sits in ~/.openclaw). All DenchClaw config sits in ~/.openclaw-dench/openclaw.json. Remember that anytime you interface with DenchClaw using openclaw commands, you must use "openclaw --profile dench" as a prefix, for example, to restart gateway, run "openclaw --profile dench gateway restart". After everything is setup, DenchClaw will be accessible at localhost:3100 by default. If for some reason that Port 19001 and 3100 or those ranges are taken, make sure to kill those ports/processes and then retry npx denchclaw. Also, sometimes if the Web UI on port 3100 crashes, just run "npx denchclaw update" to boot it back up. Remember to refer to https://github.com/DenchHQ/DenchClaw (DenchClaw's official GitHub Repository) for more information.
+Install DenchClaw (an OpenClaw CRM Framwork) by running "npx denchclaw bootstrap", when it asks to update OpenClaw, update it as DenchClaw requires up to date OpenClaw. When it asks for my Dench API Key, help me fetch it from dench.com/api and set it up. Remember that DenchClaw creates a new OpenClaw Gateway (~/.openclaw-dench) on port 19001 by default, and a new main agent in that gateway working in ~/.openclaw-dench/workspace directory (Separate from the usual non-DenchClaw OpenClaw gateway that usually sits in ~/.openclaw). All DenchClaw config sits in ~/.openclaw-dench/openclaw.json. Remember that anytime you interface with DenchClaw using openclaw commands, you must use "openclaw --profile dench" as a prefix, for example, to restart gateway, run "openclaw --profile dench gateway restart". After everything is setup, DenchClaw will be accessible at localhost:3100 by default. If for some reason that Port 19001 and 3100 or those ranges are taken, make sure to kill those ports/processes and then retry npx denchclaw bootstrap. Also, sometimes if the Web UI on port 3100 crashes, just run "npx denchclaw update" to boot it back up. Remember to refer to https://github.com/DenchHQ/DenchClaw (DenchClaw's official GitHub Repository) for more information.
 ```
 
 ### Manual Install
@@ -39,7 +39,7 @@ Install DenchClaw (an OpenClaw CRM Framwork) by running "npx denchclaw", when it
 **Node 22+ required.**
 
 ```bash
-npx denchclaw@latest
+npx denchclaw@latest bootstrap
 ```
 
 Opens at `localhost:3100` after completing onboarding wizard.
@@ -49,7 +49,7 @@ Opens at `localhost:3100` after completing onboarding wizard.
 ## Commands
 
 ```bash
-npx denchclaw@latest # runs onboarding again for openclaw --profile dench
+npx denchclaw@latest bootstrap # runs onboarding again for openclaw --profile dench
 npx denchclaw@latest update # updates denchclaw web-runtime with current settings as is
 npx denchclaw restart # restarts denchclaw web server
 npx denchclaw start # starts denchclaw web server
@@ -82,7 +82,7 @@ openclaw --profile dench gateway --port 19001
 Alternatively, pass `--skip-daemon-install` to individual commands:
 
 ```bash
-npx denchclaw --skip-daemon-install
+npx denchclaw bootstrap --skip-daemon-install
 npx denchclaw update --skip-daemon-install
 npx denchclaw start --skip-daemon-install
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "denchclaw",
-  "version": "3.1.5",
+  "version": "4.0.0",
   "description": "Fully Managed OpenClaw Framework for managing your CRM, Sales Automation and Outreach agents. The only local productivity tool you need.",
   "keywords": [],
   "homepage": "https://github.com/DenchHQ/DenchClaw#readme",

--- a/src/cli/bootstrap-external.ts
+++ b/src/cli/bootstrap-external.ts
@@ -17,17 +17,16 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { confirm, isCancel, select, spinner, text } from "@clack/prompts";
-import gradient from "gradient-string";
 import json5 from "json5";
 import { isDaemonlessMode } from "../config/paths.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { readTelemetryConfig, markNoticeShown } from "../telemetry/config.js";
 import { track } from "../telemetry/telemetry.js";
-import { visibleWidth } from "../terminal/ansi.js";
 import { stylePromptMessage } from "../terminal/prompt-style.js";
-import { isRich, theme } from "../terminal/theme.js";
+import { theme } from "../terminal/theme.js";
 import { VERSION } from "../version.js";
+import { renderDenchCloudRecommendationBanner } from "./dench-cloud-banner.js";
 import {
   buildDenchCloudConfigPatch,
   DEFAULT_DENCH_CLOUD_GATEWAY_URL,
@@ -521,7 +520,10 @@ function mergeAllowedTools(existingTools: unknown, patchTools: unknown): string[
   return [...merged].sort((left, right) => left.localeCompare(right));
 }
 
-function mergeProviderToolPolicies(existingTools: unknown, patchTools: unknown): Record<string, unknown> {
+function mergeProviderToolPolicies(
+  existingTools: unknown,
+  patchTools: unknown,
+): Record<string, unknown> {
   const existingByProvider = asRecord(asRecord(existingTools)?.byProvider) ?? {};
   const patchByProvider = asRecord(asRecord(patchTools)?.byProvider) ?? {};
   const mergedByProvider: Record<string, unknown> = { ...existingByProvider };
@@ -2757,84 +2759,6 @@ async function promptForDenchCloudModel(params: {
     return undefined;
   }
   return String(selection);
-}
-
-function renderDenchCloudRecommendationBanner(): string {
-  const rich = isRich();
-  const W = 74;
-
-  const bdr = (s: string) => (rich ? theme.accentDim(s) : s);
-  const ironShimmer = rich
-    ? gradient(["#374151", "#6B7280", "#9CA3AF", "#D1D5DB", "#9CA3AF", "#6B7280", "#374151"])
-    : (s: string) => s;
-  const topBar = ironShimmer("─".repeat(W));
-  const botBar = ironShimmer("─".repeat(W));
-  const top = `  ${bdr("╭")}${topBar}${bdr("╮")}`;
-  const bot = `  ${bdr("╰")}${botBar}${bdr("╯")}`;
-  const blank = `  ${bdr("│")}${" ".repeat(W)}${bdr("│")}`;
-
-  const row = (content: string, indent = 4): string => {
-    const vis = visibleWidth(content);
-    const right = Math.max(1, W - indent - vis);
-    return `  ${bdr("│")}${" ".repeat(indent)}${content}${" ".repeat(right)}${bdr("│")}`;
-  };
-
-  const title = rich
-    ? gradient(["#38BDF8", "#2DD4BF", "#34D399"])("D E N C H   C L O U D")
-    : "D E N C H   C L O U D";
-  const subtitle = rich
-    ? theme.muted("The recommended way to run DenchClaw. Everything is managed for you.")
-    : "The recommended way to run DenchClaw. Everything is managed for you.";
-
-  const bullet = rich ? theme.info("▸") : "▸";
-  const lbl = (s: string) => (rich ? theme.accentBright(s) : s);
-  const dim = (s: string) => (rich ? theme.muted(s) : s);
-  const COL = 14;
-  const features: [string, string][] = [
-    [lbl("AI Models"), dim("Claude, GPT, Kimi & more — no API keys needed")],
-    [lbl("Voice"), dim("ElevenLabs built in — no account required")],
-    [lbl("Web Search"), dim("Exa ready out of the box — no key to manage")],
-    [lbl("Skills Store"), dim("Browse & install skills instantly")],
-    [lbl("Image Gen"), dim("State-of-the-art models from day one")],
-  ];
-  const featureLines = features.map(([name, desc]) => {
-    const gap = " ".repeat(Math.max(1, COL - visibleWidth(name)));
-    return `${bullet}  ${name}${gap}${desc}`;
-  });
-
-  const star = rich ? theme.warn("★") : "★";
-  const intTitle = rich ? theme.warn("1,000+ App Integrations") : "1,000+ App Integrations";
-  const dot = rich ? theme.accentDim(" · ") : " · ";
-  const apps = [
-    rich ? theme.info("Gmail") : "Gmail",
-    rich ? theme.accentBright("Notion") : "Notion",
-    rich ? theme.success("HubSpot") : "HubSpot",
-    rich ? theme.warn("PostHog") : "PostHog",
-    rich ? theme.accent("Stripe") : "Stripe",
-    rich ? theme.success("Salesforce") : "Salesforce",
-    rich ? theme.muted("…") : "…",
-  ].join(dot);
-
-  const check = rich ? theme.success("✓") : "✓";
-  const cta = rich ? theme.success("Recommended for most users") : "Recommended for most users";
-
-  return [
-    "",
-    top,
-    blank,
-    row(title),
-    row(subtitle),
-    blank,
-    ...featureLines.map((l) => row(l)),
-    blank,
-    row(`${star}  ${intTitle}`),
-    row(apps, 7),
-    blank,
-    row(`${check}  ${cta}`),
-    blank,
-    bot,
-    "",
-  ].join("\n");
 }
 
 function preStageDenchCloudConfig(params: {

--- a/src/cli/dench-cloud-banner.ts
+++ b/src/cli/dench-cloud-banner.ts
@@ -26,8 +26,8 @@ export function renderDenchCloudRecommendationBanner(): string {
     ? gradient(["#38BDF8", "#2DD4BF", "#34D399"])("D E N C H   C L O U D")
     : "D E N C H   C L O U D";
   const subtitle = rich
-    ? theme.muted("The recommended way to run DenchClaw. Everything is managed for you.")
-    : "The recommended way to run DenchClaw. Everything is managed for you.";
+    ? theme.muted("The Ultimate CRM for your AI Agents.")
+    : "The Ultimate CRM for your AI Agents.";
 
   const bullet = rich ? theme.info("▸") : "▸";
   const lbl = (s: string) => (rich ? theme.accentBright(s) : s);
@@ -35,8 +35,10 @@ export function renderDenchCloudRecommendationBanner(): string {
   const COL = 14;
   const features: [string, string][] = [
     [lbl("AI Models"), dim("Claude, GPT, Kimi & more — no API keys needed")],
-    [lbl("Voice"), dim("ElevenLabs built in — no account required")],
-    [lbl("Web Search"), dim("Exa ready out of the box — no key to manage")],
+    [lbl("CRM"), dim("Custom objects, companies, people, etc.")],
+    [lbl("Files"), dim("File Storage on Cloud")],
+    [lbl("24x7"), dim("Cron jobs that run in the background")],
+    [lbl("Web Search"), dim("Ready out of the box — no keys to manage")],
     [lbl("Skills Store"), dim("Browse & install skills instantly")],
     [lbl("Image Gen"), dim("State-of-the-art models from day one")],
   ];
@@ -59,7 +61,6 @@ export function renderDenchCloudRecommendationBanner(): string {
   ].join(dot);
 
   const check = rich ? theme.success("✓") : "✓";
-  const cta = rich ? theme.success("Recommended for most users") : "Recommended for most users";
 
   return [
     "",
@@ -72,8 +73,6 @@ export function renderDenchCloudRecommendationBanner(): string {
     blank,
     row(`${star}  ${intTitle}`),
     row(apps, 7),
-    blank,
-    row(`${check}  ${cta}`),
     blank,
     bot,
     "",

--- a/src/cli/dench-cloud-banner.ts
+++ b/src/cli/dench-cloud-banner.ts
@@ -1,0 +1,81 @@
+import gradient from "gradient-string";
+import { visibleWidth } from "../terminal/ansi.js";
+import { isRich, theme } from "../terminal/theme.js";
+
+export function renderDenchCloudRecommendationBanner(): string {
+  const rich = isRich();
+  const W = 74;
+
+  const bdr = (s: string) => (rich ? theme.accentDim(s) : s);
+  const ironShimmer = rich
+    ? gradient(["#374151", "#6B7280", "#9CA3AF", "#D1D5DB", "#9CA3AF", "#6B7280", "#374151"])
+    : (s: string) => s;
+  const topBar = ironShimmer("─".repeat(W));
+  const botBar = ironShimmer("─".repeat(W));
+  const top = `  ${bdr("╭")}${topBar}${bdr("╮")}`;
+  const bot = `  ${bdr("╰")}${botBar}${bdr("╯")}`;
+  const blank = `  ${bdr("│")}${" ".repeat(W)}${bdr("│")}`;
+
+  const row = (content: string, indent = 4): string => {
+    const vis = visibleWidth(content);
+    const right = Math.max(1, W - indent - vis);
+    return `  ${bdr("│")}${" ".repeat(indent)}${content}${" ".repeat(right)}${bdr("│")}`;
+  };
+
+  const title = rich
+    ? gradient(["#38BDF8", "#2DD4BF", "#34D399"])("D E N C H   C L O U D")
+    : "D E N C H   C L O U D";
+  const subtitle = rich
+    ? theme.muted("The recommended way to run DenchClaw. Everything is managed for you.")
+    : "The recommended way to run DenchClaw. Everything is managed for you.";
+
+  const bullet = rich ? theme.info("▸") : "▸";
+  const lbl = (s: string) => (rich ? theme.accentBright(s) : s);
+  const dim = (s: string) => (rich ? theme.muted(s) : s);
+  const COL = 14;
+  const features: [string, string][] = [
+    [lbl("AI Models"), dim("Claude, GPT, Kimi & more — no API keys needed")],
+    [lbl("Voice"), dim("ElevenLabs built in — no account required")],
+    [lbl("Web Search"), dim("Exa ready out of the box — no key to manage")],
+    [lbl("Skills Store"), dim("Browse & install skills instantly")],
+    [lbl("Image Gen"), dim("State-of-the-art models from day one")],
+  ];
+  const featureLines = features.map(([name, desc]) => {
+    const gap = " ".repeat(Math.max(1, COL - visibleWidth(name)));
+    return `${bullet}  ${name}${gap}${desc}`;
+  });
+
+  const star = rich ? theme.warn("★") : "★";
+  const intTitle = rich ? theme.warn("1,000+ App Integrations") : "1,000+ App Integrations";
+  const dot = rich ? theme.accentDim(" · ") : " · ";
+  const apps = [
+    rich ? theme.info("Gmail") : "Gmail",
+    rich ? theme.accentBright("Notion") : "Notion",
+    rich ? theme.success("HubSpot") : "HubSpot",
+    rich ? theme.warn("PostHog") : "PostHog",
+    rich ? theme.accent("Stripe") : "Stripe",
+    rich ? theme.success("Salesforce") : "Salesforce",
+    rich ? theme.muted("…") : "…",
+  ].join(dot);
+
+  const check = rich ? theme.success("✓") : "✓";
+  const cta = rich ? theme.success("Recommended for most users") : "Recommended for most users";
+
+  return [
+    "",
+    top,
+    blank,
+    row(title),
+    row(subtitle),
+    blank,
+    ...featureLines.map((l) => row(l)),
+    blank,
+    row(`${star}  ${intTitle}`),
+    row(apps, 7),
+    blank,
+    row(`${check}  ${cta}`),
+    blank,
+    bot,
+    "",
+  ].join("\n");
+}

--- a/src/cli/dench-cloud-welcome.ts
+++ b/src/cli/dench-cloud-welcome.ts
@@ -1,0 +1,56 @@
+import { spawn } from "node:child_process";
+import process from "node:process";
+import { isCancel, select } from "@clack/prompts";
+import { stylePromptMessage } from "../terminal/prompt-style.js";
+import { isRich, theme } from "../terminal/theme.js";
+import { renderDenchCloudRecommendationBanner } from "./dench-cloud-banner.js";
+
+export const DENCH_LOGIN_URL = "https://dench.com/login";
+
+async function openUrlInBrowser(url: string): Promise<boolean> {
+  const [command, ...args] =
+    process.platform === "darwin"
+      ? ["open", url]
+      : process.platform === "win32"
+        ? ["cmd", "/c", "start", "", url]
+        : ["xdg-open", url];
+  return await new Promise<boolean>((resolve) => {
+    const child = spawn(command, args, { stdio: "ignore", detached: true });
+    child.once("error", () => resolve(false));
+    child.once("spawn", () => {
+      child.unref();
+      resolve(true);
+    });
+  });
+}
+
+/**
+ * The bare `npx denchclaw` flow: show the Dench Cloud banner, offer a single
+ * "Continue with Dench.com" action that opens dench.com/login, then end the
+ * session. The full local setup lives under `npx denchclaw bootstrap`.
+ */
+export async function runDenchCloudWelcome(): Promise<void> {
+  const log = (line: string) => process.stdout.write(`${line}\n`);
+  log(renderDenchCloudRecommendationBanner());
+
+  const interactive = Boolean(process.stdin.isTTY && process.stdout.isTTY);
+  if (!interactive) {
+    log(`Continue with Dench.com: ${DENCH_LOGIN_URL}`);
+    return;
+  }
+
+  const choice = await select({
+    message: stylePromptMessage("Get started with Dench Cloud"),
+    options: [{ value: "continue", label: "Continue with Dench.com" }],
+  });
+  if (isCancel(choice)) {
+    return;
+  }
+
+  const opened = await openUrlInBrowser(DENCH_LOGIN_URL);
+  const rich = isRich();
+  const url = rich ? theme.accentBright(DENCH_LOGIN_URL) : DENCH_LOGIN_URL;
+  log("");
+  log(opened ? `  Opening ${url} in your browser…` : `  Open ${url} in your browser to continue.`);
+  log("");
+}

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -1,49 +1,28 @@
 import { describe, it, expect } from "vitest";
 import {
-  rewriteBareArgvToBootstrap,
+  isBareDenchclawInvocation,
   shouldHideCliBanner,
-  shouldEnableBootstrapCutover,
   shouldEnsureCliPath,
   shouldDelegateToGlobalOpenClaw,
 } from "./run-main.js";
 
-describe("run-main bootstrap cutover", () => {
-  it("rewrites bare denchclaw invocations to bootstrap by default", () => {
-    const argv = ["node", "denchclaw"];
-    expect(rewriteBareArgvToBootstrap(argv, {})).toEqual(["node", "denchclaw", "bootstrap"]);
+describe("run-main bare invocation welcome flow", () => {
+  it("detects bare denchclaw invocations", () => {
+    expect(isBareDenchclawInvocation(["node", "denchclaw"])).toBe(true);
   });
 
-  it("does not rewrite when a command already exists", () => {
-    const argv = ["node", "denchclaw", "chat"];
-    expect(rewriteBareArgvToBootstrap(argv, {})).toEqual(argv);
+  it("does not treat subcommand invocations as bare", () => {
+    expect(isBareDenchclawInvocation(["node", "denchclaw", "bootstrap"])).toBe(false);
+    expect(isBareDenchclawInvocation(["node", "denchclaw", "chat"])).toBe(false);
   });
 
-  it("does not rewrite non-denchclaw CLIs", () => {
-    const argv = ["node", "openclaw"];
-    expect(rewriteBareArgvToBootstrap(argv, {})).toEqual(argv);
+  it("does not treat help/version invocations as bare", () => {
+    expect(isBareDenchclawInvocation(["node", "denchclaw", "--help"])).toBe(false);
+    expect(isBareDenchclawInvocation(["node", "denchclaw", "--version"])).toBe(false);
   });
 
-  it("disables cutover in legacy rollout stage", () => {
-    const env = { DENCHCLAW_BOOTSTRAP_ROLLOUT: "legacy" };
-    expect(shouldEnableBootstrapCutover(env)).toBe(false);
-    expect(rewriteBareArgvToBootstrap(["node", "denchclaw"], env)).toEqual(["node", "denchclaw"]);
-  });
-
-  it("requires opt-in for beta rollout stage", () => {
-    const envNoOptIn = { DENCHCLAW_BOOTSTRAP_ROLLOUT: "beta" };
-    const envOptIn = {
-      DENCHCLAW_BOOTSTRAP_ROLLOUT: "beta",
-      DENCHCLAW_BOOTSTRAP_BETA_OPT_IN: "1",
-    };
-
-    expect(shouldEnableBootstrapCutover(envNoOptIn)).toBe(false);
-    expect(shouldEnableBootstrapCutover(envOptIn)).toBe(true);
-  });
-
-  it("honors explicit legacy fallback override", () => {
-    const env = { DENCHCLAW_BOOTSTRAP_LEGACY_FALLBACK: "1" };
-    expect(shouldEnableBootstrapCutover(env)).toBe(false);
-    expect(rewriteBareArgvToBootstrap(["node", "denchclaw"], env)).toEqual(["node", "denchclaw"]);
+  it("does not treat non-denchclaw CLIs as bare", () => {
+    expect(isBareDenchclawInvocation(["node", "openclaw"])).toBe(false);
   });
 });
 

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -61,67 +61,14 @@ export function shouldEnsureCliPath(argv: string[]): boolean {
   return true;
 }
 
-export type BootstrapRolloutStage = "legacy" | "internal" | "beta" | "default";
-
-function normalizeBootstrapRolloutStage(
-  value: string | undefined,
-): BootstrapRolloutStage | undefined {
-  const normalized = value?.trim().toLowerCase();
-  if (
-    normalized === "legacy" ||
-    normalized === "internal" ||
-    normalized === "beta" ||
-    normalized === "default"
-  ) {
-    return normalized;
-  }
-  return undefined;
-}
-
-export function resolveBootstrapRolloutStage(
-  env: NodeJS.ProcessEnv = process.env,
-): BootstrapRolloutStage {
-  const raw = env.DENCHCLAW_BOOTSTRAP_ROLLOUT ?? env.OPENCLAW_BOOTSTRAP_ROLLOUT;
-  return normalizeBootstrapRolloutStage(raw) ?? "default";
-}
-
-export function shouldEnableBootstrapCutover(env: NodeJS.ProcessEnv = process.env): boolean {
-  if (
-    isTruthyEnvValue(env.DENCHCLAW_BOOTSTRAP_LEGACY_FALLBACK) ||
-    isTruthyEnvValue(env.OPENCLAW_BOOTSTRAP_LEGACY_FALLBACK)
-  ) {
-    return false;
-  }
-  const stage = resolveBootstrapRolloutStage(env);
-  if (stage === "legacy") {
-    return false;
-  }
-  if (stage === "beta") {
-    return (
-      isTruthyEnvValue(env.DENCHCLAW_BOOTSTRAP_BETA_OPT_IN) ||
-      isTruthyEnvValue(env.OPENCLAW_BOOTSTRAP_BETA_OPT_IN)
-    );
-  }
-  return true;
-}
-
-export function rewriteBareArgvToBootstrap(
-  argv: string[],
-  env: NodeJS.ProcessEnv = process.env,
-): string[] {
+export function isBareDenchclawInvocation(argv: string[]): boolean {
   if (hasHelpOrVersion(argv)) {
-    return argv;
+    return false;
   }
   if (getPrimaryCommand(argv)) {
-    return argv;
+    return false;
   }
-  if (resolveCliName(argv) !== "denchclaw") {
-    return argv;
-  }
-  if (!shouldEnableBootstrapCutover(env)) {
-    return argv;
-  }
-  return [...argv.slice(0, 2), "bootstrap", ...argv.slice(2)];
+  return resolveCliName(argv) === "denchclaw";
 }
 
 function isDelegationDisabled(env: NodeJS.ProcessEnv = process.env): boolean {
@@ -227,7 +174,16 @@ export async function runCli(argv: string[] = process.argv) {
     await emitCliBanner(VERSION, { argv: normalizedArgv });
   }
 
-  const parseArgv = rewriteBareArgvToBootstrap(rewriteUpdateFlagArgv(normalizedArgv));
+  // Bare `denchclaw` gets a minimal welcome flow: the Dench Cloud banner plus
+  // a single "Continue with Dench.com" action. The full local setup pipeline
+  // is reachable explicitly via `denchclaw bootstrap`.
+  if (isBareDenchclawInvocation(normalizedArgv)) {
+    const { runDenchCloudWelcome } = await import("./dench-cloud-welcome.js");
+    await runDenchCloudWelcome();
+    return;
+  }
+
+  const parseArgv = rewriteUpdateFlagArgv(normalizedArgv);
   if (shouldDelegateToGlobalOpenClaw(parseArgv)) {
     const exitCode = await delegateToGlobalOpenClaw(parseArgv);
     process.exitCode = exitCode;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Bare `npx denchclaw` no longer rewrites to `bootstrap`. It now runs a minimal welcome flow: the colorful Dench Cloud integrations banner, followed by a single "Continue with Dench.com" action. Selecting it opens https://dench.com/login in the browser and ends the terminal session.
- In non-TTY contexts the flow prints the banner and the login URL, then exits.
- `npx denchclaw bootstrap` keeps the full existing setup pipeline (OpenClaw install/update, gateway, Dench Cloud setup, onboarding, web runtime) — unchanged.
- Extracted `renderDenchCloudRecommendationBanner()` from `bootstrap-external.ts` into `src/cli/dench-cloud-banner.ts` so the welcome flow and bootstrap share the same banner.
- Removed the now-unused bare→bootstrap cutover logic (`rewriteBareArgvToBootstrap`, rollout-stage helpers) from `run-main.ts`; bootstrap's own rollout helpers are untouched.
- README updated to document `npx denchclaw bootstrap` for installation/onboarding (AI-agent prompt, manual install, commands, daemonless examples).

## Testing

- `pnpm build` succeeds; changed files pass `oxlint --type-aware` and `oxfmt --check`.
- `run-main.test.ts`, `bootstrap-external.test.ts`, `bootstrap-external.bootstrap-command.test.ts`: 97 tests pass. (4 pre-existing failures in `flatten-standalone-deps.test.ts` also fail on `main`; unrelated.)
- Manual smoke tests:
  - Non-TTY `node denchclaw.mjs`: banner + `Continue with Dench.com: https://dench.com/login`, exits 0.
  - TTY (tmux): DENCHCLAW banner → Dench Cloud banner → "Continue with Dench.com" button; pressing Enter opens dench.com/login and the session ends.
  - `denchclaw --help` and `denchclaw bootstrap --help` still route correctly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fec11e66-cb20-4823-ac3a-19d7c84ad735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fec11e66-cb20-4823-ac3a-19d7c84ad735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

